### PR TITLE
refactor!: use __bases__ to merge mixin table args

### DIFF
--- a/advanced_alchemy/base.py
+++ b/advanced_alchemy/base.py
@@ -78,11 +78,7 @@ table_name_regexp = re.compile("((?<=[a-z0-9])[A-Z]|(?!^)[A-Z](?=[a-z]))")
 """Regular expression for table name"""
 
 
-def merge_table_arguments(
-    cls: DeclarativeBase,
-    *mixins: Any,
-    table_args: dict | tuple | None = None,
-) -> tuple | dict:
+def merge_table_arguments(cls: type[DeclarativeBase], table_args: dict | tuple | None = None) -> tuple | dict:
     """Merge Table Arguments.
 
     When using mixins that include their own table args, it is difficult to append info into the model such as a comment.
@@ -91,7 +87,6 @@ def merge_table_arguments(
 
     Args:
         cls (DeclarativeBase): This is the model that will get the table args
-        *mixins (Any): The mixins to add into the model
         table_args: additional information to add to tableargs
 
     Returns:
@@ -100,7 +95,7 @@ def merge_table_arguments(
     args: list[Any] = []
     kwargs: dict[str, Any] = {}
 
-    mixin_table_args = (getattr(super(base_cls, cls), "__table_args__", None) for base_cls in (cls, *mixins))
+    mixin_table_args = (getattr(base_cls, "__table_args__", None) for base_cls in reversed(cls.mro()[1:]))
 
     for arg_to_merge in (*mixin_table_args, table_args):
         if arg_to_merge:

--- a/advanced_alchemy/base.py
+++ b/advanced_alchemy/base.py
@@ -95,7 +95,7 @@ def merge_table_arguments(cls: type[DeclarativeBase], table_args: dict | tuple |
     args: list[Any] = []
     kwargs: dict[str, Any] = {}
 
-    mixin_table_args = (getattr(base_cls, "__table_args__", None) for base_cls in reversed(cls.mro()[1:]))
+    mixin_table_args = (getattr(super(base_cls, cls), "__table_args__", None) for base_cls in cls.__bases__)
 
     for arg_to_merge in (*mixin_table_args, table_args):
         if arg_to_merge:

--- a/tests/models_bigint.py
+++ b/tests/models_bigint.py
@@ -59,8 +59,8 @@ class BigIntSlugBook(BigIntBase, SlugKey):
     title: Mapped[str] = mapped_column(String(length=250))  # pyright: ignore
     author_id: Mapped[str] = mapped_column(String(length=250))  # pyright: ignore
 
-    @classmethod
     @declared_attr.directive
+    @classmethod
     def __table_args__(cls) -> dict | tuple:
         return merge_table_arguments(
             cls,

--- a/tests/models_bigint.py
+++ b/tests/models_bigint.py
@@ -59,11 +59,11 @@ class BigIntSlugBook(BigIntBase, SlugKey):
     title: Mapped[str] = mapped_column(String(length=250))  # pyright: ignore
     author_id: Mapped[str] = mapped_column(String(length=250))  # pyright: ignore
 
+    @classmethod
     @declared_attr.directive
     def __table_args__(cls) -> dict | tuple:
         return merge_table_arguments(
             cls,
-            SlugKey,
             table_args={"comment": "Slugbook"},
         )
 

--- a/tests/models_uuid.py
+++ b/tests/models_uuid.py
@@ -55,11 +55,11 @@ class UUIDSlugBook(UUIDBase, SlugKey):
     title: Mapped[str] = mapped_column(String(length=250))  # pyright: ignore
     author_id: Mapped[str] = mapped_column(String(length=250))  # pyright: ignore
 
+    @classmethod
     @declared_attr.directive
     def __table_args__(cls) -> dict | tuple:
         return merge_table_arguments(
             cls,
-            SlugKey,
             table_args={"comment": "Slugbook"},
         )
 

--- a/tests/models_uuid.py
+++ b/tests/models_uuid.py
@@ -55,8 +55,8 @@ class UUIDSlugBook(UUIDBase, SlugKey):
     title: Mapped[str] = mapped_column(String(length=250))  # pyright: ignore
     author_id: Mapped[str] = mapped_column(String(length=250))  # pyright: ignore
 
-    @classmethod
     @declared_attr.directive
+    @classmethod
     def __table_args__(cls) -> dict | tuple:
         return merge_table_arguments(
             cls,


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

Uses `__bases__` of the DeclaredAttr type to get `__table_args__` of classes in the mixin hierarchy.

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
## Closes
