### PR TITLE
feat: services accept BaseModels and Structs

### DIFF
--- a/advanced_alchemy/service/_async.py
+++ b/advanced_alchemy/service/_async.py
@@ -295,7 +295,7 @@ class SQLAlchemyAsyncRepositoryReadService(ResultConverter, Generic[ModelT]):
         if MSGSPEC_INSTALLED and isinstance(data, Struct):
             return model_from_dict(
                 model=self.repository.model_type,
-                **{f: getattr(data, f) for f in data.__struct_fields__ if getattr(data, f, None) != UNSET},
+                **{f: val for f in data.__struct_fields__ if (val := getattr(data, f, None)) != UNSET},
             )
 
         return cast("ModelT", data)

--- a/advanced_alchemy/service/_async.py
+++ b/advanced_alchemy/service/_async.py
@@ -439,11 +439,7 @@ class SQLAlchemyAsyncRepositoryService(SQLAlchemyAsyncRepositoryReadService[Mode
 
     async def create_many(
         self,
-        data: list[ModelT | dict[str, Any] | Struct | BaseModel]
-        | list[dict[str, Any]]
-        | list[ModelT]
-        | list[Struct]
-        | list[BaseModel],
+        data: Sequence[ModelT | dict[str, Any] | Struct | BaseModel],
         auto_commit: bool | None = None,
         auto_expunge: bool | None = None,
         load: LoadSpec | None = None,
@@ -464,7 +460,11 @@ class SQLAlchemyAsyncRepositoryService(SQLAlchemyAsyncRepositoryReadService[Mode
             Representation of created instances.
         """
         data = [(await self.to_model(datum, "create")) for datum in data]
-        return await self.repository.add_many(data=data, auto_commit=auto_commit, auto_expunge=auto_expunge)
+        return await self.repository.add_many(
+            data=cast("list[ModelT]", data),  # pyright: ignore[reportUnnecessaryCast]
+            auto_commit=auto_commit,
+            auto_expunge=auto_expunge,
+        )
 
     async def update(
         self,
@@ -533,11 +533,7 @@ class SQLAlchemyAsyncRepositoryService(SQLAlchemyAsyncRepositoryReadService[Mode
 
     async def update_many(
         self,
-        data: list[ModelT | dict[str, Any] | Struct | BaseModel]
-        | list[dict[str, Any]]
-        | list[ModelT]
-        | list[Struct]
-        | list[BaseModel],
+        data: Sequence[ModelT | dict[str, Any] | Struct | BaseModel],
         auto_commit: bool | None = None,
         auto_expunge: bool | None = None,
         load: LoadSpec | None = None,
@@ -559,7 +555,7 @@ class SQLAlchemyAsyncRepositoryService(SQLAlchemyAsyncRepositoryReadService[Mode
         """
         data = [(await self.to_model(datum, "update")) for datum in data]
         return await self.repository.update_many(
-            data,
+            cast("list[ModelT]", data),  # pyright: ignore[reportUnnecessaryCast]
             auto_commit=auto_commit,
             auto_expunge=auto_expunge,
             load=load,
@@ -622,11 +618,7 @@ class SQLAlchemyAsyncRepositoryService(SQLAlchemyAsyncRepositoryReadService[Mode
 
     async def upsert_many(
         self,
-        data: list[ModelT | dict[str, Any] | Struct | BaseModel]
-        | list[dict[str, Any]]
-        | list[ModelT]
-        | list[Struct]
-        | list[BaseModel],
+        data: Sequence[ModelT | dict[str, Any] | Struct | BaseModel],
         auto_expunge: bool | None = None,
         auto_commit: bool | None = None,
         no_merge: bool = False,
@@ -656,7 +648,7 @@ class SQLAlchemyAsyncRepositoryService(SQLAlchemyAsyncRepositoryReadService[Mode
         """
         data = [(await self.to_model(datum, "upsert")) for datum in data]
         return await self.repository.upsert_many(
-            data=data,
+            data=cast("list[ModelT]", data),  # pyright: ignore[reportUnnecessaryCast]
             auto_expunge=auto_expunge,
             auto_commit=auto_commit,
             no_merge=no_merge,

--- a/advanced_alchemy/service/_sync.py
+++ b/advanced_alchemy/service/_sync.py
@@ -296,7 +296,7 @@ class SQLAlchemySyncRepositoryReadService(ResultConverter, Generic[ModelT]):
         if MSGSPEC_INSTALLED and isinstance(data, Struct):
             return model_from_dict(
                 model=self.repository.model_type,
-                **{f: getattr(data, f) for f in data.__struct_fields__ if getattr(data, f, None) != UNSET},
+                **{f: val for f in data.__struct_fields__ if (val := getattr(data, f, None)) != UNSET},
             )
 
         return cast("ModelT", data)

--- a/advanced_alchemy/service/_sync.py
+++ b/advanced_alchemy/service/_sync.py
@@ -440,11 +440,7 @@ class SQLAlchemySyncRepositoryService(SQLAlchemySyncRepositoryReadService[ModelT
 
     def create_many(
         self,
-        data: list[ModelT | dict[str, Any] | Struct | BaseModel]
-        | list[dict[str, Any]]
-        | list[ModelT]
-        | list[Struct]
-        | list[BaseModel],
+        data: Sequence[ModelT | dict[str, Any] | Struct | BaseModel],
         auto_commit: bool | None = None,
         auto_expunge: bool | None = None,
         load: LoadSpec | None = None,
@@ -465,7 +461,11 @@ class SQLAlchemySyncRepositoryService(SQLAlchemySyncRepositoryReadService[ModelT
             Representation of created instances.
         """
         data = [(self.to_model(datum, "create")) for datum in data]
-        return self.repository.add_many(data=data, auto_commit=auto_commit, auto_expunge=auto_expunge)
+        return self.repository.add_many(
+            data=cast("list[ModelT]", data),  # pyright: ignore[reportUnnecessaryCast]
+            auto_commit=auto_commit,
+            auto_expunge=auto_expunge,
+        )
 
     def update(
         self,
@@ -534,11 +534,7 @@ class SQLAlchemySyncRepositoryService(SQLAlchemySyncRepositoryReadService[ModelT
 
     def update_many(
         self,
-        data: list[ModelT | dict[str, Any] | Struct | BaseModel]
-        | list[dict[str, Any]]
-        | list[ModelT]
-        | list[Struct]
-        | list[BaseModel],
+        data: Sequence[ModelT | dict[str, Any] | Struct | BaseModel],
         auto_commit: bool | None = None,
         auto_expunge: bool | None = None,
         load: LoadSpec | None = None,
@@ -560,7 +556,7 @@ class SQLAlchemySyncRepositoryService(SQLAlchemySyncRepositoryReadService[ModelT
         """
         data = [(self.to_model(datum, "update")) for datum in data]
         return self.repository.update_many(
-            data,
+            cast("list[ModelT]", data),  # pyright: ignore[reportUnnecessaryCast]
             auto_commit=auto_commit,
             auto_expunge=auto_expunge,
             load=load,
@@ -623,11 +619,7 @@ class SQLAlchemySyncRepositoryService(SQLAlchemySyncRepositoryReadService[ModelT
 
     def upsert_many(
         self,
-        data: list[ModelT | dict[str, Any] | Struct | BaseModel]
-        | list[dict[str, Any]]
-        | list[ModelT]
-        | list[Struct]
-        | list[BaseModel],
+        data: Sequence[ModelT | dict[str, Any] | Struct | BaseModel],
         auto_expunge: bool | None = None,
         auto_commit: bool | None = None,
         no_merge: bool = False,
@@ -657,7 +649,7 @@ class SQLAlchemySyncRepositoryService(SQLAlchemySyncRepositoryReadService[ModelT
         """
         data = [(self.to_model(datum, "upsert")) for datum in data]
         return self.repository.upsert_many(
-            data=data,
+            data=cast("list[ModelT]", data),  # pyright: ignore[reportUnnecessaryCast]
             auto_expunge=auto_expunge,
             auto_commit=auto_commit,
             no_merge=no_merge,

--- a/advanced_alchemy/service/typing.py
+++ b/advanced_alchemy/service/typing.py
@@ -21,19 +21,26 @@ from advanced_alchemy.filters import StatementFilter  # noqa: TCH001
 from advanced_alchemy.repository.typing import ModelT  # noqa: TCH001
 
 try:
-    from msgspec import Struct, convert  # pyright: ignore[reportAssignmentType,reportUnusedImport]
+    from msgspec import UNSET, Struct, UnsetType, convert  # pyright: ignore[reportAssignmentType,reportUnusedImport]
 
     MSGSPEC_INSTALLED: Final[bool] = True
 
 except ImportError:  # pragma: nocover
+    import enum
 
     class Struct(Protocol):  # type: ignore[no-redef] # pragma: nocover
         """Placeholder Implementation"""
+
+        __struct_fields__: tuple[str, ...]
 
     def convert(*args: Any, **kwargs: Any) -> Any:  # type: ignore[no-redef] # noqa: ARG001 # pragma: nocover
         """Placeholder implementation"""
         return {}
 
+    class UnsetType(enum.Enum):  # type: ignore[no-redef] # pragma: nocover
+        UNSET = "UNSET"
+
+    UNSET = UnsetType.UNSET  # pyright: ignore[reportConstantRedefinition,reportGeneralTypeIssues]
     MSGSPEC_INSTALLED: Final[bool] = False  # type: ignore # pyright: ignore[reportConstantRedefinition,reportGeneralTypeIssues]  # noqa: PGH003
 
 
@@ -81,4 +88,5 @@ __all__ = (
     "TypeAdapter",
     "Struct",
     "convert",
+    "UNSET",
 )

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -11,7 +11,7 @@ sonar.coverage.exclusions=\
   tests/*.py, \
   tests/**/*.py, \
   advanced_alchemy.filters.py, \
-  advanced_alchemy/service/_converters.py, \
+  advanced_alchemy/service/typing.py, \
   advanced_alchemy/service/_util.py, \
   advanced_alchemy/alembic/templates/asyncio/env.py, \
   advanced_alchemy/alembic/templates/sync/env.py, \

--- a/tests/fixtures/bigint/services.py
+++ b/tests/fixtures/bigint/services.py
@@ -4,6 +4,9 @@ from __future__ import annotations
 
 from typing import Any
 
+from msgspec import Struct
+from pydantic import BaseModel
+
 from advanced_alchemy.service import (
     SQLAlchemyAsyncRepositoryService,
     SQLAlchemySyncRepositoryService,
@@ -222,7 +225,11 @@ class SlugBookAsyncService(SQLAlchemyAsyncRepositoryService[BigIntSlugBook]):
     def __init__(self, **repo_kwargs: Any) -> None:
         self.repository: SlugBookAsyncRepository = self.repository_type(**repo_kwargs)  # pyright: ignore
 
-    async def to_model(self, data: BigIntSlugBook | dict[str, Any], operation: str | None = None) -> BigIntSlugBook:
+    async def to_model(
+        self,
+        data: BigIntSlugBook | dict[str, Any] | BaseModel | Struct,
+        operation: str | None = None,
+    ) -> BigIntSlugBook:
         if isinstance(data, dict) and "slug" not in data and operation == "create":
             data["slug"] = await self.repository.get_available_slug(data["title"])
         if isinstance(data, dict) and "slug" not in data and "title" in data and operation == "update":
@@ -239,7 +246,11 @@ class SlugBookSyncService(SQLAlchemySyncRepositoryService[BigIntSlugBook]):
     def __init__(self, **repo_kwargs: Any) -> None:
         self.repository: SlugBookSyncRepository = self.repository_type(**repo_kwargs)  # pyright: ignore
 
-    def to_model(self, data: BigIntSlugBook | dict[str, Any], operation: str | None = None) -> BigIntSlugBook:
+    def to_model(
+        self,
+        data: BigIntSlugBook | dict[str, Any] | BaseModel | Struct,
+        operation: str | None = None,
+    ) -> BigIntSlugBook:
         if isinstance(data, dict) and "slug" not in data and operation == "create":
             data["slug"] = self.repository.get_available_slug(data["title"])
         if isinstance(data, dict) and "slug" not in data and "title" in data and operation == "update":
@@ -256,7 +267,11 @@ class SlugBookAsyncMockService(SQLAlchemyAsyncRepositoryService[BigIntSlugBook])
     def __init__(self, **repo_kwargs: Any) -> None:
         self.repository: SlugBookAsyncMockRepository = self.repository_type(**repo_kwargs)  # pyright: ignore
 
-    async def to_model(self, data: BigIntSlugBook | dict[str, Any], operation: str | None = None) -> BigIntSlugBook:
+    async def to_model(
+        self,
+        data: BigIntSlugBook | dict[str, Any] | BaseModel | Struct,
+        operation: str | None = None,
+    ) -> BigIntSlugBook:
         if isinstance(data, dict) and "slug" not in data and operation == "create":
             data["slug"] = await self.repository.get_available_slug(data["title"])
         if isinstance(data, dict) and "slug" not in data and "title" in data and operation == "update":
@@ -273,7 +288,11 @@ class SlugBookSyncMockService(SQLAlchemySyncRepositoryService[BigIntSlugBook]):
     def __init__(self, **repo_kwargs: Any) -> None:
         self.repository: SlugBookSyncMockRepository = self.repository_type(**repo_kwargs)  # pyright: ignore
 
-    def to_model(self, data: BigIntSlugBook | dict[str, Any], operation: str | None = None) -> BigIntSlugBook:
+    def to_model(
+        self,
+        data: BigIntSlugBook | dict[str, Any] | BaseModel | Struct,
+        operation: str | None = None,
+    ) -> BigIntSlugBook:
         if isinstance(data, dict) and "slug" not in data and operation == "create":
             data["slug"] = self.repository.get_available_slug(data["title"])
         if isinstance(data, dict) and "slug" not in data and "title" in data and operation == "update":

--- a/tests/fixtures/uuid/services.py
+++ b/tests/fixtures/uuid/services.py
@@ -4,6 +4,9 @@ from __future__ import annotations
 
 from typing import Any
 
+from msgspec import Struct
+from pydantic import BaseModel
+
 from advanced_alchemy.service import (
     SQLAlchemyAsyncRepositoryService,
     SQLAlchemySyncRepositoryService,
@@ -218,7 +221,9 @@ class SlugBookAsyncService(SQLAlchemyAsyncRepositoryService[UUIDSlugBook]):
     def __init__(self, **repo_kwargs: Any) -> None:
         self.repository: SlugBookAsyncRepository = self.repository_type(**repo_kwargs)  # pyright: ignore
 
-    async def to_model(self, data: UUIDSlugBook | dict[str, Any], operation: str | None = None) -> UUIDSlugBook:
+    async def to_model(
+        self, data: UUIDSlugBook | dict[str, Any] | BaseModel | Struct, operation: str | None = None,
+    ) -> UUIDSlugBook:
         if isinstance(data, dict) and "slug" not in data and operation == "create":
             data["slug"] = await self.repository.get_available_slug(data["title"])
         if isinstance(data, dict) and "slug" not in data and "title" in data and operation == "update":
@@ -234,7 +239,11 @@ class SlugBookSyncService(SQLAlchemySyncRepositoryService[UUIDSlugBook]):
     def __init__(self, **repo_kwargs: Any) -> None:
         self.repository: SlugBookSyncRepository = self.repository_type(**repo_kwargs)  # pyright: ignore
 
-    def to_model(self, data: UUIDSlugBook | dict[str, Any], operation: str | None = None) -> UUIDSlugBook:
+    def to_model(
+        self,
+        data: UUIDSlugBook | dict[str, Any] | BaseModel | Struct,
+        operation: str | None = None,
+    ) -> UUIDSlugBook:
         if isinstance(data, dict) and "slug" not in data and operation == "create":
             data["slug"] = self.repository.get_available_slug(data["title"])
         if isinstance(data, dict) and "slug" not in data and "title" in data and operation == "update":
@@ -251,7 +260,11 @@ class SlugBookAsyncMockService(SQLAlchemyAsyncRepositoryService[UUIDSlugBook]):
     def __init__(self, **repo_kwargs: Any) -> None:
         self.repository: SlugBookAsyncMockRepository = self.repository_type(**repo_kwargs)  # pyright: ignore
 
-    async def to_model(self, data: UUIDSlugBook | dict[str, Any], operation: str | None = None) -> UUIDSlugBook:
+    async def to_model(
+        self,
+        data: UUIDSlugBook | dict[str, Any] | BaseModel | Struct,
+        operation: str | None = None,
+    ) -> UUIDSlugBook:
         if isinstance(data, dict) and "slug" not in data and operation == "create":
             data["slug"] = await self.repository.get_available_slug(data["title"])
         if isinstance(data, dict) and "slug" not in data and "title" in data and operation == "update":
@@ -268,7 +281,11 @@ class SlugBookSyncMockService(SQLAlchemySyncRepositoryService[UUIDSlugBook]):
     def __init__(self, **repo_kwargs: Any) -> None:
         self.repository: SlugBookSyncMockRepository = self.repository_type(**repo_kwargs)  # pyright: ignore
 
-    def to_model(self, data: UUIDSlugBook | dict[str, Any], operation: str | None = None) -> UUIDSlugBook:
+    def to_model(
+        self,
+        data: UUIDSlugBook | dict[str, Any] | BaseModel | Struct,
+        operation: str | None = None,
+    ) -> UUIDSlugBook:
         if isinstance(data, dict) and "slug" not in data and operation == "create":
             data["slug"] = self.repository.get_available_slug(data["title"])
         if isinstance(data, dict) and "slug" not in data and "title" in data and operation == "update":


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

This PR allows the service layer to accept MsgSpec Struct or Pydantic BaseModels in addition to dictionaries and SQLAlchemy models.

The service will attempt to convert the Pydantic or Msgspec model to a dictionary before calling the repository methods.

This allows a few lines to be removed in places like HTTP routes because you no longer need to convert the model to a dict before calling the service.

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
## Closes
