### PR TITLE
feat: create a `StatementFilter` type for repository filters

### DIFF
--- a/advanced_alchemy/extensions/litestar/plugins/init/config/asyncio.py
+++ b/advanced_alchemy/extensions/litestar/plugins/init/config/asyncio.py
@@ -30,7 +30,6 @@ if TYPE_CHECKING:
     from litestar.types import BeforeMessageSendHookHandler, Message, Scope
 
     # noinspection PyUnresolvedReferences
-    from litestar.types.asgi_types import HTTPResponseStartEvent
 
 
 __all__ = (
@@ -95,10 +94,9 @@ def autocommit_handler_maker(
         session = cast("AsyncSession | None", get_aa_scope_state(scope, SESSION_SCOPE_KEY))
         try:
             if session is not None and message["type"] == HTTP_RESPONSE_START:
-                if (
-                    cast("HTTPResponseStartEvent", message)["status"] in commit_range
-                    or message["status"] in extra_commit_statuses
-                ) and message["status"] not in extra_rollback_statuses:
+                if (message["status"] in commit_range or message["status"] in extra_commit_statuses) and message[
+                    "status"
+                ] not in extra_rollback_statuses:
                     await session.commit()
                 else:
                     await session.rollback()
@@ -135,7 +133,7 @@ class SQLAlchemyAsyncConfig(_SQLAlchemyAsyncConfig):
     """Key under which to store the SQLAlchemy :class:`sessionmaker <sqlalchemy.orm.sessionmaker>` in the application
     :class:`State <.datastructures.State>` instance.
     """
-    engine_config: EngineConfig = field(default_factory=EngineConfig)
+    engine_config: EngineConfig = field(default_factory=EngineConfig)  # pyright: ignore[reportIncompatibleVariableOverride]
     """Configuration for the SQLAlchemy engine.
 
     The configuration options are documented in the SQLAlchemy documentation.
@@ -153,7 +151,7 @@ class SQLAlchemyAsyncConfig(_SQLAlchemyAsyncConfig):
         session_kws = self.session_config_dict
         if session_kws.get("bind") is None:
             session_kws["bind"] = self.get_engine()
-        return self.session_maker_class(**session_kws)
+        return self.session_maker_class(**session_kws)  # pyright: ignore[reportUnknownVariableType,reportUnknownMemberType]
 
     @asynccontextmanager
     async def lifespan(

--- a/advanced_alchemy/filters.py
+++ b/advanced_alchemy/filters.py
@@ -198,10 +198,8 @@ class NotInCollectionFilter(InAnyFilter, Generic[T]):
         prefer_any: bool = False,
     ) -> Select[tuple[ModelT]]:
         field = self._get_instrumented_attr(model, self.field_name)
-        if self.values is None:
-            return statement
         if not self.values:
-            return statement.where(text("1=-1"))
+            return statement
         if prefer_any:
             return statement.where(any_(self.values) == field)  # type: ignore[arg-type]
         return statement.where(field.in_(self.values))
@@ -213,10 +211,7 @@ class NotInCollectionFilter(InAnyFilter, Generic[T]):
         prefer_any: bool = False,
     ) -> StatementLambdaElement:
         field = self._get_instrumented_attr(model, self.field_name)
-        if self.values is None:
-            return statement
         if not self.values:
-            statement += lambda s: s.where(text("1=-1"))  # pyright: ignore[reportUnknownLambdaType,reportUnknownMemberType]
             return statement
         if prefer_any:
             values = self.values

--- a/advanced_alchemy/filters.py
+++ b/advanced_alchemy/filters.py
@@ -152,7 +152,9 @@ class CollectionFilter(InAnyFilter, Generic[T]):
     ) -> Select[tuple[ModelT]]:
         field = self._get_instrumented_attr(model, self.field_name)
         if self.values is None:
-            return statement.where(text("1=1"))
+            return statement
+        if not self.values:
+            return statement.where(text("1=-1"))
         if prefer_any:
             return statement.where(any_(self.values) == field)  # type: ignore[arg-type]
         return statement.where(field.in_(self.values))
@@ -165,7 +167,9 @@ class CollectionFilter(InAnyFilter, Generic[T]):
     ) -> StatementLambdaElement:
         field = self._get_instrumented_attr(model, self.field_name)
         if self.values is None:
-            statement += lambda s: s.where(text("1=1"))  # pyright: ignore[reportUnknownLambdaType,reportUnknownMemberType]
+            return statement
+        if not self.values:
+            statement += lambda s: s.where(text("1=-1"))  # pyright: ignore[reportUnknownLambdaType,reportUnknownMemberType]
             return statement
         if prefer_any:
             values = self.values
@@ -195,6 +199,8 @@ class NotInCollectionFilter(InAnyFilter, Generic[T]):
     ) -> Select[tuple[ModelT]]:
         field = self._get_instrumented_attr(model, self.field_name)
         if self.values is None:
+            return statement
+        if not self.values:
             return statement.where(text("1=-1"))
         if prefer_any:
             return statement.where(any_(self.values) == field)  # type: ignore[arg-type]
@@ -208,6 +214,8 @@ class NotInCollectionFilter(InAnyFilter, Generic[T]):
     ) -> StatementLambdaElement:
         field = self._get_instrumented_attr(model, self.field_name)
         if self.values is None:
+            return statement
+        if not self.values:
             statement += lambda s: s.where(text("1=-1"))  # pyright: ignore[reportUnknownLambdaType,reportUnknownMemberType]
             return statement
         if prefer_any:

--- a/advanced_alchemy/filters.py
+++ b/advanced_alchemy/filters.py
@@ -6,15 +6,18 @@ from abc import ABC, abstractmethod
 from collections import abc  # noqa: TCH003
 from dataclasses import dataclass
 from datetime import datetime  # noqa: TCH003
-from typing import TYPE_CHECKING, Any, Generic, Literal, TypeVar, overload
+from typing import TYPE_CHECKING, Any, Generic, Literal, TypeVar, cast
 
-from sqlalchemy import Select, StatementLambdaElement
+from sqlalchemy import any_, text
 
 if TYPE_CHECKING:
+    from sqlalchemy import Select, StatementLambdaElement
+    from sqlalchemy.orm import InstrumentedAttribute
     from typing_extensions import TypeAlias
 
-T = TypeVar("T")
-ModelT = TypeVar("ModelT")
+    from advanced_alchemy import base
+
+
 __all__ = (
     "BeforeAfter",
     "CollectionFilter",
@@ -25,29 +28,37 @@ __all__ = (
     "NotInCollectionFilter",
     "OnBeforeAfter",
     "NotInSearchFilter",
+    "PaginationFilter",
+    "InAnyFilter",
 )
 
-
+T = TypeVar("T")
+ModelT = TypeVar("ModelT", bound="base.ModelProtocol")
+StatementFilterT = TypeVar("StatementFilterT", bound="StatementFilter")
 FilterTypes: TypeAlias = "BeforeAfter | OnBeforeAfter | CollectionFilter[Any] | LimitOffset | OrderBy | SearchFilter | NotInCollectionFilter[Any] | NotInSearchFilter"
 """Aggregate type alias of the types supported for collection filtering."""
 
 
 class StatementFilter(ABC):
-    @overload
     @abstractmethod
-    def to_statement(self, statement: Select[tuple[ModelT]]) -> Select[tuple[ModelT]]: ...
-
-    @overload
-    @abstractmethod
-    def to_statement(self, statement: StatementLambdaElement) -> StatementLambdaElement: ...
-
-    @abstractmethod
-    def to_statement(
-        self,
-        statement: Select[tuple[ModelT]] | StatementLambdaElement,
-    ) -> Select[tuple[ModelT]] | StatementLambdaElement:
-        """Add filter to statement"""
+    def append_to_statement(self, statement: Select[tuple[ModelT]], model: type[ModelT]) -> Select[tuple[ModelT]]:
         return statement
+
+    @abstractmethod
+    def append_to_lambda_statement(
+        self,
+        statement: StatementLambdaElement,
+        *args: Any,
+        **kwargs: Any,
+    ) -> StatementLambdaElement:
+        return statement
+
+    @staticmethod
+    def _get_instrumented_attr(model: Any, key: str | InstrumentedAttribute[Any]) -> InstrumentedAttribute[Any]:
+        # copy this here to avoid a circular import of `get_instrumented_attribute`.  Maybe we move that function somewhere else?
+        if isinstance(key, str):
+            return cast("InstrumentedAttribute[Any]", getattr(model, key))
+        return key
 
 
 @dataclass
@@ -61,9 +72,29 @@ class BeforeAfter(StatementFilter):
     after: datetime | None
     """Filter results where field later than this."""
 
+    def append_to_statement(self, statement: Select[tuple[ModelT]], model: type[ModelT]) -> Select[tuple[ModelT]]:
+        field = self._get_instrumented_attr(model, self.field_name)
+        if self.before is not None:
+            statement = statement.where(field < self.before)  # pyright: ignore[reportUnknownLambdaType,reportUnknownMemberType]
+        if self.after is not None:
+            statement = statement.where(field > self.after)  # pyright: ignore[reportUnknownLambdaType,reportUnknownMemberType]
+        return statement
+
+    def append_to_lambda_statement(
+        self,
+        statement: StatementLambdaElement,
+        model: type[ModelT],
+    ) -> StatementLambdaElement:
+        field = self._get_instrumented_attr(model, self.field_name)
+        if self.before is not None:
+            statement += lambda s: s.where(field < self.before)  # pyright: ignore[reportUnknownLambdaType,reportUnknownMemberType]
+        if self.after is not None:
+            statement += lambda s: s.where(field > self.after)  # pyright: ignore[reportUnknownLambdaType,reportUnknownMemberType]
+        return statement
+
 
 @dataclass
-class OnBeforeAfter:
+class OnBeforeAfter(StatementFilter):
     """Data required to filter a query on a ``datetime`` column."""
 
     field_name: str
@@ -73,9 +104,33 @@ class OnBeforeAfter:
     on_or_after: datetime | None
     """Filter results where field on or later than this."""
 
+    def append_to_statement(self, statement: Select[tuple[ModelT]], model: type[ModelT]) -> Select[tuple[ModelT]]:
+        field = self._get_instrumented_attr(model, self.field_name)
+        if self.on_or_before is not None:
+            statement = statement.where(field <= self.on_or_before)  # pyright: ignore[reportUnknownLambdaType,reportUnknownMemberType]
+        if self.on_or_after is not None:
+            statement = statement.where(field >= self.on_or_after)  # pyright: ignore[reportUnknownLambdaType,reportUnknownMemberType]
+        return statement
+
+    def append_to_lambda_statement(
+        self,
+        statement: StatementLambdaElement,
+        model: type[ModelT],
+    ) -> StatementLambdaElement:
+        field = self._get_instrumented_attr(model, self.field_name)
+        if self.on_or_before is not None:
+            statement += lambda s: s.where(field <= self.on_or_before)  # pyright: ignore[reportUnknownLambdaType,reportUnknownMemberType]
+        if self.on_or_after is not None:
+            statement += lambda s: s.where(field >= self.on_or_after)  # pyright: ignore[reportUnknownLambdaType,reportUnknownMemberType]
+        return statement
+
+
+class InAnyFilter(StatementFilter, ABC):
+    """Subclass for methods that have a `prefer_any` attribute."""
+
 
 @dataclass
-class CollectionFilter(Generic[T]):
+class CollectionFilter(InAnyFilter, Generic[T]):
     """Data required to construct a ``WHERE ... IN (...)`` clause."""
 
     field_name: str
@@ -85,9 +140,38 @@ class CollectionFilter(Generic[T]):
 
     An empty list will return an empty result set, however, if ``None``, the filter is not applied to the query, and all rows are returned. """
 
+    def append_to_statement(
+        self,
+        statement: Select[tuple[ModelT]],
+        model: type[ModelT],
+        prefer_any: bool = False,
+    ) -> Select[tuple[ModelT]]:
+        field = self._get_instrumented_attr(model, self.field_name)
+        if not self.values:
+            return statement.where(text("1=-1"))
+        if prefer_any:
+            return statement.where(any_(self.values) == field)  # type: ignore[arg-type]
+        return statement.where(field.in_(self.values))
+
+    def append_to_lambda_statement(
+        self,
+        statement: StatementLambdaElement,
+        model: type[ModelT],
+        prefer_any: bool = False,
+    ) -> StatementLambdaElement:
+        field = self._get_instrumented_attr(model, self.field_name)
+        if not self.values:
+            statement += lambda s: s.where(text("1=-1"))  # pyright: ignore[reportUnknownLambdaType,reportUnknownMemberType]
+            return statement
+        if prefer_any:
+            statement += lambda s: s.where(any_(self.values) == field)  # type: ignore[arg-type]
+            return statement
+        statement += lambda s: s.where(field.in_(self.values))  # type: ignore[arg-type] # pyright: ignore[reportUnknownLambdaType,reportArgumentType,reportUnknownMemberType]
+        return statement
+
 
 @dataclass
-class NotInCollectionFilter(Generic[T]):
+class NotInCollectionFilter(InAnyFilter, Generic[T]):
     """Data required to construct a ``WHERE ... NOT IN (...)`` clause."""
 
     field_name: str
@@ -97,9 +181,42 @@ class NotInCollectionFilter(Generic[T]):
 
     An empty list or ``None`` will return all rows."""
 
+    def append_to_statement(
+        self,
+        statement: Select[tuple[ModelT]],
+        model: type[ModelT],
+        prefer_any: bool = False,
+    ) -> Select[tuple[ModelT]]:
+        field = self._get_instrumented_attr(model, self.field_name)
+        if not self.values:
+            return statement.where(text("1=-1"))
+        if prefer_any:
+            return statement.where(any_(self.values) == field)  # type: ignore[arg-type]
+        return statement.where(field.in_(self.values))
+
+    def append_to_lambda_statement(
+        self,
+        statement: StatementLambdaElement,
+        model: type[ModelT],
+        prefer_any: bool = False,
+    ) -> StatementLambdaElement:
+        field = self._get_instrumented_attr(model, self.field_name)
+        if not self.values:
+            statement += lambda s: s.where(text("1=-1"))  # pyright: ignore[reportUnknownLambdaType,reportUnknownMemberType]
+            return statement
+        if prefer_any:
+            statement += lambda s: s.where(any_(self.values) != field)  # type: ignore[arg-type]
+            return statement
+        statement += lambda s: s.where(field.notin_(self.values))  # type: ignore[arg-type] # pyright: ignore[reportUnknownLambdaType,reportArgumentType,reportUnknownMemberType]
+        return statement
+
+
+class PaginationFilter(StatementFilter, ABC):
+    """Subclass for methods that function as a pagination type."""
+
 
 @dataclass
-class LimitOffset:
+class LimitOffset(PaginationFilter):
     """Data required to add limit/offset filtering to a query."""
 
     limit: int
@@ -107,9 +224,20 @@ class LimitOffset:
     offset: int
     """Value for ``OFFSET`` clause of query."""
 
+    def append_to_statement(self, statement: Select[tuple[ModelT]], model: type[ModelT]) -> Select[tuple[ModelT]]:
+        return statement.limit(self.limit).offset(self.offset)
+
+    def append_to_lambda_statement(
+        self,
+        statement: StatementLambdaElement,
+        model: type[ModelT],
+    ) -> StatementLambdaElement:
+        statement += lambda s: s.limit(self.limit).offset(self.offset)  # pyright: ignore[reportUnknownLambdaType,reportUnknownMemberType]
+        return statement
+
 
 @dataclass
-class OrderBy:
+class OrderBy(StatementFilter):
     """Data required to construct a ``ORDER BY ...`` clause."""
 
     field_name: str
@@ -117,9 +245,27 @@ class OrderBy:
     sort_order: Literal["asc", "desc"] = "asc"
     """Sort ascending or descending"""
 
+    def append_to_statement(self, statement: Select[tuple[ModelT]], model: type[ModelT]) -> Select[tuple[ModelT]]:
+        field = self._get_instrumented_attr(model, self.field_name)
+        if self.sort_order == "desc":
+            return statement.order_by(field.desc())
+        return statement.order_by(field.asc())
+
+    def append_to_lambda_statement(
+        self,
+        statement: StatementLambdaElement,
+        model: type[ModelT],
+    ) -> StatementLambdaElement:
+        field = self._get_instrumented_attr(model, self.field_name)
+        if self.sort_order == "desc":
+            statement += lambda s: s.order_by(field.desc())  # pyright: ignore[reportUnknownLambdaType,reportUnknownMemberType]
+            return statement
+        statement += lambda s: s.order_by(field.asc())  # pyright: ignore[reportUnknownLambdaType,reportUnknownMemberType]
+        return statement
+
 
 @dataclass
-class SearchFilter:
+class SearchFilter(StatementFilter):
     """Data required to construct a ``WHERE field_name LIKE '%' || :value || '%'`` clause."""
 
     field_name: str
@@ -129,9 +275,33 @@ class SearchFilter:
     ignore_case: bool | None = False
     """Should the search be case insensitive."""
 
+    def append_to_statement(
+        self,
+        statement: Select[tuple[ModelT]],
+        model: type[ModelT],
+    ) -> Select[tuple[ModelT]]:
+        field = self._get_instrumented_attr(model, self.field_name)
+        search_text = f"%{self.value}%"
+        if self.ignore_case:
+            return statement.where(field.ilike(search_text))
+        return statement.where(field.like(search_text))
+
+    def append_to_lambda_statement(
+        self,
+        statement: StatementLambdaElement,
+        model: type[ModelT],
+    ) -> StatementLambdaElement:
+        field = self._get_instrumented_attr(model, self.field_name)
+        search_text = f"%{self.value}%"
+        if self.ignore_case:
+            statement += lambda s: s.where(field.ilike(search_text))  # pyright: ignore[reportUnknownLambdaType,reportArgumentType,reportUnknownMemberType]
+            return statement
+        statement += lambda s: s.where(field.like(search_text))  # pyright: ignore[reportUnknownLambdaType,reportArgumentType,reportUnknownMemberType]
+        return statement
+
 
 @dataclass
-class NotInSearchFilter:
+class NotInSearchFilter(StatementFilter):
     """Data required to construct a ``WHERE field_name NOT LIKE '%' || :value || '%'`` clause."""
 
     field_name: str
@@ -140,3 +310,27 @@ class NotInSearchFilter:
     """Values for ``NOT LIKE`` clause."""
     ignore_case: bool | None = False
     """Should the search be case insensitive."""
+
+    def append_to_statement(
+        self,
+        statement: Select[tuple[ModelT]],
+        model: type[ModelT],
+    ) -> Select[tuple[ModelT]]:
+        field = self._get_instrumented_attr(model, self.field_name)
+        search_text = f"%{self.value}%"
+        if self.ignore_case:
+            return statement.where(field.not_ilike(search_text))
+        return statement.where(field.not_like(search_text))
+
+    def append_to_lambda_statement(
+        self,
+        statement: StatementLambdaElement,
+        model: type[ModelT],
+    ) -> StatementLambdaElement:
+        field = self._get_instrumented_attr(model, self.field_name)
+        search_text = f"%{self.value}%"
+        if self.ignore_case:
+            statement += lambda s: s.where(field.not_ilike(search_text))  # pyright: ignore[reportUnknownLambdaType,reportUnknownMemberType]
+            return statement
+        statement += lambda s: s.where(field.not_like(search_text))  # pyright: ignore[reportUnknownLambdaType,reportArgumentType,reportUnknownMemberType]
+        return statement

--- a/advanced_alchemy/filters.py
+++ b/advanced_alchemy/filters.py
@@ -152,7 +152,7 @@ class CollectionFilter(InAnyFilter, Generic[T]):
     ) -> Select[tuple[ModelT]]:
         field = self._get_instrumented_attr(model, self.field_name)
         if not self.values:
-            return statement.where(text("1=-1"))
+            return statement.where(text("1=1"))
         if prefer_any:
             return statement.where(any_(self.values) == field)  # type: ignore[arg-type]
         return statement.where(field.in_(self.values))
@@ -165,7 +165,7 @@ class CollectionFilter(InAnyFilter, Generic[T]):
     ) -> StatementLambdaElement:
         field = self._get_instrumented_attr(model, self.field_name)
         if not self.values:
-            statement += lambda s: s.where(text("1=-1"))  # pyright: ignore[reportUnknownLambdaType,reportUnknownMemberType]
+            statement += lambda s: s.where(text("1=1"))  # pyright: ignore[reportUnknownLambdaType,reportUnknownMemberType]
             return statement
         if prefer_any:
             values = self.values

--- a/advanced_alchemy/filters.py
+++ b/advanced_alchemy/filters.py
@@ -2,16 +2,19 @@
 
 from __future__ import annotations
 
+from abc import ABC, abstractmethod
 from collections import abc  # noqa: TCH003
 from dataclasses import dataclass
 from datetime import datetime  # noqa: TCH003
-from typing import TYPE_CHECKING, Any, Generic, Literal, TypeVar
+from typing import TYPE_CHECKING, Any, Generic, Literal, TypeVar, overload
+
+from sqlalchemy import Select, StatementLambdaElement
 
 if TYPE_CHECKING:
     from typing_extensions import TypeAlias
 
 T = TypeVar("T")
-
+ModelT = TypeVar("ModelT")
 __all__ = (
     "BeforeAfter",
     "CollectionFilter",
@@ -25,14 +28,30 @@ __all__ = (
 )
 
 
-FilterTypes: TypeAlias = (
-    "BeforeAfter | OnBeforeAfter | CollectionFilter[Any] | LimitOffset | OrderBy | SearchFilter | NotInCollectionFilter[Any] | NotInSearchFilter"
-)
+FilterTypes: TypeAlias = "BeforeAfter | OnBeforeAfter | CollectionFilter[Any] | LimitOffset | OrderBy | SearchFilter | NotInCollectionFilter[Any] | NotInSearchFilter"
 """Aggregate type alias of the types supported for collection filtering."""
 
 
+class StatementFilter(ABC):
+    @overload
+    @abstractmethod
+    def to_statement(self, statement: Select[tuple[ModelT]]) -> Select[tuple[ModelT]]: ...
+
+    @overload
+    @abstractmethod
+    def to_statement(self, statement: StatementLambdaElement) -> StatementLambdaElement: ...
+
+    @abstractmethod
+    def to_statement(
+        self,
+        statement: Select[tuple[ModelT]] | StatementLambdaElement,
+    ) -> Select[tuple[ModelT]] | StatementLambdaElement:
+        """Add filter to statement"""
+        return statement
+
+
 @dataclass
-class BeforeAfter:
+class BeforeAfter(StatementFilter):
     """Data required to filter a query on a ``datetime`` column."""
 
     field_name: str

--- a/advanced_alchemy/filters.py
+++ b/advanced_alchemy/filters.py
@@ -151,7 +151,7 @@ class CollectionFilter(InAnyFilter, Generic[T]):
         prefer_any: bool = False,
     ) -> Select[tuple[ModelT]]:
         field = self._get_instrumented_attr(model, self.field_name)
-        if not self.values:
+        if self.values is None:
             return statement.where(text("1=1"))
         if prefer_any:
             return statement.where(any_(self.values) == field)  # type: ignore[arg-type]
@@ -164,7 +164,7 @@ class CollectionFilter(InAnyFilter, Generic[T]):
         prefer_any: bool = False,
     ) -> StatementLambdaElement:
         field = self._get_instrumented_attr(model, self.field_name)
-        if not self.values:
+        if self.values is None:
             statement += lambda s: s.where(text("1=1"))  # pyright: ignore[reportUnknownLambdaType,reportUnknownMemberType]
             return statement
         if prefer_any:
@@ -194,7 +194,7 @@ class NotInCollectionFilter(InAnyFilter, Generic[T]):
         prefer_any: bool = False,
     ) -> Select[tuple[ModelT]]:
         field = self._get_instrumented_attr(model, self.field_name)
-        if not self.values:
+        if self.values is None:
             return statement.where(text("1=-1"))
         if prefer_any:
             return statement.where(any_(self.values) == field)  # type: ignore[arg-type]
@@ -207,7 +207,7 @@ class NotInCollectionFilter(InAnyFilter, Generic[T]):
         prefer_any: bool = False,
     ) -> StatementLambdaElement:
         field = self._get_instrumented_attr(model, self.field_name)
-        if not self.values:
+        if self.values is None:
             statement += lambda s: s.where(text("1=-1"))  # pyright: ignore[reportUnknownLambdaType,reportUnknownMemberType]
             return statement
         if prefer_any:

--- a/advanced_alchemy/filters.py
+++ b/advanced_alchemy/filters.py
@@ -87,9 +87,11 @@ class BeforeAfter(StatementFilter):
     ) -> StatementLambdaElement:
         field = self._get_instrumented_attr(model, self.field_name)
         if self.before is not None:
-            statement += lambda s: s.where(field < self.before)  # pyright: ignore[reportUnknownLambdaType,reportUnknownMemberType]
+            before = self.before
+            statement += lambda s: s.where(field < before)  # pyright: ignore[reportUnknownLambdaType,reportUnknownMemberType]
         if self.after is not None:
-            statement += lambda s: s.where(field > self.after)  # pyright: ignore[reportUnknownLambdaType,reportUnknownMemberType]
+            after = self.after
+            statement += lambda s: s.where(field > after)  # pyright: ignore[reportUnknownLambdaType,reportUnknownMemberType]
         return statement
 
 
@@ -119,9 +121,11 @@ class OnBeforeAfter(StatementFilter):
     ) -> StatementLambdaElement:
         field = self._get_instrumented_attr(model, self.field_name)
         if self.on_or_before is not None:
-            statement += lambda s: s.where(field <= self.on_or_before)  # pyright: ignore[reportUnknownLambdaType,reportUnknownMemberType]
+            on_or_before = self.on_or_before
+            statement += lambda s: s.where(field <= on_or_before)  # pyright: ignore[reportUnknownLambdaType,reportUnknownMemberType]
         if self.on_or_after is not None:
-            statement += lambda s: s.where(field >= self.on_or_after)  # pyright: ignore[reportUnknownLambdaType,reportUnknownMemberType]
+            on_or_after = self.on_or_after
+            statement += lambda s: s.where(field >= on_or_after)  # pyright: ignore[reportUnknownLambdaType,reportUnknownMemberType]
         return statement
 
 
@@ -164,9 +168,11 @@ class CollectionFilter(InAnyFilter, Generic[T]):
             statement += lambda s: s.where(text("1=-1"))  # pyright: ignore[reportUnknownLambdaType,reportUnknownMemberType]
             return statement
         if prefer_any:
-            statement += lambda s: s.where(any_(self.values) == field)  # type: ignore[arg-type]
+            values = self.values
+            statement += lambda s: s.where(any_(values) == field)  # type: ignore[arg-type]
             return statement
-        statement += lambda s: s.where(field.in_(self.values))  # type: ignore[arg-type] # pyright: ignore[reportUnknownLambdaType,reportArgumentType,reportUnknownMemberType]
+        values = self.values
+        statement += lambda s: s.where(field.in_(values))  # pyright: ignore[reportUnknownLambdaType,reportArgumentType,reportUnknownMemberType]
         return statement
 
 
@@ -205,9 +211,11 @@ class NotInCollectionFilter(InAnyFilter, Generic[T]):
             statement += lambda s: s.where(text("1=-1"))  # pyright: ignore[reportUnknownLambdaType,reportUnknownMemberType]
             return statement
         if prefer_any:
-            statement += lambda s: s.where(any_(self.values) != field)  # type: ignore[arg-type]
+            values = self.values
+            statement += lambda s: s.where(any_(values) != field)  # type: ignore[arg-type]
             return statement
-        statement += lambda s: s.where(field.notin_(self.values))  # type: ignore[arg-type] # pyright: ignore[reportUnknownLambdaType,reportArgumentType,reportUnknownMemberType]
+        values = self.values
+        statement += lambda s: s.where(field.notin_(values))  # pyright: ignore[reportUnknownLambdaType,reportArgumentType,reportUnknownMemberType]
         return statement
 
 
@@ -232,7 +240,9 @@ class LimitOffset(PaginationFilter):
         statement: StatementLambdaElement,
         model: type[ModelT],
     ) -> StatementLambdaElement:
-        statement += lambda s: s.limit(self.limit).offset(self.offset)  # pyright: ignore[reportUnknownLambdaType,reportUnknownMemberType]
+        limit = self.limit
+        offset = self.offset
+        statement += lambda s: s.limit(limit).offset(offset)  # pyright: ignore[reportUnknownLambdaType,reportUnknownMemberType]
         return statement
 
 

--- a/advanced_alchemy/repository/_async.py
+++ b/advanced_alchemy/repository/_async.py
@@ -1407,9 +1407,11 @@ class SQLAlchemyAsyncRepository(FilterableRepository[ModelT]):
             **kwargs: key/value pairs such that objects remaining in the collection after filtering
                 have the property that their attribute named `key` has value equal to `value`.
         """
-        collection = lambda_stmt(lambda: collection)
-        collection += lambda s: s.filter_by(**kwargs)  # pyright: ignore[reportUnknownLambdaType,reportUnknownMemberType]
-        return collection
+        with wrap_sqlalchemy_exception():
+            if isinstance(collection, Select):
+                collection = lambda_stmt(lambda: collection)
+            collection += lambda s: s.filter_by(**kwargs)  # pyright: ignore[reportUnknownLambdaType,reportUnknownMemberType]
+            return collection
 
     @classmethod
     async def check_health(cls, session: AsyncSession | async_scoped_session[AsyncSession]) -> bool:

--- a/advanced_alchemy/repository/_sync.py
+++ b/advanced_alchemy/repository/_sync.py
@@ -1408,9 +1408,11 @@ class SQLAlchemySyncRepository(FilterableRepository[ModelT]):
             **kwargs: key/value pairs such that objects remaining in the collection after filtering
                 have the property that their attribute named `key` has value equal to `value`.
         """
-        collection = lambda_stmt(lambda: collection)
-        collection += lambda s: s.filter_by(**kwargs)  # pyright: ignore[reportUnknownLambdaType,reportUnknownMemberType]
-        return collection
+        with wrap_sqlalchemy_exception():
+            if isinstance(collection, Select):
+                collection = lambda_stmt(lambda: collection)
+            collection += lambda s: s.filter_by(**kwargs)  # pyright: ignore[reportUnknownLambdaType,reportUnknownMemberType]
+            return collection
 
     @classmethod
     def check_health(cls, session: Session | scoped_session[Session]) -> bool:

--- a/advanced_alchemy/repository/_util.py
+++ b/advanced_alchemy/repository/_util.py
@@ -112,15 +112,6 @@ class FilterableRepository(Generic[ModelT]):
     prefer_any_dialects: tuple[str] | None = ("postgresql",)
     """List of dialects that prefer to use ``field.id = ANY(:1)`` instead of ``field.id IN (...)``."""
 
-    def _apply_limit_offset_pagination(
-        self,
-        limit: int,
-        offset: int,
-        statement: StatementLambdaElement,
-    ) -> StatementLambdaElement:
-        statement += lambda s: s.limit(limit).offset(offset)  # pyright: ignore[reportUnknownLambdaType,reportUnknownMemberType]
-        return statement
-
     def _apply_filters(
         self,
         *filters: StatementFilter | ColumnElement[bool],

--- a/advanced_alchemy/service/_async.py
+++ b/advanced_alchemy/service/_async.py
@@ -31,7 +31,7 @@ if TYPE_CHECKING:
     from sqlalchemy.sql import ColumnElement
 
     from advanced_alchemy.config.asyncio import SQLAlchemyAsyncConfig
-    from advanced_alchemy.filters import FilterTypes
+    from advanced_alchemy.filters import StatementFilter
     from advanced_alchemy.repository import SQLAlchemyAsyncRepository
     from advanced_alchemy.repository.memory import SQLAlchemyAsyncMockRepository
 
@@ -123,7 +123,7 @@ class SQLAlchemyAsyncRepositoryReadService(Generic[ModelT], ResultConverter):
 
     async def count(
         self,
-        *filters: FilterTypes | ColumnElement[bool],
+        *filters: StatementFilter | ColumnElement[bool],
         statement: Select[tuple[ModelT]] | StatementLambdaElement | None = None,
         load: LoadSpec | None = None,
         execution_options: dict[str, Any] | None = None,
@@ -152,7 +152,7 @@ class SQLAlchemyAsyncRepositoryReadService(Generic[ModelT], ResultConverter):
 
     async def exists(
         self,
-        *filters: FilterTypes | ColumnElement[bool],
+        *filters: StatementFilter | ColumnElement[bool],
         load: LoadSpec | None = None,
         execution_options: dict[str, Any] | None = None,
         **kwargs: Any,
@@ -280,7 +280,7 @@ class SQLAlchemyAsyncRepositoryReadService(Generic[ModelT], ResultConverter):
 
     async def list_and_count(
         self,
-        *filters: FilterTypes | ColumnElement[bool],
+        *filters: StatementFilter | ColumnElement[bool],
         auto_expunge: bool | None = None,
         statement: Select[tuple[ModelT]] | StatementLambdaElement | None = None,
         force_basic_query_mode: bool | None = None,
@@ -348,7 +348,7 @@ class SQLAlchemyAsyncRepositoryReadService(Generic[ModelT], ResultConverter):
     # this needs to stay at the end to make the vscode linter happy
     async def list(
         self,
-        *filters: FilterTypes | ColumnElement[bool],
+        *filters: StatementFilter | ColumnElement[bool],
         auto_expunge: bool | None = None,
         statement: Select[tuple[ModelT]] | StatementLambdaElement | None = None,
         load: LoadSpec | None = None,

--- a/advanced_alchemy/service/_sync.py
+++ b/advanced_alchemy/service/_sync.py
@@ -32,7 +32,7 @@ if TYPE_CHECKING:
     from sqlalchemy.sql import ColumnElement
 
     from advanced_alchemy.config.sync import SQLAlchemySyncConfig
-    from advanced_alchemy.filters import FilterTypes
+    from advanced_alchemy.filters import StatementFilter
     from advanced_alchemy.repository import SQLAlchemySyncRepository
     from advanced_alchemy.repository.memory import SQLAlchemySyncMockRepository
 
@@ -124,7 +124,7 @@ class SQLAlchemySyncRepositoryReadService(Generic[ModelT], ResultConverter):
 
     def count(
         self,
-        *filters: FilterTypes | ColumnElement[bool],
+        *filters: StatementFilter | ColumnElement[bool],
         statement: Select[tuple[ModelT]] | StatementLambdaElement | None = None,
         load: LoadSpec | None = None,
         execution_options: dict[str, Any] | None = None,
@@ -153,7 +153,7 @@ class SQLAlchemySyncRepositoryReadService(Generic[ModelT], ResultConverter):
 
     def exists(
         self,
-        *filters: FilterTypes | ColumnElement[bool],
+        *filters: StatementFilter | ColumnElement[bool],
         load: LoadSpec | None = None,
         execution_options: dict[str, Any] | None = None,
         **kwargs: Any,
@@ -281,7 +281,7 @@ class SQLAlchemySyncRepositoryReadService(Generic[ModelT], ResultConverter):
 
     def list_and_count(
         self,
-        *filters: FilterTypes | ColumnElement[bool],
+        *filters: StatementFilter | ColumnElement[bool],
         auto_expunge: bool | None = None,
         statement: Select[tuple[ModelT]] | StatementLambdaElement | None = None,
         force_basic_query_mode: bool | None = None,
@@ -349,7 +349,7 @@ class SQLAlchemySyncRepositoryReadService(Generic[ModelT], ResultConverter):
     # this needs to stay at the end to make the vscode linter happy
     def list(
         self,
-        *filters: FilterTypes | ColumnElement[bool],
+        *filters: StatementFilter | ColumnElement[bool],
         auto_expunge: bool | None = None,
         statement: Select[tuple[ModelT]] | StatementLambdaElement | None = None,
         load: LoadSpec | None = None,

--- a/tests/unit/test_repository.py
+++ b/tests/unit/test_repository.py
@@ -772,8 +772,8 @@ async def test_execute(mock_repo: SQLAlchemyAsyncRepository[Any]) -> None:
 def test_filter_in_collection_noop_if_collection_empty(mock_repo: SQLAlchemyAsyncRepository[Any]) -> None:
     """Ensures we don't filter on an empty collection."""
     statement = MagicMock()
-    filter = CollectionFilter(field_name="id", values=[])
-    statement = filter.append_to_lambda_statement(statement, MagicMock())
+    filter = CollectionFilter(field_name="id", values=[])  # type:ignore[var-annotated]
+    statement = filter.append_to_lambda_statement(statement, MagicMock())  # type:ignore[assignment]
     mock_repo.statement.where.assert_not_called()
 
 
@@ -791,7 +791,7 @@ def test_filter_on_datetime_field(before: datetime, after: datetime, mock_repo: 
     statement = MagicMock()
     field_mock.__gt__ = field_mock.__lt__ = lambda self, other: True
     filter = BeforeAfter(field_name="updated_at", before=before, after=after)
-    statement = filter.append_to_lambda_statement(statement, MagicMock())
+    statement = filter.append_to_lambda_statement(statement, MagicMock())  # type:ignore[assignment]
     mock_repo.model_type.updated_at = field_mock
     mock_repo.statement.where.assert_not_called()
 

--- a/tests/unit/test_repository.py
+++ b/tests/unit/test_repository.py
@@ -10,7 +10,7 @@ from uuid import uuid4
 import pytest
 from pytest_lazyfixture import lazy_fixture
 from sqlalchemy import String
-from sqlalchemy.exc import InvalidRequestError, SQLAlchemyError
+from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import InstrumentedAttribute, Mapped, Session, mapped_column
 
@@ -76,7 +76,7 @@ def sync_mock_repo() -> SQLAlchemySyncRepository[MagicMock]:
 
 @pytest.fixture(params=[lazy_fixture("sync_mock_repo"), lazy_fixture("async_mock_repo")])
 def mock_repo(request: FixtureRequest) -> SQLAlchemyAsyncRepository[MagicMock]:
-    return cast(SQLAlchemyAsyncRepository, request.param)
+    return cast(SQLAlchemyAsyncRepository[Any], request.param)
 
 
 @pytest.fixture()
@@ -187,7 +187,7 @@ def test_wrap_sqlalchemy_generic_error() -> None:
         raise SQLAlchemyError
 
 
-async def test_sqlalchemy_repo_add(mock_repo: SQLAlchemyAsyncRepository) -> None:
+async def test_sqlalchemy_repo_add(mock_repo: SQLAlchemyAsyncRepository[Any]) -> None:
     """Test expected method calls for add operation."""
     mock_instance = MagicMock()
 
@@ -202,7 +202,7 @@ async def test_sqlalchemy_repo_add(mock_repo: SQLAlchemyAsyncRepository) -> None
 
 
 async def test_sqlalchemy_repo_add_many(
-    mock_repo: SQLAlchemyAsyncRepository,
+    mock_repo: SQLAlchemyAsyncRepository[Any],
     monkeypatch: MonkeyPatch,
     mocker: MockerFixture,
     request: FixtureRequest,
@@ -223,7 +223,7 @@ async def test_sqlalchemy_repo_add_many(
 
 
 async def test_sqlalchemy_repo_update_many(
-    mock_repo: SQLAlchemyAsyncRepository,
+    mock_repo: SQLAlchemyAsyncRepository[Any],
     monkeypatch: MonkeyPatch,
     mocker: MockerFixture,
 ) -> None:
@@ -244,7 +244,7 @@ async def test_sqlalchemy_repo_update_many(
 
 
 async def test_sqlalchemy_repo_upsert_many(
-    mock_repo: SQLAlchemyAsyncRepository,
+    mock_repo: SQLAlchemyAsyncRepository[Any],
     monkeypatch: MonkeyPatch,
     mocker: MockerFixture,
 ) -> None:
@@ -267,7 +267,7 @@ async def test_sqlalchemy_repo_upsert_many(
     mock_repo.session.commit.assert_not_called()
 
 
-async def test_sqlalchemy_repo_delete(mock_repo: SQLAlchemyAsyncRepository, mocker: MockerFixture) -> None:
+async def test_sqlalchemy_repo_delete(mock_repo: SQLAlchemyAsyncRepository[Any], mocker: MockerFixture) -> None:
     """Test expected method calls for delete operation."""
     mock_instance = MagicMock()
     mocker.patch.object(mock_repo, "get", return_value=mock_instance)
@@ -282,7 +282,7 @@ async def test_sqlalchemy_repo_delete(mock_repo: SQLAlchemyAsyncRepository, mock
 
 
 async def test_sqlalchemy_repo_delete_many_uuid(
-    mock_repo: SQLAlchemyAsyncRepository,
+    mock_repo: SQLAlchemyAsyncRepository[Any],
     monkeypatch: MonkeyPatch,
     mock_session_scalars: AnyMock,
     mock_session_execute: AnyMock,
@@ -306,7 +306,7 @@ async def test_sqlalchemy_repo_delete_many_uuid(
 
 
 async def test_sqlalchemy_repo_delete_many_bigint(
-    mock_repo: SQLAlchemyAsyncRepository,
+    mock_repo: SQLAlchemyAsyncRepository[Any],
     monkeypatch: MonkeyPatch,
     mock_session_scalars: AnyMock,
     mock_session_execute: AnyMock,
@@ -331,7 +331,7 @@ async def test_sqlalchemy_repo_delete_many_bigint(
 
 
 async def test_sqlalchemy_repo_get_member(
-    mock_repo: SQLAlchemyAsyncRepository,
+    mock_repo: SQLAlchemyAsyncRepository[Any],
     monkeypatch: MonkeyPatch,
     mock_repo_execute: AnyMock,
 ) -> None:
@@ -347,7 +347,7 @@ async def test_sqlalchemy_repo_get_member(
 
 
 async def test_sqlalchemy_repo_get_one_member(
-    mock_repo: SQLAlchemyAsyncRepository,
+    mock_repo: SQLAlchemyAsyncRepository[Any],
     monkeypatch: MonkeyPatch,
     mock_repo_execute: AnyMock,
 ) -> None:
@@ -363,7 +363,7 @@ async def test_sqlalchemy_repo_get_one_member(
 
 
 async def test_sqlalchemy_repo_get_or_upsert_member_existing(
-    mock_repo: SQLAlchemyAsyncRepository,
+    mock_repo: SQLAlchemyAsyncRepository[Any],
     monkeypatch: MonkeyPatch,
     mock_repo_execute: AnyMock,
     mock_repo_attach_to_session: AnyMock,
@@ -383,7 +383,7 @@ async def test_sqlalchemy_repo_get_or_upsert_member_existing(
 
 
 async def test_sqlalchemy_repo_get_or_upsert_member_existing_upsert(
-    mock_repo: SQLAlchemyAsyncRepository,
+    mock_repo: SQLAlchemyAsyncRepository[Any],
     monkeypatch: MonkeyPatch,
     mock_repo_execute: AnyMock,
     mock_repo_attach_to_session: AnyMock,
@@ -406,7 +406,7 @@ async def test_sqlalchemy_repo_get_or_upsert_member_existing_upsert(
 
 
 async def test_sqlalchemy_repo_get_or_upsert_member_existing_no_upsert(
-    mock_repo: SQLAlchemyAsyncRepository,
+    mock_repo: SQLAlchemyAsyncRepository[Any],
     monkeypatch: MonkeyPatch,
     mock_repo_execute: AnyMock,
 ) -> None:
@@ -426,7 +426,7 @@ async def test_sqlalchemy_repo_get_or_upsert_member_existing_no_upsert(
 
 
 async def test_sqlalchemy_repo_get_or_upsert_member_created(
-    mock_repo: SQLAlchemyAsyncRepository,
+    mock_repo: SQLAlchemyAsyncRepository[Any],
     monkeypatch: MonkeyPatch,
     mock_repo_execute: AnyMock,
 ) -> None:
@@ -443,7 +443,7 @@ async def test_sqlalchemy_repo_get_or_upsert_member_created(
 
 
 async def test_sqlalchemy_repo_get_one_or_none_member(
-    mock_repo: SQLAlchemyAsyncRepository,
+    mock_repo: SQLAlchemyAsyncRepository[Any],
     monkeypatch: MonkeyPatch,
     mock_repo_execute: AnyMock,
 ) -> None:
@@ -459,7 +459,7 @@ async def test_sqlalchemy_repo_get_one_or_none_member(
 
 
 async def test_sqlalchemy_repo_get_one_or_none_not_found(
-    mock_repo: SQLAlchemyAsyncRepository,
+    mock_repo: SQLAlchemyAsyncRepository[Any],
     monkeypatch: MonkeyPatch,
     mock_repo_execute: AnyMock,
 ) -> None:
@@ -475,7 +475,7 @@ async def test_sqlalchemy_repo_get_one_or_none_not_found(
 
 
 async def test_sqlalchemy_repo_list(
-    mock_repo: SQLAlchemyAsyncRepository,
+    mock_repo: SQLAlchemyAsyncRepository[Any],
     monkeypatch: MonkeyPatch,
     mock_repo_execute: AnyMock,
 ) -> None:
@@ -490,7 +490,7 @@ async def test_sqlalchemy_repo_list(
     mock_repo.session.commit.assert_not_called()
 
 
-async def test_sqlalchemy_repo_list_and_count(mock_repo: SQLAlchemyAsyncRepository, mocker: MockerFixture) -> None:
+async def test_sqlalchemy_repo_list_and_count(mock_repo: SQLAlchemyAsyncRepository[Any], mocker: MockerFixture) -> None:
     """Test expected method calls for list operation."""
     mock_instances = [MagicMock(), MagicMock()]
     mock_count = len(mock_instances)
@@ -506,7 +506,7 @@ async def test_sqlalchemy_repo_list_and_count(mock_repo: SQLAlchemyAsyncReposito
 
 
 async def test_sqlalchemy_repo_list_and_count_basic(
-    mock_repo: SQLAlchemyAsyncRepository,
+    mock_repo: SQLAlchemyAsyncRepository[Any],
     mocker: MockerFixture,
 ) -> None:
     """Test expected method calls for list operation."""
@@ -524,7 +524,7 @@ async def test_sqlalchemy_repo_list_and_count_basic(
 
 
 async def test_sqlalchemy_repo_exists(
-    mock_repo: SQLAlchemyAsyncRepository,
+    mock_repo: SQLAlchemyAsyncRepository[Any],
     monkeypatch: MonkeyPatch,
     mock_repo_execute: AnyMock,
     mock_repo_count: AnyMock,
@@ -539,7 +539,7 @@ async def test_sqlalchemy_repo_exists(
 
 
 async def test_sqlalchemy_repo_exists_with_filter(
-    mock_repo: SQLAlchemyAsyncRepository,
+    mock_repo: SQLAlchemyAsyncRepository[Any],
     monkeypatch: MonkeyPatch,
     mock_repo_execute: AnyMock,
     mock_repo_count: AnyMock,
@@ -555,7 +555,7 @@ async def test_sqlalchemy_repo_exists_with_filter(
 
 
 async def test_sqlalchemy_repo_count(
-    mock_repo: SQLAlchemyAsyncRepository,
+    mock_repo: SQLAlchemyAsyncRepository[Any],
     monkeypatch: MonkeyPatch,
     mock_repo_execute: AnyMock,
     mock_repo_count: AnyMock,
@@ -570,65 +570,54 @@ async def test_sqlalchemy_repo_count(
 
 
 async def test_sqlalchemy_repo_list_with_pagination(
-    mock_repo: SQLAlchemyAsyncRepository,
+    mock_repo: SQLAlchemyAsyncRepository[Any],
     monkeypatch: MonkeyPatch,
     mock_repo_execute: AnyMock,
     mocker: MockerFixture,
 ) -> None:
     """Test list operation with pagination."""
-    mocker.patch.object(mock_repo, "_apply_limit_offset_pagination", return_value=mock_repo.statement)
+    statement = MagicMock()
     mock_repo_execute.return_value = MagicMock()
-    mock_repo.statement.where.return_value = mock_repo.statement
+    mocker.patch.object(LimitOffset, "append_to_lambda_statement", return_value=statement)
+    mock_repo_execute.return_value = MagicMock()
     await maybe_async(mock_repo.list(LimitOffset(2, 3)))
-    assert mock_repo._apply_limit_offset_pagination.call_count == 1
-    mock_repo._apply_limit_offset_pagination.assert_called_with(2, 3, statement=mock_repo.statement)
+    mock_repo._execute.assert_called_with(statement, uniquify=False)
 
 
 async def test_sqlalchemy_repo_list_with_before_after_filter(
-    mock_repo: SQLAlchemyAsyncRepository,
+    mock_repo: SQLAlchemyAsyncRepository[Any],
     mock_repo_execute: AnyMock,
     mocker: MockerFixture,
 ) -> None:
     """Test list operation with BeforeAfter filter."""
+    statement = MagicMock()
     mocker.patch.object(mock_repo.model_type.updated_at, "__lt__", return_value="lt")
     mocker.patch.object(mock_repo.model_type.updated_at, "__gt__", return_value="gt")
-    mocker.patch.object(mock_repo, "_filter_on_datetime_field", return_value=mock_repo.statement)
+    mocker.patch.object(BeforeAfter, "append_to_lambda_statement", return_value=statement)
     mock_repo_execute.return_value = MagicMock()
-    mock_repo.statement.where.return_value = mock_repo.statement
     await maybe_async(mock_repo.list(BeforeAfter("updated_at", datetime.max, datetime.min)))
-    assert mock_repo._filter_on_datetime_field.call_count == 1
-    mock_repo._filter_on_datetime_field.assert_called_with(
-        field_name="updated_at",
-        before=datetime.max,
-        after=datetime.min,
-        statement=mock_repo.statement,
-    )
+    mock_repo._execute.assert_called_with(statement, uniquify=False)
 
 
 async def test_sqlalchemy_repo_list_with_on_before_after_filter(
-    mock_repo: SQLAlchemyAsyncRepository,
+    mock_repo: SQLAlchemyAsyncRepository[Any],
     monkeypatch: MonkeyPatch,
     mock_repo_execute: AnyMock,
     mocker: MockerFixture,
 ) -> None:
     """Test list operation with BeforeAfter filter."""
+    statement = MagicMock()
     mocker.patch.object(mock_repo.model_type.updated_at, "__le__", return_value="le")
     mocker.patch.object(mock_repo.model_type.updated_at, "__ge__", return_value="ge")
-    mocker.patch.object(mock_repo, "_filter_on_datetime_field", return_value=mock_repo.statement)
+    mocker.patch.object(OnBeforeAfter, "append_to_lambda_statement", return_value=statement)
+
     mock_repo_execute.return_value = MagicMock()
-    mock_repo.statement.where.return_value = mock_repo.statement
     await maybe_async(mock_repo.list(OnBeforeAfter("updated_at", datetime.max, datetime.min)))
-    assert mock_repo._filter_on_datetime_field.call_count == 1
-    mock_repo._filter_on_datetime_field.assert_called_with(
-        field_name="updated_at",
-        on_or_before=datetime.max,
-        on_or_after=datetime.min,
-        statement=mock_repo.statement,
-    )
+    mock_repo._execute.assert_called_with(statement, uniquify=False)
 
 
 async def test_sqlalchemy_repo_list_with_collection_filter(
-    mock_repo: SQLAlchemyAsyncRepository,
+    mock_repo: SQLAlchemyAsyncRepository[Any],
     monkeypatch: MonkeyPatch,
     mock_repo_execute: AnyMock,
     mocker: MockerFixture,
@@ -637,15 +626,14 @@ async def test_sqlalchemy_repo_list_with_collection_filter(
     field_name = "id"
     mock_repo_execute.return_value = MagicMock()
     mock_repo.statement.where.return_value = mock_repo.statement
-    mocker.patch.object(mock_repo, "_filter_in_collection", return_value=mock_repo.statement)
+    mocker.patch.object(CollectionFilter, "append_to_lambda_statement", return_value=mock_repo.statement)
     values = [1, 2, 3]
     await maybe_async(mock_repo.list(CollectionFilter(field_name, values)))
-    assert mock_repo._filter_in_collection.call_count == 1
-    mock_repo._filter_in_collection.assert_called_with(field_name, values, statement=mock_repo.statement)
+    mock_repo._execute.assert_called_with(mock_repo.statement, uniquify=False)
 
 
 async def test_sqlalchemy_repo_list_with_null_collection_filter(
-    mock_repo: SQLAlchemyAsyncRepository,
+    mock_repo: SQLAlchemyAsyncRepository[Any],
     monkeypatch: MonkeyPatch,
     mock_repo_execute: AnyMock,
     mocker: MockerFixture,
@@ -654,13 +642,17 @@ async def test_sqlalchemy_repo_list_with_null_collection_filter(
     field_name = "id"
     mock_repo_execute.return_value = MagicMock()
     mock_repo.statement.where.return_value = mock_repo.statement
-    mocker.patch.object(mock_repo, "_filter_in_collection", return_value=mock_repo.statement)
+    monkeypatch.setattr(
+        CollectionFilter,
+        "append_to_lambda_statement",
+        MagicMock(return_value=mock_repo.statement),
+    )
     await maybe_async(mock_repo.list(CollectionFilter(field_name, None)))
-    mock_repo._filter_in_collection.assert_not_called()
+    mock_repo._execute.assert_called_with(mock_repo.statement, uniquify=False)
 
 
 async def test_sqlalchemy_repo_empty_list_with_collection_filter(
-    mock_repo: SQLAlchemyAsyncRepository,
+    mock_repo: SQLAlchemyAsyncRepository[Any],
     monkeypatch: MonkeyPatch,
     mock_repo_execute: AnyMock,
     mocker: MockerFixture,
@@ -669,15 +661,19 @@ async def test_sqlalchemy_repo_empty_list_with_collection_filter(
     field_name = "id"
     mock_repo_execute.return_value = MagicMock()
     mock_repo.statement.where.return_value = mock_repo.statement
-    mocker.patch.object(mock_repo, "_filter_in_collection", return_value=mock_repo.statement)
     values: Collection[Any] = []
     await maybe_async(mock_repo.list(CollectionFilter(field_name, values)))
-    assert mock_repo._filter_in_collection.call_count == 1
-    mock_repo._filter_in_collection.assert_called_with(field_name, values, statement=mock_repo.statement)
+    monkeypatch.setattr(
+        CollectionFilter,
+        "append_to_lambda_statement",
+        MagicMock(return_value=mock_repo.statement),
+    )
+    await maybe_async(mock_repo.list(CollectionFilter(field_name, values)))
+    mock_repo._execute.assert_called_with(mock_repo.statement, uniquify=False)
 
 
 async def test_sqlalchemy_repo_list_with_not_in_collection_filter(
-    mock_repo: SQLAlchemyAsyncRepository,
+    mock_repo: SQLAlchemyAsyncRepository[Any],
     monkeypatch: MonkeyPatch,
     mock_repo_execute: AnyMock,
     mocker: MockerFixture,
@@ -686,15 +682,18 @@ async def test_sqlalchemy_repo_list_with_not_in_collection_filter(
     field_name = "id"
     mock_repo_execute.return_value = MagicMock()
     mock_repo.statement.where.return_value = mock_repo.statement
-    mocker.patch.object(mock_repo, "_filter_not_in_collection", return_value=mock_repo.statement)
+    monkeypatch.setattr(
+        NotInCollectionFilter,
+        "append_to_lambda_statement",
+        MagicMock(return_value=mock_repo.statement),
+    )
     values = [1, 2, 3]
     await maybe_async(mock_repo.list(NotInCollectionFilter(field_name, values)))
-    assert mock_repo._filter_not_in_collection.call_count == 1
-    mock_repo._filter_not_in_collection.assert_called_with(field_name, values, statement=mock_repo.statement)
+    mock_repo._execute.assert_called_with(mock_repo.statement, uniquify=False)
 
 
 async def test_sqlalchemy_repo_list_with_null_not_in_collection_filter(
-    mock_repo: SQLAlchemyAsyncRepository,
+    mock_repo: SQLAlchemyAsyncRepository[Any],
     monkeypatch: MonkeyPatch,
     mock_repo_execute: AnyMock,
     mocker: MockerFixture,
@@ -703,19 +702,23 @@ async def test_sqlalchemy_repo_list_with_null_not_in_collection_filter(
     field_name = "id"
     mock_repo_execute.return_value = MagicMock()
     mock_repo.statement.where.return_value = mock_repo.statement
-    mocker.patch.object(mock_repo, "_filter_not_in_collection", return_value=mock_repo.statement)
+    monkeypatch.setattr(
+        NotInCollectionFilter,
+        "append_to_lambda_statement",
+        MagicMock(return_value=mock_repo.statement),
+    )
     await maybe_async(mock_repo.list(NotInCollectionFilter(field_name, None)))
-    mock_repo._filter_not_in_collection.assert_not_called()
+    mock_repo._execute.assert_called_with(mock_repo.statement, uniquify=False)
 
 
-async def test_sqlalchemy_repo_unknown_filter_type_raises(mock_repo: SQLAlchemyAsyncRepository) -> None:
+async def test_sqlalchemy_repo_unknown_filter_type_raises(mock_repo: SQLAlchemyAsyncRepository[Any]) -> None:
     """Test that repo raises exception if list receives unknown filter type."""
     with pytest.raises(RepositoryError):
         await maybe_async(mock_repo.list("not a filter"))  # type: ignore
 
 
 async def test_sqlalchemy_repo_update(
-    mock_repo: SQLAlchemyAsyncRepository,
+    mock_repo: SQLAlchemyAsyncRepository[Any],
     monkeypatch: MonkeyPatch,
     mocker: MockerFixture,
 ) -> None:
@@ -736,7 +739,7 @@ async def test_sqlalchemy_repo_update(
     mock_repo.session.refresh.assert_called_once_with(mock_instance, attribute_names=None, with_for_update=None)
 
 
-async def test_sqlalchemy_repo_upsert(mock_repo: SQLAlchemyAsyncRepository, mocker: MockerFixture) -> None:
+async def test_sqlalchemy_repo_upsert(mock_repo: SQLAlchemyAsyncRepository[Any], mocker: MockerFixture) -> None:
     """Test the sequence of repo calls for upsert operation."""
     mock_instance = MagicMock()
     mock_repo.session.merge.return_value = mock_instance
@@ -753,23 +756,24 @@ async def test_sqlalchemy_repo_upsert(mock_repo: SQLAlchemyAsyncRepository, mock
 
 
 async def test_attach_to_session_unexpected_strategy_raises_valueerror(
-    mock_repo: SQLAlchemyAsyncRepository,
+    mock_repo: SQLAlchemyAsyncRepository[Any],
 ) -> None:
     """Test to hit the error condition in SQLAlchemy._attach_to_session()."""
     with pytest.raises(ValueError):
         await maybe_async(mock_repo._attach_to_session(MagicMock(), strategy="t-rex"))  # type:ignore[arg-type]
 
 
-async def test_execute(mock_repo: SQLAlchemyAsyncRepository) -> None:
+async def test_execute(mock_repo: SQLAlchemyAsyncRepository[Any]) -> None:
     """Simple test of the abstraction over `AsyncSession.execute()`"""
     _ = await maybe_async(mock_repo._execute(mock_repo.statement))
     mock_repo.session.execute.assert_called_once_with(mock_repo.statement)
 
 
-def test_filter_in_collection_noop_if_collection_empty(mock_repo: SQLAlchemyAsyncRepository) -> None:
+def test_filter_in_collection_noop_if_collection_empty(mock_repo: SQLAlchemyAsyncRepository[Any]) -> None:
     """Ensures we don't filter on an empty collection."""
-    statement = mock_repo._to_lambda_stmt(mock_repo.statement)
-    mock_repo._filter_in_collection("id", [], statement=statement)
+    statement = MagicMock()
+    filter = CollectionFilter(field_name="id", values=[])
+    statement = filter.append_to_lambda_statement(statement, MagicMock())
     mock_repo.statement.where.assert_not_called()
 
 
@@ -781,34 +785,21 @@ def test_filter_in_collection_noop_if_collection_empty(mock_repo: SQLAlchemyAsyn
         (datetime.max, None),
     ],
 )
-def test_filter_on_datetime_field(before: datetime, after: datetime, mock_repo: SQLAlchemyAsyncRepository) -> None:
+def test_filter_on_datetime_field(before: datetime, after: datetime, mock_repo: SQLAlchemyAsyncRepository[Any]) -> None:
     """Test through branches of _filter_on_datetime_field()"""
     field_mock = MagicMock()
+    statement = MagicMock()
     field_mock.__gt__ = field_mock.__lt__ = lambda self, other: True
-    statement = mock_repo._to_lambda_stmt(mock_repo.statement)
+    filter = BeforeAfter(field_name="updated_at", before=before, after=after)
+    statement = filter.append_to_lambda_statement(statement, MagicMock())
     mock_repo.model_type.updated_at = field_mock
-    mock_repo._filter_on_datetime_field("updated_at", before=before, after=after, statement=statement)
+    mock_repo.statement.where.assert_not_called()
 
 
-def test_filter_collection_by_kwargs(mock_repo: SQLAlchemyAsyncRepository, mocker: MockerFixture) -> None:
+def test_filter_collection_by_kwargs(mock_repo: SQLAlchemyAsyncRepository[Any], mocker: MockerFixture) -> None:
     """Test `filter_by()` called with kwargs."""
     mock_repo_execute.return_value = MagicMock()
     statement = mock_repo._to_lambda_stmt(mock_repo.statement)
     mocker.patch.object(mock_repo, "filter_collection_by_kwargs", return_value=statement)
     _ = mock_repo.filter_collection_by_kwargs(statement, a=1, b=2)
     mock_repo.filter_collection_by_kwargs.assert_called_once_with(statement, a=1, b=2)
-
-
-def test_filter_collection_by_kwargs_raises_repository_exception_for_attribute_error(
-    mock_repo: SQLAlchemyAsyncRepository,
-    mocker: MockerFixture,
-) -> None:
-    """Test that we raise a repository exception if an attribute name is
-    incorrect.
-    """
-    statement = mock_repo._to_lambda_stmt(mock_repo.statement)
-    statement.filter_by = MagicMock(  # type: ignore # pyright: ignore[reportGeneralTypeIssues]
-        side_effect=InvalidRequestError,
-    )
-    with pytest.raises(RepositoryError):
-        _ = mock_repo.filter_collection_by_kwargs(statement, a=1)


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

This refactors the FilterTypes to a more extensible design.  You can now subclass StatementFilter to create your own custom repository filters.

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
## Closes
