### PR TITLE
fix: type hint for 3.8 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,10 +107,10 @@ with session_factory() as db_session:
     repo = UserRepository(session=db_session)
     # 1) Create multiple users with `add_many`
     bulk_users = [
-        {"email": 'cody@advanced-alchemy.dev', 'name': 'Cody'},
-        {"email": 'janek@advanced-alchemy.dev', 'name': 'Janek'},
-        {"email": 'peter@advanced-alchemy.dev', 'name': 'Peter'},
-        {"email": 'jacob@advanced-alchemy.dev', 'name': 'Jacob'}
+        {"email": 'cody@litestar.dev', 'name': 'Cody'},
+        {"email": 'janek@litestar.dev', 'name': 'Janek'},
+        {"email": 'peter@litestar.dev', 'name': 'Peter'},
+        {"email": 'jacob@litestar.dev', 'name': 'Jacob'}
     ]
     objs = repo.add_many([User(**raw_user) for raw_user in bulk_users])
     db_session.commit()
@@ -181,10 +181,10 @@ with session_factory() as db_session:
     service = UserService(session=db_session)
     # 1) Create multiple users with `add_many`
     objs = service.create_many([
-        {"email": 'cody@advanced-alchemy.dev', 'name': 'Cody'},
-        {"email": 'janek@advanced-alchemy.dev', 'name': 'Janek'},
-        {"email": 'peter@advanced-alchemy.dev', 'name': 'Peter'},
-        {"email": 'jacob@advanced-alchemy.dev', 'name': 'Jacob'}
+        {"email": 'cody@litestar.dev', 'name': 'Cody'},
+        {"email": 'janek@litestar.dev', 'name': 'Janek'},
+        {"email": 'peter@litestar.dev', 'name': 'Peter'},
+        {"email": 'jacob@litestar.dev', 'name': 'Jacob'}
     ])
     print(objs)
     print(f"Created {len(objs)} new objects.")

--- a/README.md
+++ b/README.md
@@ -28,15 +28,14 @@ Check out the [project documentation][project-docs] 📚 for more information.
 ## About
 
 A carefully crafted, thoroughly tested, optimized companion library for SQLAlchemy,
-offering features such as:
+offering:
 
 - Sync and async repositories, featuring common CRUD and highly optimized bulk operations
-- Integration with major web frameworks including Litestar, Starlette, FastAPI, Sanic.
+- Integration with major web frameworks including Litestar, Starlette, FastAPI, Sanic
 - Custom-built alembic configuration and CLI with optional framework integration
 - Utility base classes with audit columns, primary keys and utility functions
-- Optimized JSON types including a custom JSON type for Oracle.
+- Optimized JSON types including a custom JSON type for Oracle
 - Integrated support for UUID6 and UUID7 using [`uuid-utils`](https://github.com/aminalaee/uuid-utils) (install with the `uuid` extra)
-
 - Pre-configured base classes with audit columns UUID or Big Integer primary keys and
   a [sentinel column](https://docs.sqlalchemy.org/en/20/core/connections.html#configuring-sentinel-columns).
 - Synchronous and asynchronous repositories featuring:
@@ -46,7 +45,6 @@ offering features such as:
     for improved query building performance
   - Integrated counts, pagination, sorting, filtering with `LIKE`, `IN`, and dates before and/or after.
 - Tested support for multiple database backends including:
-
   - SQLite via [aiosqlite](https://aiosqlite.omnilib.dev/en/stable/) or [sqlite](https://docs.python.org/3/library/sqlite3.html)
   - Postgres via [asyncpg](https://magicstack.github.io/asyncpg/current/) or [psycopg3 (async or sync)](https://www.psycopg.org/psycopg3/)
   - MySQL via [asyncmy](https://github.com/long2ice/asyncmy)
@@ -55,6 +53,7 @@ offering features such as:
   - DuckDB via [duckdb_engine](https://github.com/Mause/duckdb_engine)
   - Microsoft SQL Server via [pyodbc](https://github.com/mkleehammer/pyodbc) or [aioodbc](https://github.com/aio-libs/aioodbc)
   - CockroachDB via [sqlalchemy-cockroachdb (async or sync)](https://github.com/cockroachdb/sqlalchemy-cockroachdb)
+- ...and much more
 
 ## Usage
 
@@ -129,6 +128,7 @@ with session_factory() as db_session:
     remaining_count = repo.count()
     print(f"Found {remaining_count} remaining records after delete.")
 ```
+
 </details>
 
 For a full standalone example, see the sample [here][standalone-example]
@@ -201,6 +201,7 @@ with session_factory() as db_session:
     remaining_count = service.count()
     print(f"Found {remaining_count} remaining records after delete.")
 ```
+
 </details>
 
 ### Web Frameworks
@@ -230,6 +231,7 @@ alchemy = SQLAlchemyPlugin(
 )
 app = Litestar(plugins=[alchemy])
 ```
+
 </details>
 
 For a full Litestar example, check [here][litestar-example]
@@ -250,6 +252,7 @@ alchemy = StarletteAdvancedAlchemy(
     config=SQLAlchemyAsyncConfig(connection_string="sqlite+aiosqlite:///test.sqlite"), app=app,
 )
 ```
+
 </details>
 
 For a full FastAPI example, see [here][fastapi-example]
@@ -270,6 +273,7 @@ alchemy = StarletteAdvancedAlchemy(
     config=SQLAlchemyAsyncConfig(connection_string="sqlite+aiosqlite:///test.sqlite"), app=app,
 )
 ```
+
 </details>
 
 #### Sanic
@@ -290,6 +294,7 @@ alchemy = SanicAdvancedAlchemy(
 )
 Extend.register(alchemy)
 ```
+
 </details>
 
 ## Contributing

--- a/advanced_alchemy/service/pagination.py
+++ b/advanced_alchemy/service/pagination.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Generic, TypeVar
+from typing import Generic, List, TypeVar
 from uuid import UUID
 
 T = TypeVar("T")
@@ -16,7 +16,7 @@ class OffsetPagination(Generic[T]):
 
     __slots__ = ("items", "limit", "offset", "total")
 
-    items: list[T]
+    items: List[T]  # noqa: UP006
     """List of data being sent as part of the response."""
     limit: int
     """Maximal number of items to send."""

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -140,6 +140,7 @@ html_context = {
 html_theme_options = {
     "logo_target": "/",
     "github_repo_name": "advanced-alchemy",
+    "github_url": "https://github.com/litestar-org/advanced-alchemy",
     "navigation_with_keys": True,
     "nav_links": [  # TODO(provinzkraut): I need a guide on extra_navbar_items and its magic :P
         {"title": "Home", "url": "index"},


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

This PR addresses a type hint compatibility issue for Python 3.8

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
## Closes
