### PR TITLE
fix: fixed behavior for `updated_at` field when updating the model

### DIFF
--- a/advanced_alchemy/base.py
+++ b/advanced_alchemy/base.py
@@ -193,6 +193,7 @@ class AuditColumns:
     """Date/time of instance creation."""
     updated_at: Mapped[datetime] = mapped_column(
         DateTimeUTC(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
         onupdate=lambda: datetime.now(timezone.utc),
     )
     """Date/time of instance last update."""

--- a/advanced_alchemy/base.py
+++ b/advanced_alchemy/base.py
@@ -193,7 +193,7 @@ class AuditColumns:
     """Date/time of instance creation."""
     updated_at: Mapped[datetime] = mapped_column(
         DateTimeUTC(timezone=True),
-        default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc),
     )
     """Date/time of instance last update."""
 


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

- fixed behavior for `updated_at` field when updating the model

  When the model is created, it is not necessary to fill in the 'updated_at` field.
  But when updating the model, it needs to be updated automatically.

- hotfix

  Returned the default value for the field.

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
## Closes
