### PR TITLE
fix: html_title

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -113,7 +113,7 @@ exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
 # -- Style configuration -----------------------------------------------------
 html_theme = "litestar_sphinx_theme"
-html_title = "Litestar Framework"
+html_title = "Advanced Alchemy"
 pygments_style = "lightbulb"
 todo_include_todos = True
 


### PR DESCRIPTION
## Description

- Title shows up as "Litestar Framework", fixed to make it show "Advanced Alchemy""
<img width="552" alt="image" src="https://github.com/litestar-org/advanced-alchemy/assets/45509143/3c031976-a4e7-464d-a622-15479c451fa4">

