### PR TITLE
feat!: revert `to_schema` overloads & optimize `upsert_many`

### DIFF
--- a/advanced_alchemy/repository/_async.py
+++ b/advanced_alchemy/repository/_async.py
@@ -1584,10 +1584,7 @@ class SQLAlchemyAsyncRepository(SQLAlchemyAsyncRepositoryProtocol[ModelT], Filte
                 matched_values = [
                     field_data for datum in data if (field_data := getattr(datum, field_name)) is not None
                 ]
-                if self._prefer_any:
-                    match_filter.append(any_(matched_values) == field)  # type: ignore[arg-type]
-                else:
-                    match_filter.append(field.in_(matched_values))
+                match_filter.append(any_(matched_values) == field if self._prefer_any else field.in_(matched_values))  # type: ignore[arg-type]
 
         with wrap_sqlalchemy_exception():
             existing_objs = await self.list(
@@ -1598,11 +1595,10 @@ class SQLAlchemyAsyncRepository(SQLAlchemyAsyncRepositoryProtocol[ModelT], Filte
             )
             for field_name in match_fields:
                 field = get_instrumented_attr(self.model_type, field_name)
-                matched_values = [getattr(datum, field_name) for datum in existing_objs if datum]
-                if self._prefer_any:
-                    match_filter.append(any_(matched_values) == field)  # type: ignore[arg-type]
-                else:
-                    match_filter.append(field.in_(matched_values))
+                matched_values = list(
+                    {getattr(datum, field_name) for datum in existing_objs if datum},  # ensure the list is unique
+                )
+                match_filter.append(any_(matched_values) == field if self._prefer_any else field.in_(matched_values))  # type: ignore[arg-type]
             existing_ids = self._get_object_ids(existing_objs=existing_objs)
             data = self._merge_on_match_fields(data, existing_objs, match_fields)
             for datum in data:

--- a/advanced_alchemy/service/_async.py
+++ b/advanced_alchemy/service/_async.py
@@ -7,7 +7,7 @@ should be a SQLAlchemy model.
 from __future__ import annotations
 
 from contextlib import asynccontextmanager
-from typing import TYPE_CHECKING, Any, Generic, Iterable, cast, overload
+from typing import TYPE_CHECKING, Any, Generic, Iterable, cast
 
 from sqlalchemy import Select
 from typing_extensions import Self
@@ -28,7 +28,6 @@ from advanced_alchemy.service.typing import (
     UNSET,
     ModelDictListT,
     ModelDictT,
-    ModelDTOT,
     is_dict,
     is_msgspec_model,
     is_pydantic_model,
@@ -45,7 +44,6 @@ if TYPE_CHECKING:
 
     from advanced_alchemy.config.asyncio import SQLAlchemyAsyncConfig
     from advanced_alchemy.filters import StatementFilter
-    from advanced_alchemy.service.pagination import OffsetPagination
 
 
 class SQLAlchemyAsyncQueryService(ResultConverter):
@@ -183,7 +181,6 @@ class SQLAlchemyAsyncRepositoryReadService(Generic[ModelT], ResultConverter):
         """
         return await self.repository.exists(*filters, load=load, execution_options=execution_options, **kwargs)
 
-    @overload
     async def get(
         self,
         item_id: Any,
@@ -193,33 +190,7 @@ class SQLAlchemyAsyncRepositoryReadService(Generic[ModelT], ResultConverter):
         load: LoadSpec | None = None,
         execution_options: dict[str, Any] | None = None,
         auto_expunge: bool | None = None,
-        to_schema: None = None,
-    ) -> ModelT: ...
-
-    @overload
-    async def get(
-        self,
-        item_id: Any,
-        *,
-        statement: Select[tuple[ModelT]] | StatementLambdaElement | None = None,
-        id_attribute: str | InstrumentedAttribute[Any] | None = None,
-        load: LoadSpec | None = None,
-        execution_options: dict[str, Any] | None = None,
-        auto_expunge: bool | None = None,
-        to_schema: type[ModelDTOT],
-    ) -> ModelDTOT: ...
-
-    async def get(
-        self,
-        item_id: Any,
-        *,
-        statement: Select[tuple[ModelT]] | StatementLambdaElement | None = None,
-        id_attribute: str | InstrumentedAttribute[Any] | None = None,
-        load: LoadSpec | None = None,
-        execution_options: dict[str, Any] | None = None,
-        auto_expunge: bool | None = None,
-        to_schema: type[ModelDTOT] | None = None,
-    ) -> ModelT | ModelDTOT:
+    ) -> ModelT:
         """Wrap repository scalar operation.
 
         Args:
@@ -232,13 +203,13 @@ class SQLAlchemyAsyncRepositoryReadService(Generic[ModelT], ResultConverter):
                 Defaults to `id`, but can reference any surrogate or candidate key for the table.
             load: Set relationships to be loaded
             execution_options: Set default execution options
-            to_schema: optionally convert to alternative schema object
+
 
 
         Returns:
             Representation of instance with identifier `item_id`.
         """
-        result = await self.repository.get(
+        return await self.repository.get(
             item_id=item_id,
             auto_expunge=auto_expunge,
             statement=statement,
@@ -246,33 +217,6 @@ class SQLAlchemyAsyncRepositoryReadService(Generic[ModelT], ResultConverter):
             load=load,
             execution_options=execution_options,
         )
-        if to_schema is not None:
-            return self.to_schema(data=result, schema_type=to_schema)
-        return result
-
-    @overload
-    async def get_one(
-        self,
-        *filters: StatementFilter | ColumnElement[bool],
-        statement: Select[tuple[ModelT]] | StatementLambdaElement | None = None,
-        load: LoadSpec | None = None,
-        execution_options: dict[str, Any] | None = None,
-        to_schema: None = None,
-        auto_expunge: bool | None = None,
-        **kwargs: Any,
-    ) -> ModelT: ...
-
-    @overload
-    async def get_one(
-        self,
-        *filters: StatementFilter | ColumnElement[bool],
-        statement: Select[tuple[ModelT]] | StatementLambdaElement | None = None,
-        load: LoadSpec | None = None,
-        execution_options: dict[str, Any] | None = None,
-        auto_expunge: bool | None = None,
-        to_schema: type[ModelDTOT],
-        **kwargs: Any,
-    ) -> ModelDTOT: ...
 
     async def get_one(
         self,
@@ -281,9 +225,8 @@ class SQLAlchemyAsyncRepositoryReadService(Generic[ModelT], ResultConverter):
         load: LoadSpec | None = None,
         auto_expunge: bool | None = None,
         execution_options: dict[str, Any] | None = None,
-        to_schema: type[ModelDTOT] | None = None,
         **kwargs: Any,
-    ) -> ModelT | ModelDTOT:
+    ) -> ModelT:
         """Wrap repository scalar operation.
 
         Args:
@@ -294,13 +237,12 @@ class SQLAlchemyAsyncRepositoryReadService(Generic[ModelT], ResultConverter):
                 Defaults to :class:`SQLAlchemyAsyncRepository.statement <SQLAlchemyAsyncRepository>`
             load: Set default relationships to be loaded
             execution_options: Set default execution options
-            to_schema: optionally convert to alternative schema object
             **kwargs: Identifier of the instance to be retrieved.
 
         Returns:
             Representation of instance with identifier `item_id`.
         """
-        result = await self.repository.get_one(
+        return await self.repository.get_one(
             *filters,
             auto_expunge=auto_expunge,
             statement=statement,
@@ -308,33 +250,6 @@ class SQLAlchemyAsyncRepositoryReadService(Generic[ModelT], ResultConverter):
             execution_options=execution_options,
             **kwargs,
         )
-        if to_schema is not None:
-            return self.to_schema(data=result, schema_type=to_schema)
-        return result
-
-    @overload
-    async def get_one_or_none(
-        self,
-        *filters: StatementFilter | ColumnElement[bool],
-        statement: Select[tuple[ModelT]] | StatementLambdaElement | None = None,
-        load: LoadSpec | None = None,
-        execution_options: dict[str, Any] | None = None,
-        auto_expunge: bool | None = None,
-        to_schema: None = None,
-        **kwargs: Any,
-    ) -> ModelT | None: ...
-
-    @overload
-    async def get_one_or_none(
-        self,
-        *filters: StatementFilter | ColumnElement[bool],
-        statement: Select[tuple[ModelT]] | StatementLambdaElement | None = None,
-        load: LoadSpec | None = None,
-        execution_options: dict[str, Any] | None = None,
-        auto_expunge: bool | None = None,
-        to_schema: type[ModelDTOT],
-        **kwargs: Any,
-    ) -> ModelDTOT | None: ...
 
     async def get_one_or_none(
         self,
@@ -343,9 +258,8 @@ class SQLAlchemyAsyncRepositoryReadService(Generic[ModelT], ResultConverter):
         load: LoadSpec | None = None,
         execution_options: dict[str, Any] | None = None,
         auto_expunge: bool | None = None,
-        to_schema: type[ModelDTOT] | None = None,
         **kwargs: Any,
-    ) -> ModelT | ModelDTOT | None:
+    ) -> ModelT | None:
         """Wrap repository scalar operation.
 
         Args:
@@ -356,13 +270,12 @@ class SQLAlchemyAsyncRepositoryReadService(Generic[ModelT], ResultConverter):
                 Defaults to :class:`SQLAlchemyAsyncRepository.statement <SQLAlchemyAsyncRepository>`
             load: Set default relationships to be loaded
             execution_options: Set default execution options
-            to_schema: optionally convert to alternative schema object
             **kwargs: Identifier of the instance to be retrieved.
 
         Returns:
             Representation of instance with identifier `item_id`.
         """
-        result = await self.repository.get_one_or_none(
+        return await self.repository.get_one_or_none(
             *filters,
             auto_expunge=auto_expunge,
             statement=statement,
@@ -370,9 +283,6 @@ class SQLAlchemyAsyncRepositoryReadService(Generic[ModelT], ResultConverter):
             execution_options=execution_options,
             **kwargs,
         )
-        if result is not None and to_schema is not None:
-            return self.to_schema(data=result, schema_type=to_schema)
-        return result
 
     async def to_model(
         self,
@@ -403,7 +313,6 @@ class SQLAlchemyAsyncRepositoryReadService(Generic[ModelT], ResultConverter):
 
         return cast("ModelT", data)
 
-    @overload
     async def list_and_count(
         self,
         *filters: StatementFilter | ColumnElement[bool],
@@ -412,34 +321,8 @@ class SQLAlchemyAsyncRepositoryReadService(Generic[ModelT], ResultConverter):
         execution_options: dict[str, Any] | None = None,
         force_basic_query_mode: bool | None = None,
         auto_expunge: bool | None = None,
-        to_schema: None = None,
         **kwargs: Any,
-    ) -> tuple[Sequence[ModelT], int]: ...
-
-    @overload
-    async def list_and_count(
-        self,
-        *filters: StatementFilter | ColumnElement[bool],
-        statement: Select[tuple[ModelT]] | StatementLambdaElement | None = None,
-        load: LoadSpec | None = None,
-        execution_options: dict[str, Any] | None = None,
-        force_basic_query_mode: bool | None = None,
-        auto_expunge: bool | None = None,
-        to_schema: type[ModelDTOT],
-        **kwargs: Any,
-    ) -> OffsetPagination[ModelDTOT]: ...
-
-    async def list_and_count(
-        self,
-        *filters: StatementFilter | ColumnElement[bool],
-        statement: Select[tuple[ModelT]] | StatementLambdaElement | None = None,
-        load: LoadSpec | None = None,
-        execution_options: dict[str, Any] | None = None,
-        force_basic_query_mode: bool | None = None,
-        auto_expunge: bool | None = None,
-        to_schema: type[ModelDTOT] | None = None,
-        **kwargs: Any,
-    ) -> tuple[Sequence[ModelT], int] | OffsetPagination[ModelDTOT]:
+    ) -> tuple[Sequence[ModelT], int]:
         """List of records and total count returned by query.
 
         Args:
@@ -451,13 +334,12 @@ class SQLAlchemyAsyncRepositoryReadService(Generic[ModelT], ResultConverter):
             force_basic_query_mode: Force list and count to use two queries instead of an analytical window function.
             load: Set default relationships to be loaded
             execution_options: Set default execution options
-            to_schema: optionally convert to alternative schema object
             **kwargs: Instance attribute value filters.
 
         Returns:
             List of instances and count of total collection, ignoring pagination.
         """
-        result = await self.repository.list_and_count(
+        return await self.repository.list_and_count(
             *filters,
             statement=statement,
             auto_expunge=auto_expunge,
@@ -466,9 +348,6 @@ class SQLAlchemyAsyncRepositoryReadService(Generic[ModelT], ResultConverter):
             execution_options=execution_options,
             **kwargs,
         )
-        if to_schema is not None:
-            return self.to_schema(data=result[0], total=result[1], schema_type=to_schema)
-        return result
 
     @classmethod
     @asynccontextmanager
@@ -501,8 +380,6 @@ class SQLAlchemyAsyncRepositoryReadService(Generic[ModelT], ResultConverter):
                     execution_options=execution_options,
                 )
 
-    # this needs to stay at the end to make the vscode linter happy
-    @overload
     async def list(
         self,
         *filters: StatementFilter | ColumnElement[bool],
@@ -510,32 +387,8 @@ class SQLAlchemyAsyncRepositoryReadService(Generic[ModelT], ResultConverter):
         load: LoadSpec | None = None,
         execution_options: dict[str, Any] | None = None,
         auto_expunge: bool | None = None,
-        to_schema: None = None,
         **kwargs: Any,
-    ) -> Sequence[ModelT]: ...
-
-    @overload
-    async def list(
-        self,
-        *filters: StatementFilter | ColumnElement[bool],
-        statement: Select[tuple[ModelT]] | StatementLambdaElement | None = None,
-        load: LoadSpec | None = None,
-        execution_options: dict[str, Any] | None = None,
-        auto_expunge: bool | None = None,
-        to_schema: type[ModelDTOT],
-        **kwargs: Any,
-    ) -> OffsetPagination[ModelDTOT]: ...
-
-    async def list(
-        self,
-        *filters: StatementFilter | ColumnElement[bool],
-        statement: Select[tuple[ModelT]] | StatementLambdaElement | None = None,
-        load: LoadSpec | None = None,
-        execution_options: dict[str, Any] | None = None,
-        auto_expunge: bool | None = None,
-        to_schema: type[ModelDTOT] | None = None,
-        **kwargs: Any,
-    ) -> Sequence[ModelT] | OffsetPagination[ModelDTOT]:
+    ) -> Sequence[ModelT]:
         """Wrap repository scalars operation.
 
         Args:
@@ -546,13 +399,12 @@ class SQLAlchemyAsyncRepositoryReadService(Generic[ModelT], ResultConverter):
                 Defaults to :class:`SQLAlchemyAsyncRepository.statement <SQLAlchemyAsyncRepository>`
             load: Set default relationships to be loaded
             execution_options: Set default execution options
-            to_schema: optionally convert to alternative schema object
             **kwargs: Instance attribute value filters.
 
         Returns:
             The list of instances retrieved from the repository.
         """
-        result = await self.repository.list(
+        return await self.repository.list(
             *filters,
             statement=statement,
             auto_expunge=auto_expunge,
@@ -560,45 +412,21 @@ class SQLAlchemyAsyncRepositoryReadService(Generic[ModelT], ResultConverter):
             execution_options=execution_options,
             **kwargs,
         )
-        if to_schema is not None:
-            return self.to_schema(data=result, schema_type=to_schema)
-        return result
 
 
 class SQLAlchemyAsyncRepositoryService(SQLAlchemyAsyncRepositoryReadService[ModelT]):
     """Service object that operates on a repository object."""
 
-    @overload
     async def create(
         self,
         data: ModelDictT[ModelT],
         *,
+        load: LoadSpec | None = None,
+        execution_options: dict[str, Any] | None = None,
         auto_commit: bool | None = None,
         auto_expunge: bool | None = None,
         auto_refresh: bool | None = None,
-        to_schema: type[ModelDTOT],
-    ) -> ModelDTOT: ...
-
-    @overload
-    async def create(
-        self,
-        data: ModelDictT[ModelT],
-        *,
-        auto_commit: bool | None = None,
-        auto_expunge: bool | None = None,
-        auto_refresh: bool | None = None,
-        to_schema: None = None,
-    ) -> ModelT: ...
-
-    async def create(
-        self,
-        data: ModelDictT[ModelT],
-        *,
-        auto_commit: bool | None = None,
-        auto_expunge: bool | None = None,
-        auto_refresh: bool | None = None,
-        to_schema: type[ModelDTOT] | None = None,
-    ) -> ModelT | ModelDTOT:
+    ) -> ModelT:
         """Wrap repository instance creation.
 
         Args:
@@ -611,44 +439,17 @@ class SQLAlchemyAsyncRepositoryService(SQLAlchemyAsyncRepositoryReadService[Mode
                 :class:`SQLAlchemyAsyncRepository.auto_commit <SQLAlchemyAsyncRepository>`
             load: Set default relationships to be loaded
             execution_options: Set default execution options
-            to_schema: optionally convert to alternative schema object
+
         Returns:
             Representation of created instance.
         """
         data = await self.to_model(data, "create")
-        result = await self.repository.add(
+        return await self.repository.add(
             data=data,
             auto_commit=auto_commit,
             auto_expunge=auto_expunge,
             auto_refresh=auto_refresh,
         )
-        if to_schema is not None:
-            return self.to_schema(data=result, schema_type=to_schema)
-        return result
-
-    @overload
-    async def create_many(
-        self,
-        data: ModelDictListT[ModelT],
-        *,
-        load: LoadSpec | None = None,
-        execution_options: dict[str, Any] | None = None,
-        auto_commit: bool | None = None,
-        auto_expunge: bool | None = None,
-        to_schema: None = None,
-    ) -> Sequence[ModelT]: ...
-
-    @overload
-    async def create_many(
-        self,
-        data: ModelDictListT[ModelT],
-        *,
-        load: LoadSpec | None = None,
-        execution_options: dict[str, Any] | None = None,
-        auto_commit: bool | None = None,
-        auto_expunge: bool | None = None,
-        to_schema: type[ModelDTOT],
-    ) -> OffsetPagination[ModelDTOT]: ...
 
     async def create_many(
         self,
@@ -658,8 +459,7 @@ class SQLAlchemyAsyncRepositoryService(SQLAlchemyAsyncRepositoryReadService[Mode
         execution_options: dict[str, Any] | None = None,
         auto_commit: bool | None = None,
         auto_expunge: bool | None = None,
-        to_schema: type[ModelDTOT] | None = None,
-    ) -> Sequence[ModelT] | OffsetPagination[ModelDTOT]:
+    ) -> Sequence[ModelT]:
         """Wrap repository bulk instance creation.
 
         Args:
@@ -670,53 +470,16 @@ class SQLAlchemyAsyncRepositoryService(SQLAlchemyAsyncRepositoryReadService[Mode
                 :class:`SQLAlchemyAsyncRepository.auto_commit <SQLAlchemyAsyncRepository>`
             load: Set default relationships to be loaded
             execution_options: Set default execution options
-            to_schema: optionally convert to alternative schema object
+
         Returns:
             Representation of created instances.
         """
         data = [(await self.to_model(datum, "create")) for datum in data]
-        result = await self.repository.add_many(
+        return await self.repository.add_many(
             data=cast("list[ModelT]", data),  # pyright: ignore[reportUnnecessaryCast]
             auto_commit=auto_commit,
             auto_expunge=auto_expunge,
         )
-        if to_schema is not None:
-            return self.to_schema(data=result, schema_type=to_schema)
-        return result
-
-    @overload
-    async def update(
-        self,
-        data: ModelDictT[ModelT],
-        item_id: Any | None = None,
-        *,
-        id_attribute: str | InstrumentedAttribute[Any] | None = None,
-        load: LoadSpec | None = None,
-        execution_options: dict[str, Any] | None = None,
-        attribute_names: Iterable[str] | None = None,
-        with_for_update: bool | None = None,
-        auto_commit: bool | None = None,
-        auto_expunge: bool | None = None,
-        auto_refresh: bool | None = None,
-        to_schema: None = None,
-    ) -> ModelT: ...
-
-    @overload
-    async def update(
-        self,
-        data: ModelDictT[ModelT],
-        item_id: Any | None = None,
-        *,
-        id_attribute: str | InstrumentedAttribute[Any] | None = None,
-        load: LoadSpec | None = None,
-        execution_options: dict[str, Any] | None = None,
-        attribute_names: Iterable[str] | None = None,
-        with_for_update: bool | None = None,
-        auto_commit: bool | None = None,
-        auto_expunge: bool | None = None,
-        auto_refresh: bool | None = None,
-        to_schema: type[ModelDTOT],
-    ) -> ModelDTOT: ...
 
     async def update(
         self,
@@ -731,8 +494,7 @@ class SQLAlchemyAsyncRepositoryService(SQLAlchemyAsyncRepositoryReadService[Mode
         auto_commit: bool | None = None,
         auto_expunge: bool | None = None,
         auto_refresh: bool | None = None,
-        to_schema: type[ModelDTOT] | None = None,
-    ) -> ModelT | ModelDTOT:
+    ) -> ModelT:
         """Wrap repository update operation.
 
         Args:
@@ -753,7 +515,6 @@ class SQLAlchemyAsyncRepositoryService(SQLAlchemyAsyncRepositoryReadService[Mode
                 Defaults to `id`, but can reference any surrogate or candidate key for the table.
             load: Set default relationships to be loaded
             execution_options: Set default execution options
-            to_schema: optionally convert to alternative schema object
 
         Returns:
             Updated representation.
@@ -774,7 +535,7 @@ class SQLAlchemyAsyncRepositoryService(SQLAlchemyAsyncRepositoryReadService[Mode
             raise RepositoryError(msg)
         if item_id is not None:
             data = self.repository.set_id_attribute_value(item_id=item_id, item=data, id_attribute=id_attribute)  # pyright: ignore[reportUnknownMemberType]
-        result = await self.repository.update(
+        return await self.repository.update(
             data=data,
             attribute_names=attribute_names,
             with_for_update=with_for_update,
@@ -785,33 +546,6 @@ class SQLAlchemyAsyncRepositoryService(SQLAlchemyAsyncRepositoryReadService[Mode
             load=load,
             execution_options=execution_options,
         )
-        if to_schema is not None:
-            return self.to_schema(data=result, schema_type=to_schema)
-        return result
-
-    @overload
-    async def update_many(
-        self,
-        data: ModelDictListT[ModelT],
-        *,
-        load: LoadSpec | None = None,
-        execution_options: dict[str, Any] | None = None,
-        auto_commit: bool | None = None,
-        auto_expunge: bool | None = None,
-        to_schema: None = None,
-    ) -> Sequence[ModelT]: ...
-
-    @overload
-    async def update_many(
-        self,
-        data: ModelDictListT[ModelT],
-        *,
-        load: LoadSpec | None = None,
-        execution_options: dict[str, Any] | None = None,
-        auto_commit: bool | None = None,
-        auto_expunge: bool | None = None,
-        to_schema: type[ModelDTOT],
-    ) -> OffsetPagination[ModelDTOT]: ...
 
     async def update_many(
         self,
@@ -821,8 +555,7 @@ class SQLAlchemyAsyncRepositoryService(SQLAlchemyAsyncRepositoryReadService[Mode
         execution_options: dict[str, Any] | None = None,
         auto_commit: bool | None = None,
         auto_expunge: bool | None = None,
-        to_schema: type[ModelDTOT] | None = None,
-    ) -> Sequence[ModelT] | OffsetPagination[ModelDTOT]:
+    ) -> Sequence[ModelT]:
         """Wrap repository bulk instance update.
 
         Args:
@@ -833,56 +566,18 @@ class SQLAlchemyAsyncRepositoryService(SQLAlchemyAsyncRepositoryReadService[Mode
                 :class:`SQLAlchemyAsyncRepository.auto_commit <SQLAlchemyAsyncRepository>`
             load: Set default relationships to be loaded
             execution_options: Set default execution options
-            to_schema: optionally convert to alternative schema object
 
         Returns:
             Representation of updated instances.
         """
         data = [(await self.to_model(datum, "update")) for datum in data]
-        result = await self.repository.update_many(
+        return await self.repository.update_many(
             cast("list[ModelT]", data),  # pyright: ignore[reportUnnecessaryCast]
             auto_commit=auto_commit,
             auto_expunge=auto_expunge,
             load=load,
             execution_options=execution_options,
         )
-        if to_schema is not None:
-            return self.to_schema(data=result, schema_type=to_schema)
-        return result
-
-    @overload
-    async def upsert(
-        self,
-        data: ModelDictT[ModelT],
-        item_id: Any | None = None,
-        *,
-        load: LoadSpec | None = None,
-        execution_options: dict[str, Any] | None = None,
-        attribute_names: Iterable[str] | None = None,
-        with_for_update: bool | None = None,
-        auto_expunge: bool | None = None,
-        auto_commit: bool | None = None,
-        auto_refresh: bool | None = None,
-        match_fields: list[str] | str | None = None,
-        to_schema: None = None,
-    ) -> ModelT: ...
-
-    @overload
-    async def upsert(
-        self,
-        data: ModelDictT[ModelT],
-        item_id: Any | None = None,
-        *,
-        load: LoadSpec | None = None,
-        execution_options: dict[str, Any] | None = None,
-        attribute_names: Iterable[str] | None = None,
-        with_for_update: bool | None = None,
-        auto_expunge: bool | None = None,
-        auto_commit: bool | None = None,
-        auto_refresh: bool | None = None,
-        match_fields: list[str] | str | None = None,
-        to_schema: type[ModelDTOT],
-    ) -> ModelDTOT: ...
 
     async def upsert(
         self,
@@ -897,8 +592,7 @@ class SQLAlchemyAsyncRepositoryService(SQLAlchemyAsyncRepositoryReadService[Mode
         auto_commit: bool | None = None,
         auto_refresh: bool | None = None,
         match_fields: list[str] | str | None = None,
-        to_schema: type[ModelDTOT] | None = None,
-    ) -> ModelT | ModelDTOT:
+    ) -> ModelT:
         """Wrap repository upsert operation.
 
         Args:
@@ -920,7 +614,6 @@ class SQLAlchemyAsyncRepositoryService(SQLAlchemyAsyncRepositoryReadService[Mode
                 empty, all fields are matched.
             load: Set default relationships to be loaded
             execution_options: Set default execution options
-            to_schema: optionally convert to alternative schema object
 
         Returns:
             Updated or created representation.
@@ -929,7 +622,7 @@ class SQLAlchemyAsyncRepositoryService(SQLAlchemyAsyncRepositoryReadService[Mode
         item_id = item_id if item_id is not None else self.repository.get_id_attribute_value(item=data)  # pyright: ignore[reportUnknownMemberType]
         if item_id is not None:
             self.repository.set_id_attribute_value(item_id, data)  # pyright: ignore[reportUnknownMemberType]
-        result = await self.repository.upsert(
+        return await self.repository.upsert(
             data=data,
             attribute_names=attribute_names,
             with_for_update=with_for_update,
@@ -940,36 +633,6 @@ class SQLAlchemyAsyncRepositoryService(SQLAlchemyAsyncRepositoryReadService[Mode
             load=load,
             execution_options=execution_options,
         )
-        if to_schema is not None:
-            return self.to_schema(data=result, schema_type=to_schema)
-        return result
-
-    @overload
-    async def upsert_many(
-        self,
-        data: ModelDictListT[ModelT],
-        *,
-        load: LoadSpec | None = None,
-        execution_options: dict[str, Any] | None = None,
-        auto_expunge: bool | None = None,
-        auto_commit: bool | None = None,
-        no_merge: bool = False,
-        match_fields: list[str] | str | None = None,
-        to_schema: None = None,
-    ) -> Sequence[ModelT]: ...
-    @overload
-    async def upsert_many(
-        self,
-        data: ModelDictListT[ModelT],
-        *,
-        load: LoadSpec | None = None,
-        execution_options: dict[str, Any] | None = None,
-        auto_expunge: bool | None = None,
-        auto_commit: bool | None = None,
-        no_merge: bool = False,
-        match_fields: list[str] | str | None = None,
-        to_schema: type[ModelDTOT],
-    ) -> OffsetPagination[ModelDTOT]: ...
 
     async def upsert_many(
         self,
@@ -981,8 +644,7 @@ class SQLAlchemyAsyncRepositoryService(SQLAlchemyAsyncRepositoryReadService[Mode
         auto_commit: bool | None = None,
         no_merge: bool = False,
         match_fields: list[str] | str | None = None,
-        to_schema: type[ModelDTOT] | None = None,
-    ) -> Sequence[ModelT] | OffsetPagination[ModelDTOT]:
+    ) -> Sequence[ModelT]:
         """Wrap repository upsert operation.
 
         Args:
@@ -999,13 +661,12 @@ class SQLAlchemyAsyncRepositoryService(SQLAlchemyAsyncRepositoryReadService[Mode
                 empty, all fields are matched.
             load: Set default relationships to be loaded
             execution_options: Set default execution options
-            to_schema: optionally convert to alternative schema object
 
         Returns:
             Updated or created representation.
         """
         data = [(await self.to_model(datum, "upsert")) for datum in data]
-        result = await self.repository.upsert_many(
+        return await self.repository.upsert_many(
             data=cast("list[ModelT]", data),  # pyright: ignore[reportUnnecessaryCast]
             auto_expunge=auto_expunge,
             auto_commit=auto_commit,
@@ -1014,43 +675,6 @@ class SQLAlchemyAsyncRepositoryService(SQLAlchemyAsyncRepositoryReadService[Mode
             load=load,
             execution_options=execution_options,
         )
-        if to_schema is not None:
-            return self.to_schema(data=result, schema_type=to_schema)
-        return result
-
-    @overload
-    async def get_or_upsert(
-        self,
-        *filters: StatementFilter | ColumnElement[bool],
-        match_fields: list[str] | str | None = None,
-        load: LoadSpec | None = None,
-        execution_options: dict[str, Any] | None = None,
-        upsert: bool = True,
-        attribute_names: Iterable[str] | None = None,
-        with_for_update: bool | None = None,
-        auto_commit: bool | None = None,
-        auto_expunge: bool | None = None,
-        auto_refresh: bool | None = None,
-        to_schema: None = None,
-        **kwargs: Any,
-    ) -> tuple[ModelT, bool]: ...
-
-    @overload
-    async def get_or_upsert(
-        self,
-        *filters: StatementFilter | ColumnElement[bool],
-        match_fields: list[str] | str | None = None,
-        load: LoadSpec | None = None,
-        execution_options: dict[str, Any] | None = None,
-        upsert: bool = True,
-        attribute_names: Iterable[str] | None = None,
-        with_for_update: bool | None = None,
-        auto_commit: bool | None = None,
-        auto_expunge: bool | None = None,
-        auto_refresh: bool | None = None,
-        to_schema: type[ModelDTOT],
-        **kwargs: Any,
-    ) -> tuple[ModelDTOT, bool]: ...
 
     async def get_or_upsert(
         self,
@@ -1064,9 +688,8 @@ class SQLAlchemyAsyncRepositoryService(SQLAlchemyAsyncRepositoryReadService[Mode
         auto_commit: bool | None = None,
         auto_expunge: bool | None = None,
         auto_refresh: bool | None = None,
-        to_schema: type[ModelDTOT] | None = None,
         **kwargs: Any,
-    ) -> tuple[ModelT | ModelDTOT, bool]:
+    ) -> tuple[ModelT, bool]:
         """Wrap repository instance creation.
 
         Args:
@@ -1089,7 +712,6 @@ class SQLAlchemyAsyncRepositoryService(SQLAlchemyAsyncRepositoryReadService[Mode
                 :class:`SQLAlchemyAsyncRepository.auto_commit <SQLAlchemyAsyncRepository>`
             load: Set default relationships to be loaded
             execution_options: Set default execution options
-            to_schema: optionally convert to alternative schema object
             **kwargs: Identifier of the instance to be retrieved.
 
         Returns:
@@ -1097,7 +719,7 @@ class SQLAlchemyAsyncRepositoryService(SQLAlchemyAsyncRepositoryReadService[Mode
         """
         match_fields = match_fields or self.match_fields
         validated_model = await self.to_model(kwargs, "create")
-        result = await self.repository.get_or_upsert(
+        return await self.repository.get_or_upsert(
             *filters,
             match_fields=match_fields,
             upsert=upsert,
@@ -1110,41 +732,6 @@ class SQLAlchemyAsyncRepositoryService(SQLAlchemyAsyncRepositoryReadService[Mode
             execution_options=execution_options,
             **validated_model.to_dict(),
         )
-        if to_schema is not None:
-            return (self.to_schema(data=result[0], schema_type=to_schema), result[1])
-        return result
-
-    @overload
-    async def get_and_update(
-        self,
-        *filters: StatementFilter | ColumnElement[bool],
-        match_fields: list[str] | str | None = None,
-        load: LoadSpec | None = None,
-        execution_options: dict[str, Any] | None = None,
-        attribute_names: Iterable[str] | None = None,
-        with_for_update: bool | None = None,
-        auto_commit: bool | None = None,
-        auto_expunge: bool | None = None,
-        auto_refresh: bool | None = None,
-        to_schema: None = None,
-        **kwargs: Any,
-    ) -> tuple[ModelT, bool]: ...
-
-    @overload
-    async def get_and_update(
-        self,
-        *filters: StatementFilter | ColumnElement[bool],
-        match_fields: list[str] | str | None = None,
-        load: LoadSpec | None = None,
-        execution_options: dict[str, Any] | None = None,
-        attribute_names: Iterable[str] | None = None,
-        with_for_update: bool | None = None,
-        auto_commit: bool | None = None,
-        auto_expunge: bool | None = None,
-        auto_refresh: bool | None = None,
-        to_schema: type[ModelDTOT],
-        **kwargs: Any,
-    ) -> tuple[ModelDTOT, bool]: ...
 
     async def get_and_update(
         self,
@@ -1157,9 +744,8 @@ class SQLAlchemyAsyncRepositoryService(SQLAlchemyAsyncRepositoryReadService[Mode
         auto_commit: bool | None = None,
         auto_expunge: bool | None = None,
         auto_refresh: bool | None = None,
-        to_schema: type[ModelDTOT] | None = None,
         **kwargs: Any,
-    ) -> tuple[ModelT | ModelDTOT, bool]:
+    ) -> tuple[ModelT, bool]:
         """Wrap repository instance creation.
 
         Args:
@@ -1179,7 +765,6 @@ class SQLAlchemyAsyncRepositoryService(SQLAlchemyAsyncRepositoryReadService[Mode
                 :class:`SQLAlchemyAsyncRepository.auto_commit <SQLAlchemyAsyncRepository>`
             load: Set default relationships to be loaded
             execution_options: Set default execution options
-            to_schema: optionally convert to alternative schema object
             **kwargs: Identifier of the instance to be retrieved.
 
         Returns:
@@ -1187,7 +772,7 @@ class SQLAlchemyAsyncRepositoryService(SQLAlchemyAsyncRepositoryReadService[Mode
         """
         match_fields = match_fields or self.match_fields
         validated_model = await self.to_model(kwargs, "update")
-        result = await self.repository.get_and_update(
+        return await self.repository.get_and_update(
             *filters,
             match_fields=match_fields,
             attribute_names=attribute_names,
@@ -1199,35 +784,6 @@ class SQLAlchemyAsyncRepositoryService(SQLAlchemyAsyncRepositoryReadService[Mode
             execution_options=execution_options,
             **validated_model.to_dict(),
         )
-        if to_schema is not None:
-            return (self.to_schema(data=result[0], schema_type=to_schema), result[1])
-        return result
-
-    @overload
-    async def delete(
-        self,
-        item_id: Any,
-        *,
-        id_attribute: str | InstrumentedAttribute[Any] | None = None,
-        load: LoadSpec | None = None,
-        execution_options: dict[str, Any] | None = None,
-        auto_commit: bool | None = None,
-        auto_expunge: bool | None = None,
-        to_schema: None = None,
-    ) -> ModelT: ...
-
-    @overload
-    async def delete(
-        self,
-        item_id: Any,
-        *,
-        id_attribute: str | InstrumentedAttribute[Any] | None = None,
-        load: LoadSpec | None = None,
-        execution_options: dict[str, Any] | None = None,
-        auto_commit: bool | None = None,
-        auto_expunge: bool | None = None,
-        to_schema: type[ModelDTOT],
-    ) -> ModelDTOT: ...
 
     async def delete(
         self,
@@ -1238,8 +794,7 @@ class SQLAlchemyAsyncRepositoryService(SQLAlchemyAsyncRepositoryReadService[Mode
         execution_options: dict[str, Any] | None = None,
         auto_commit: bool | None = None,
         auto_expunge: bool | None = None,
-        to_schema: type[ModelDTOT] | None = None,
-    ) -> ModelT | ModelDTOT:
+    ) -> ModelT:
         """Wrap repository delete operation.
 
         Args:
@@ -1252,12 +807,11 @@ class SQLAlchemyAsyncRepositoryService(SQLAlchemyAsyncRepositoryReadService[Mode
                 Defaults to `id`, but can reference any surrogate or candidate key for the table.
             load: Set default relationships to be loaded
             execution_options: Set default execution options
-            to_schema: optionally convert to alternative schema object
 
         Returns:
             Representation of the deleted instance.
         """
-        result = await self.repository.delete(
+        return await self.repository.delete(
             item_id=item_id,
             auto_commit=auto_commit,
             auto_expunge=auto_expunge,
@@ -1265,37 +819,6 @@ class SQLAlchemyAsyncRepositoryService(SQLAlchemyAsyncRepositoryReadService[Mode
             load=load,
             execution_options=execution_options,
         )
-        if to_schema is not None:
-            return self.to_schema(data=result, schema_type=to_schema)
-        return result
-
-    @overload
-    async def delete_many(
-        self,
-        item_ids: list[Any],
-        *,
-        id_attribute: str | InstrumentedAttribute[Any] | None = None,
-        load: LoadSpec | None = None,
-        execution_options: dict[str, Any] | None = None,
-        chunk_size: int | None = None,
-        auto_commit: bool | None = None,
-        auto_expunge: bool | None = None,
-        to_schema: None = None,
-    ) -> Sequence[ModelT]: ...
-
-    @overload
-    async def delete_many(
-        self,
-        item_ids: list[Any],
-        *,
-        id_attribute: str | InstrumentedAttribute[Any] | None = None,
-        load: LoadSpec | None = None,
-        execution_options: dict[str, Any] | None = None,
-        chunk_size: int | None = None,
-        auto_commit: bool | None = None,
-        auto_expunge: bool | None = None,
-        to_schema: type[ModelDTOT],
-    ) -> OffsetPagination[ModelDTOT]: ...
 
     async def delete_many(
         self,
@@ -1307,8 +830,7 @@ class SQLAlchemyAsyncRepositoryService(SQLAlchemyAsyncRepositoryReadService[Mode
         chunk_size: int | None = None,
         auto_commit: bool | None = None,
         auto_expunge: bool | None = None,
-        to_schema: type[ModelDTOT] | None = None,
-    ) -> Sequence[ModelT] | OffsetPagination[ModelDTOT]:
+    ) -> Sequence[ModelT]:
         """Wrap repository bulk instance deletion.
 
         Args:
@@ -1323,12 +845,11 @@ class SQLAlchemyAsyncRepositoryService(SQLAlchemyAsyncRepositoryReadService[Mode
                 Defaults to `950` if left unset.
             load: Set default relationships to be loaded
             execution_options: Set default execution options
-            to_schema: optionally convert to alternative schema object
 
         Returns:
             Representation of removed instances.
         """
-        result = await self.repository.delete_many(
+        return await self.repository.delete_many(
             item_ids=item_ids,
             auto_commit=auto_commit,
             auto_expunge=auto_expunge,
@@ -1337,33 +858,6 @@ class SQLAlchemyAsyncRepositoryService(SQLAlchemyAsyncRepositoryReadService[Mode
             load=load,
             execution_options=execution_options,
         )
-        if to_schema is not None:
-            return self.to_schema(data=result, schema_type=to_schema)
-        return result
-
-    @overload
-    async def delete_where(
-        self,
-        *filters: StatementFilter | ColumnElement[bool],
-        load: LoadSpec | None = None,
-        execution_options: dict[str, Any] | None = None,
-        auto_commit: bool | None = None,
-        auto_expunge: bool | None = None,
-        to_schema: None = None,
-        **kwargs: Any,
-    ) -> Sequence[ModelT]: ...
-
-    @overload
-    async def delete_where(
-        self,
-        *filters: StatementFilter | ColumnElement[bool],
-        load: LoadSpec | None = None,
-        execution_options: dict[str, Any] | None = None,
-        auto_commit: bool | None = None,
-        auto_expunge: bool | None = None,
-        to_schema: type[ModelDTOT],
-        **kwargs: Any,
-    ) -> OffsetPagination[ModelDTOT]: ...
 
     async def delete_where(
         self,
@@ -1372,9 +866,8 @@ class SQLAlchemyAsyncRepositoryService(SQLAlchemyAsyncRepositoryReadService[Mode
         execution_options: dict[str, Any] | None = None,
         auto_commit: bool | None = None,
         auto_expunge: bool | None = None,
-        to_schema: type[ModelDTOT] | None = None,
         **kwargs: Any,
-    ) -> Sequence[ModelT] | OffsetPagination[ModelDTOT]:
+    ) -> Sequence[ModelT]:
         """Wrap repository scalars operation.
 
         Args:
@@ -1385,13 +878,12 @@ class SQLAlchemyAsyncRepositoryService(SQLAlchemyAsyncRepositoryReadService[Mode
                 :class:`SQLAlchemyAsyncRepository.auto_commit <SQLAlchemyAsyncRepository>`
             load: Set default relationships to be loaded
             execution_options: Set default execution options
-            to_schema: optionally convert to alternative schema object
             **kwargs: Instance attribute value filters.
 
         Returns:
             The list of instances deleted from the repository.
         """
-        result = await self.repository.delete_where(
+        return await self.repository.delete_where(
             *filters,
             auto_commit=auto_commit,
             auto_expunge=auto_expunge,
@@ -1399,6 +891,3 @@ class SQLAlchemyAsyncRepositoryService(SQLAlchemyAsyncRepositoryReadService[Mode
             execution_options=execution_options,
             **kwargs,
         )
-        if to_schema is not None:
-            return self.to_schema(data=result, schema_type=to_schema)
-        return result

--- a/advanced_alchemy/service/_sync.py
+++ b/advanced_alchemy/service/_sync.py
@@ -9,7 +9,7 @@ should be a SQLAlchemy model.
 from __future__ import annotations
 
 from contextlib import contextmanager
-from typing import TYPE_CHECKING, Any, Generic, Iterable, cast, overload
+from typing import TYPE_CHECKING, Any, Generic, Iterable, cast
 
 from sqlalchemy import Select
 from typing_extensions import Self
@@ -30,7 +30,6 @@ from advanced_alchemy.service.typing import (
     UNSET,
     ModelDictListT,
     ModelDictT,
-    ModelDTOT,
     is_dict,
     is_msgspec_model,
     is_pydantic_model,
@@ -46,7 +45,6 @@ if TYPE_CHECKING:
 
     from advanced_alchemy.config.sync import SQLAlchemySyncConfig
     from advanced_alchemy.filters import StatementFilter
-    from advanced_alchemy.service.pagination import OffsetPagination
 
 
 class SQLAlchemySyncQueryService(ResultConverter):
@@ -184,7 +182,6 @@ class SQLAlchemySyncRepositoryReadService(Generic[ModelT], ResultConverter):
         """
         return self.repository.exists(*filters, load=load, execution_options=execution_options, **kwargs)
 
-    @overload
     def get(
         self,
         item_id: Any,
@@ -194,33 +191,7 @@ class SQLAlchemySyncRepositoryReadService(Generic[ModelT], ResultConverter):
         load: LoadSpec | None = None,
         execution_options: dict[str, Any] | None = None,
         auto_expunge: bool | None = None,
-        to_schema: None = None,
-    ) -> ModelT: ...
-
-    @overload
-    def get(
-        self,
-        item_id: Any,
-        *,
-        statement: Select[tuple[ModelT]] | StatementLambdaElement | None = None,
-        id_attribute: str | InstrumentedAttribute[Any] | None = None,
-        load: LoadSpec | None = None,
-        execution_options: dict[str, Any] | None = None,
-        auto_expunge: bool | None = None,
-        to_schema: type[ModelDTOT],
-    ) -> ModelDTOT: ...
-
-    def get(
-        self,
-        item_id: Any,
-        *,
-        statement: Select[tuple[ModelT]] | StatementLambdaElement | None = None,
-        id_attribute: str | InstrumentedAttribute[Any] | None = None,
-        load: LoadSpec | None = None,
-        execution_options: dict[str, Any] | None = None,
-        auto_expunge: bool | None = None,
-        to_schema: type[ModelDTOT] | None = None,
-    ) -> ModelT | ModelDTOT:
+    ) -> ModelT:
         """Wrap repository scalar operation.
 
         Args:
@@ -233,13 +204,13 @@ class SQLAlchemySyncRepositoryReadService(Generic[ModelT], ResultConverter):
                 Defaults to `id`, but can reference any surrogate or candidate key for the table.
             load: Set relationships to be loaded
             execution_options: Set default execution options
-            to_schema: optionally convert to alternative schema object
+
 
 
         Returns:
             Representation of instance with identifier `item_id`.
         """
-        result = self.repository.get(
+        return self.repository.get(
             item_id=item_id,
             auto_expunge=auto_expunge,
             statement=statement,
@@ -247,33 +218,6 @@ class SQLAlchemySyncRepositoryReadService(Generic[ModelT], ResultConverter):
             load=load,
             execution_options=execution_options,
         )
-        if to_schema is not None:
-            return self.to_schema(data=result, schema_type=to_schema)
-        return result
-
-    @overload
-    def get_one(
-        self,
-        *filters: StatementFilter | ColumnElement[bool],
-        statement: Select[tuple[ModelT]] | StatementLambdaElement | None = None,
-        load: LoadSpec | None = None,
-        execution_options: dict[str, Any] | None = None,
-        to_schema: None = None,
-        auto_expunge: bool | None = None,
-        **kwargs: Any,
-    ) -> ModelT: ...
-
-    @overload
-    def get_one(
-        self,
-        *filters: StatementFilter | ColumnElement[bool],
-        statement: Select[tuple[ModelT]] | StatementLambdaElement | None = None,
-        load: LoadSpec | None = None,
-        execution_options: dict[str, Any] | None = None,
-        auto_expunge: bool | None = None,
-        to_schema: type[ModelDTOT],
-        **kwargs: Any,
-    ) -> ModelDTOT: ...
 
     def get_one(
         self,
@@ -282,9 +226,8 @@ class SQLAlchemySyncRepositoryReadService(Generic[ModelT], ResultConverter):
         load: LoadSpec | None = None,
         auto_expunge: bool | None = None,
         execution_options: dict[str, Any] | None = None,
-        to_schema: type[ModelDTOT] | None = None,
         **kwargs: Any,
-    ) -> ModelT | ModelDTOT:
+    ) -> ModelT:
         """Wrap repository scalar operation.
 
         Args:
@@ -295,13 +238,12 @@ class SQLAlchemySyncRepositoryReadService(Generic[ModelT], ResultConverter):
                 Defaults to :class:`SQLAlchemyAsyncRepository.statement <SQLAlchemyAsyncRepository>`
             load: Set default relationships to be loaded
             execution_options: Set default execution options
-            to_schema: optionally convert to alternative schema object
             **kwargs: Identifier of the instance to be retrieved.
 
         Returns:
             Representation of instance with identifier `item_id`.
         """
-        result = self.repository.get_one(
+        return self.repository.get_one(
             *filters,
             auto_expunge=auto_expunge,
             statement=statement,
@@ -309,33 +251,6 @@ class SQLAlchemySyncRepositoryReadService(Generic[ModelT], ResultConverter):
             execution_options=execution_options,
             **kwargs,
         )
-        if to_schema is not None:
-            return self.to_schema(data=result, schema_type=to_schema)
-        return result
-
-    @overload
-    def get_one_or_none(
-        self,
-        *filters: StatementFilter | ColumnElement[bool],
-        statement: Select[tuple[ModelT]] | StatementLambdaElement | None = None,
-        load: LoadSpec | None = None,
-        execution_options: dict[str, Any] | None = None,
-        auto_expunge: bool | None = None,
-        to_schema: None = None,
-        **kwargs: Any,
-    ) -> ModelT | None: ...
-
-    @overload
-    def get_one_or_none(
-        self,
-        *filters: StatementFilter | ColumnElement[bool],
-        statement: Select[tuple[ModelT]] | StatementLambdaElement | None = None,
-        load: LoadSpec | None = None,
-        execution_options: dict[str, Any] | None = None,
-        auto_expunge: bool | None = None,
-        to_schema: type[ModelDTOT],
-        **kwargs: Any,
-    ) -> ModelDTOT | None: ...
 
     def get_one_or_none(
         self,
@@ -344,9 +259,8 @@ class SQLAlchemySyncRepositoryReadService(Generic[ModelT], ResultConverter):
         load: LoadSpec | None = None,
         execution_options: dict[str, Any] | None = None,
         auto_expunge: bool | None = None,
-        to_schema: type[ModelDTOT] | None = None,
         **kwargs: Any,
-    ) -> ModelT | ModelDTOT | None:
+    ) -> ModelT | None:
         """Wrap repository scalar operation.
 
         Args:
@@ -357,13 +271,12 @@ class SQLAlchemySyncRepositoryReadService(Generic[ModelT], ResultConverter):
                 Defaults to :class:`SQLAlchemyAsyncRepository.statement <SQLAlchemyAsyncRepository>`
             load: Set default relationships to be loaded
             execution_options: Set default execution options
-            to_schema: optionally convert to alternative schema object
             **kwargs: Identifier of the instance to be retrieved.
 
         Returns:
             Representation of instance with identifier `item_id`.
         """
-        result = self.repository.get_one_or_none(
+        return self.repository.get_one_or_none(
             *filters,
             auto_expunge=auto_expunge,
             statement=statement,
@@ -371,9 +284,6 @@ class SQLAlchemySyncRepositoryReadService(Generic[ModelT], ResultConverter):
             execution_options=execution_options,
             **kwargs,
         )
-        if result is not None and to_schema is not None:
-            return self.to_schema(data=result, schema_type=to_schema)
-        return result
 
     def to_model(
         self,
@@ -404,7 +314,6 @@ class SQLAlchemySyncRepositoryReadService(Generic[ModelT], ResultConverter):
 
         return cast("ModelT", data)
 
-    @overload
     def list_and_count(
         self,
         *filters: StatementFilter | ColumnElement[bool],
@@ -413,34 +322,8 @@ class SQLAlchemySyncRepositoryReadService(Generic[ModelT], ResultConverter):
         execution_options: dict[str, Any] | None = None,
         force_basic_query_mode: bool | None = None,
         auto_expunge: bool | None = None,
-        to_schema: None = None,
         **kwargs: Any,
-    ) -> tuple[Sequence[ModelT], int]: ...
-
-    @overload
-    def list_and_count(
-        self,
-        *filters: StatementFilter | ColumnElement[bool],
-        statement: Select[tuple[ModelT]] | StatementLambdaElement | None = None,
-        load: LoadSpec | None = None,
-        execution_options: dict[str, Any] | None = None,
-        force_basic_query_mode: bool | None = None,
-        auto_expunge: bool | None = None,
-        to_schema: type[ModelDTOT],
-        **kwargs: Any,
-    ) -> OffsetPagination[ModelDTOT]: ...
-
-    def list_and_count(
-        self,
-        *filters: StatementFilter | ColumnElement[bool],
-        statement: Select[tuple[ModelT]] | StatementLambdaElement | None = None,
-        load: LoadSpec | None = None,
-        execution_options: dict[str, Any] | None = None,
-        force_basic_query_mode: bool | None = None,
-        auto_expunge: bool | None = None,
-        to_schema: type[ModelDTOT] | None = None,
-        **kwargs: Any,
-    ) -> tuple[Sequence[ModelT], int] | OffsetPagination[ModelDTOT]:
+    ) -> tuple[Sequence[ModelT], int]:
         """List of records and total count returned by query.
 
         Args:
@@ -452,13 +335,12 @@ class SQLAlchemySyncRepositoryReadService(Generic[ModelT], ResultConverter):
             force_basic_query_mode: Force list and count to use two queries instead of an analytical window function.
             load: Set default relationships to be loaded
             execution_options: Set default execution options
-            to_schema: optionally convert to alternative schema object
             **kwargs: Instance attribute value filters.
 
         Returns:
             List of instances and count of total collection, ignoring pagination.
         """
-        result = self.repository.list_and_count(
+        return self.repository.list_and_count(
             *filters,
             statement=statement,
             auto_expunge=auto_expunge,
@@ -467,9 +349,6 @@ class SQLAlchemySyncRepositoryReadService(Generic[ModelT], ResultConverter):
             execution_options=execution_options,
             **kwargs,
         )
-        if to_schema is not None:
-            return self.to_schema(data=result[0], total=result[1], schema_type=to_schema)
-        return result
 
     @classmethod
     @contextmanager
@@ -502,8 +381,6 @@ class SQLAlchemySyncRepositoryReadService(Generic[ModelT], ResultConverter):
                     execution_options=execution_options,
                 )
 
-    # this needs to stay at the end to make the vscode linter happy
-    @overload
     def list(
         self,
         *filters: StatementFilter | ColumnElement[bool],
@@ -511,32 +388,8 @@ class SQLAlchemySyncRepositoryReadService(Generic[ModelT], ResultConverter):
         load: LoadSpec | None = None,
         execution_options: dict[str, Any] | None = None,
         auto_expunge: bool | None = None,
-        to_schema: None = None,
         **kwargs: Any,
-    ) -> Sequence[ModelT]: ...
-
-    @overload
-    def list(
-        self,
-        *filters: StatementFilter | ColumnElement[bool],
-        statement: Select[tuple[ModelT]] | StatementLambdaElement | None = None,
-        load: LoadSpec | None = None,
-        execution_options: dict[str, Any] | None = None,
-        auto_expunge: bool | None = None,
-        to_schema: type[ModelDTOT],
-        **kwargs: Any,
-    ) -> OffsetPagination[ModelDTOT]: ...
-
-    def list(
-        self,
-        *filters: StatementFilter | ColumnElement[bool],
-        statement: Select[tuple[ModelT]] | StatementLambdaElement | None = None,
-        load: LoadSpec | None = None,
-        execution_options: dict[str, Any] | None = None,
-        auto_expunge: bool | None = None,
-        to_schema: type[ModelDTOT] | None = None,
-        **kwargs: Any,
-    ) -> Sequence[ModelT] | OffsetPagination[ModelDTOT]:
+    ) -> Sequence[ModelT]:
         """Wrap repository scalars operation.
 
         Args:
@@ -547,13 +400,12 @@ class SQLAlchemySyncRepositoryReadService(Generic[ModelT], ResultConverter):
                 Defaults to :class:`SQLAlchemyAsyncRepository.statement <SQLAlchemyAsyncRepository>`
             load: Set default relationships to be loaded
             execution_options: Set default execution options
-            to_schema: optionally convert to alternative schema object
             **kwargs: Instance attribute value filters.
 
         Returns:
             The list of instances retrieved from the repository.
         """
-        result = self.repository.list(
+        return self.repository.list(
             *filters,
             statement=statement,
             auto_expunge=auto_expunge,
@@ -561,45 +413,21 @@ class SQLAlchemySyncRepositoryReadService(Generic[ModelT], ResultConverter):
             execution_options=execution_options,
             **kwargs,
         )
-        if to_schema is not None:
-            return self.to_schema(data=result, schema_type=to_schema)
-        return result
 
 
 class SQLAlchemySyncRepositoryService(SQLAlchemySyncRepositoryReadService[ModelT]):
     """Service object that operates on a repository object."""
 
-    @overload
     def create(
         self,
         data: ModelDictT[ModelT],
         *,
+        load: LoadSpec | None = None,
+        execution_options: dict[str, Any] | None = None,
         auto_commit: bool | None = None,
         auto_expunge: bool | None = None,
         auto_refresh: bool | None = None,
-        to_schema: type[ModelDTOT],
-    ) -> ModelDTOT: ...
-
-    @overload
-    def create(
-        self,
-        data: ModelDictT[ModelT],
-        *,
-        auto_commit: bool | None = None,
-        auto_expunge: bool | None = None,
-        auto_refresh: bool | None = None,
-        to_schema: None = None,
-    ) -> ModelT: ...
-
-    def create(
-        self,
-        data: ModelDictT[ModelT],
-        *,
-        auto_commit: bool | None = None,
-        auto_expunge: bool | None = None,
-        auto_refresh: bool | None = None,
-        to_schema: type[ModelDTOT] | None = None,
-    ) -> ModelT | ModelDTOT:
+    ) -> ModelT:
         """Wrap repository instance creation.
 
         Args:
@@ -612,44 +440,17 @@ class SQLAlchemySyncRepositoryService(SQLAlchemySyncRepositoryReadService[ModelT
                 :class:`SQLAlchemyAsyncRepository.auto_commit <SQLAlchemyAsyncRepository>`
             load: Set default relationships to be loaded
             execution_options: Set default execution options
-            to_schema: optionally convert to alternative schema object
+
         Returns:
             Representation of created instance.
         """
         data = self.to_model(data, "create")
-        result = self.repository.add(
+        return self.repository.add(
             data=data,
             auto_commit=auto_commit,
             auto_expunge=auto_expunge,
             auto_refresh=auto_refresh,
         )
-        if to_schema is not None:
-            return self.to_schema(data=result, schema_type=to_schema)
-        return result
-
-    @overload
-    def create_many(
-        self,
-        data: ModelDictListT[ModelT],
-        *,
-        load: LoadSpec | None = None,
-        execution_options: dict[str, Any] | None = None,
-        auto_commit: bool | None = None,
-        auto_expunge: bool | None = None,
-        to_schema: None = None,
-    ) -> Sequence[ModelT]: ...
-
-    @overload
-    def create_many(
-        self,
-        data: ModelDictListT[ModelT],
-        *,
-        load: LoadSpec | None = None,
-        execution_options: dict[str, Any] | None = None,
-        auto_commit: bool | None = None,
-        auto_expunge: bool | None = None,
-        to_schema: type[ModelDTOT],
-    ) -> OffsetPagination[ModelDTOT]: ...
 
     def create_many(
         self,
@@ -659,8 +460,7 @@ class SQLAlchemySyncRepositoryService(SQLAlchemySyncRepositoryReadService[ModelT
         execution_options: dict[str, Any] | None = None,
         auto_commit: bool | None = None,
         auto_expunge: bool | None = None,
-        to_schema: type[ModelDTOT] | None = None,
-    ) -> Sequence[ModelT] | OffsetPagination[ModelDTOT]:
+    ) -> Sequence[ModelT]:
         """Wrap repository bulk instance creation.
 
         Args:
@@ -671,53 +471,16 @@ class SQLAlchemySyncRepositoryService(SQLAlchemySyncRepositoryReadService[ModelT
                 :class:`SQLAlchemyAsyncRepository.auto_commit <SQLAlchemyAsyncRepository>`
             load: Set default relationships to be loaded
             execution_options: Set default execution options
-            to_schema: optionally convert to alternative schema object
+
         Returns:
             Representation of created instances.
         """
         data = [(self.to_model(datum, "create")) for datum in data]
-        result = self.repository.add_many(
+        return self.repository.add_many(
             data=cast("list[ModelT]", data),  # pyright: ignore[reportUnnecessaryCast]
             auto_commit=auto_commit,
             auto_expunge=auto_expunge,
         )
-        if to_schema is not None:
-            return self.to_schema(data=result, schema_type=to_schema)
-        return result
-
-    @overload
-    def update(
-        self,
-        data: ModelDictT[ModelT],
-        item_id: Any | None = None,
-        *,
-        id_attribute: str | InstrumentedAttribute[Any] | None = None,
-        load: LoadSpec | None = None,
-        execution_options: dict[str, Any] | None = None,
-        attribute_names: Iterable[str] | None = None,
-        with_for_update: bool | None = None,
-        auto_commit: bool | None = None,
-        auto_expunge: bool | None = None,
-        auto_refresh: bool | None = None,
-        to_schema: None = None,
-    ) -> ModelT: ...
-
-    @overload
-    def update(
-        self,
-        data: ModelDictT[ModelT],
-        item_id: Any | None = None,
-        *,
-        id_attribute: str | InstrumentedAttribute[Any] | None = None,
-        load: LoadSpec | None = None,
-        execution_options: dict[str, Any] | None = None,
-        attribute_names: Iterable[str] | None = None,
-        with_for_update: bool | None = None,
-        auto_commit: bool | None = None,
-        auto_expunge: bool | None = None,
-        auto_refresh: bool | None = None,
-        to_schema: type[ModelDTOT],
-    ) -> ModelDTOT: ...
 
     def update(
         self,
@@ -732,8 +495,7 @@ class SQLAlchemySyncRepositoryService(SQLAlchemySyncRepositoryReadService[ModelT
         auto_commit: bool | None = None,
         auto_expunge: bool | None = None,
         auto_refresh: bool | None = None,
-        to_schema: type[ModelDTOT] | None = None,
-    ) -> ModelT | ModelDTOT:
+    ) -> ModelT:
         """Wrap repository update operation.
 
         Args:
@@ -754,7 +516,6 @@ class SQLAlchemySyncRepositoryService(SQLAlchemySyncRepositoryReadService[ModelT
                 Defaults to `id`, but can reference any surrogate or candidate key for the table.
             load: Set default relationships to be loaded
             execution_options: Set default execution options
-            to_schema: optionally convert to alternative schema object
 
         Returns:
             Updated representation.
@@ -775,7 +536,7 @@ class SQLAlchemySyncRepositoryService(SQLAlchemySyncRepositoryReadService[ModelT
             raise RepositoryError(msg)
         if item_id is not None:
             data = self.repository.set_id_attribute_value(item_id=item_id, item=data, id_attribute=id_attribute)  # pyright: ignore[reportUnknownMemberType]
-        result = self.repository.update(
+        return self.repository.update(
             data=data,
             attribute_names=attribute_names,
             with_for_update=with_for_update,
@@ -786,33 +547,6 @@ class SQLAlchemySyncRepositoryService(SQLAlchemySyncRepositoryReadService[ModelT
             load=load,
             execution_options=execution_options,
         )
-        if to_schema is not None:
-            return self.to_schema(data=result, schema_type=to_schema)
-        return result
-
-    @overload
-    def update_many(
-        self,
-        data: ModelDictListT[ModelT],
-        *,
-        load: LoadSpec | None = None,
-        execution_options: dict[str, Any] | None = None,
-        auto_commit: bool | None = None,
-        auto_expunge: bool | None = None,
-        to_schema: None = None,
-    ) -> Sequence[ModelT]: ...
-
-    @overload
-    def update_many(
-        self,
-        data: ModelDictListT[ModelT],
-        *,
-        load: LoadSpec | None = None,
-        execution_options: dict[str, Any] | None = None,
-        auto_commit: bool | None = None,
-        auto_expunge: bool | None = None,
-        to_schema: type[ModelDTOT],
-    ) -> OffsetPagination[ModelDTOT]: ...
 
     def update_many(
         self,
@@ -822,8 +556,7 @@ class SQLAlchemySyncRepositoryService(SQLAlchemySyncRepositoryReadService[ModelT
         execution_options: dict[str, Any] | None = None,
         auto_commit: bool | None = None,
         auto_expunge: bool | None = None,
-        to_schema: type[ModelDTOT] | None = None,
-    ) -> Sequence[ModelT] | OffsetPagination[ModelDTOT]:
+    ) -> Sequence[ModelT]:
         """Wrap repository bulk instance update.
 
         Args:
@@ -834,56 +567,18 @@ class SQLAlchemySyncRepositoryService(SQLAlchemySyncRepositoryReadService[ModelT
                 :class:`SQLAlchemyAsyncRepository.auto_commit <SQLAlchemyAsyncRepository>`
             load: Set default relationships to be loaded
             execution_options: Set default execution options
-            to_schema: optionally convert to alternative schema object
 
         Returns:
             Representation of updated instances.
         """
         data = [(self.to_model(datum, "update")) for datum in data]
-        result = self.repository.update_many(
+        return self.repository.update_many(
             cast("list[ModelT]", data),  # pyright: ignore[reportUnnecessaryCast]
             auto_commit=auto_commit,
             auto_expunge=auto_expunge,
             load=load,
             execution_options=execution_options,
         )
-        if to_schema is not None:
-            return self.to_schema(data=result, schema_type=to_schema)
-        return result
-
-    @overload
-    def upsert(
-        self,
-        data: ModelDictT[ModelT],
-        item_id: Any | None = None,
-        *,
-        load: LoadSpec | None = None,
-        execution_options: dict[str, Any] | None = None,
-        attribute_names: Iterable[str] | None = None,
-        with_for_update: bool | None = None,
-        auto_expunge: bool | None = None,
-        auto_commit: bool | None = None,
-        auto_refresh: bool | None = None,
-        match_fields: list[str] | str | None = None,
-        to_schema: None = None,
-    ) -> ModelT: ...
-
-    @overload
-    def upsert(
-        self,
-        data: ModelDictT[ModelT],
-        item_id: Any | None = None,
-        *,
-        load: LoadSpec | None = None,
-        execution_options: dict[str, Any] | None = None,
-        attribute_names: Iterable[str] | None = None,
-        with_for_update: bool | None = None,
-        auto_expunge: bool | None = None,
-        auto_commit: bool | None = None,
-        auto_refresh: bool | None = None,
-        match_fields: list[str] | str | None = None,
-        to_schema: type[ModelDTOT],
-    ) -> ModelDTOT: ...
 
     def upsert(
         self,
@@ -898,8 +593,7 @@ class SQLAlchemySyncRepositoryService(SQLAlchemySyncRepositoryReadService[ModelT
         auto_commit: bool | None = None,
         auto_refresh: bool | None = None,
         match_fields: list[str] | str | None = None,
-        to_schema: type[ModelDTOT] | None = None,
-    ) -> ModelT | ModelDTOT:
+    ) -> ModelT:
         """Wrap repository upsert operation.
 
         Args:
@@ -921,7 +615,6 @@ class SQLAlchemySyncRepositoryService(SQLAlchemySyncRepositoryReadService[ModelT
                 empty, all fields are matched.
             load: Set default relationships to be loaded
             execution_options: Set default execution options
-            to_schema: optionally convert to alternative schema object
 
         Returns:
             Updated or created representation.
@@ -930,7 +623,7 @@ class SQLAlchemySyncRepositoryService(SQLAlchemySyncRepositoryReadService[ModelT
         item_id = item_id if item_id is not None else self.repository.get_id_attribute_value(item=data)  # pyright: ignore[reportUnknownMemberType]
         if item_id is not None:
             self.repository.set_id_attribute_value(item_id, data)  # pyright: ignore[reportUnknownMemberType]
-        result = self.repository.upsert(
+        return self.repository.upsert(
             data=data,
             attribute_names=attribute_names,
             with_for_update=with_for_update,
@@ -941,36 +634,6 @@ class SQLAlchemySyncRepositoryService(SQLAlchemySyncRepositoryReadService[ModelT
             load=load,
             execution_options=execution_options,
         )
-        if to_schema is not None:
-            return self.to_schema(data=result, schema_type=to_schema)
-        return result
-
-    @overload
-    def upsert_many(
-        self,
-        data: ModelDictListT[ModelT],
-        *,
-        load: LoadSpec | None = None,
-        execution_options: dict[str, Any] | None = None,
-        auto_expunge: bool | None = None,
-        auto_commit: bool | None = None,
-        no_merge: bool = False,
-        match_fields: list[str] | str | None = None,
-        to_schema: None = None,
-    ) -> Sequence[ModelT]: ...
-    @overload
-    def upsert_many(
-        self,
-        data: ModelDictListT[ModelT],
-        *,
-        load: LoadSpec | None = None,
-        execution_options: dict[str, Any] | None = None,
-        auto_expunge: bool | None = None,
-        auto_commit: bool | None = None,
-        no_merge: bool = False,
-        match_fields: list[str] | str | None = None,
-        to_schema: type[ModelDTOT],
-    ) -> OffsetPagination[ModelDTOT]: ...
 
     def upsert_many(
         self,
@@ -982,8 +645,7 @@ class SQLAlchemySyncRepositoryService(SQLAlchemySyncRepositoryReadService[ModelT
         auto_commit: bool | None = None,
         no_merge: bool = False,
         match_fields: list[str] | str | None = None,
-        to_schema: type[ModelDTOT] | None = None,
-    ) -> Sequence[ModelT] | OffsetPagination[ModelDTOT]:
+    ) -> Sequence[ModelT]:
         """Wrap repository upsert operation.
 
         Args:
@@ -1000,13 +662,12 @@ class SQLAlchemySyncRepositoryService(SQLAlchemySyncRepositoryReadService[ModelT
                 empty, all fields are matched.
             load: Set default relationships to be loaded
             execution_options: Set default execution options
-            to_schema: optionally convert to alternative schema object
 
         Returns:
             Updated or created representation.
         """
         data = [(self.to_model(datum, "upsert")) for datum in data]
-        result = self.repository.upsert_many(
+        return self.repository.upsert_many(
             data=cast("list[ModelT]", data),  # pyright: ignore[reportUnnecessaryCast]
             auto_expunge=auto_expunge,
             auto_commit=auto_commit,
@@ -1015,43 +676,6 @@ class SQLAlchemySyncRepositoryService(SQLAlchemySyncRepositoryReadService[ModelT
             load=load,
             execution_options=execution_options,
         )
-        if to_schema is not None:
-            return self.to_schema(data=result, schema_type=to_schema)
-        return result
-
-    @overload
-    def get_or_upsert(
-        self,
-        *filters: StatementFilter | ColumnElement[bool],
-        match_fields: list[str] | str | None = None,
-        load: LoadSpec | None = None,
-        execution_options: dict[str, Any] | None = None,
-        upsert: bool = True,
-        attribute_names: Iterable[str] | None = None,
-        with_for_update: bool | None = None,
-        auto_commit: bool | None = None,
-        auto_expunge: bool | None = None,
-        auto_refresh: bool | None = None,
-        to_schema: None = None,
-        **kwargs: Any,
-    ) -> tuple[ModelT, bool]: ...
-
-    @overload
-    def get_or_upsert(
-        self,
-        *filters: StatementFilter | ColumnElement[bool],
-        match_fields: list[str] | str | None = None,
-        load: LoadSpec | None = None,
-        execution_options: dict[str, Any] | None = None,
-        upsert: bool = True,
-        attribute_names: Iterable[str] | None = None,
-        with_for_update: bool | None = None,
-        auto_commit: bool | None = None,
-        auto_expunge: bool | None = None,
-        auto_refresh: bool | None = None,
-        to_schema: type[ModelDTOT],
-        **kwargs: Any,
-    ) -> tuple[ModelDTOT, bool]: ...
 
     def get_or_upsert(
         self,
@@ -1065,9 +689,8 @@ class SQLAlchemySyncRepositoryService(SQLAlchemySyncRepositoryReadService[ModelT
         auto_commit: bool | None = None,
         auto_expunge: bool | None = None,
         auto_refresh: bool | None = None,
-        to_schema: type[ModelDTOT] | None = None,
         **kwargs: Any,
-    ) -> tuple[ModelT | ModelDTOT, bool]:
+    ) -> tuple[ModelT, bool]:
         """Wrap repository instance creation.
 
         Args:
@@ -1090,7 +713,6 @@ class SQLAlchemySyncRepositoryService(SQLAlchemySyncRepositoryReadService[ModelT
                 :class:`SQLAlchemyAsyncRepository.auto_commit <SQLAlchemyAsyncRepository>`
             load: Set default relationships to be loaded
             execution_options: Set default execution options
-            to_schema: optionally convert to alternative schema object
             **kwargs: Identifier of the instance to be retrieved.
 
         Returns:
@@ -1098,7 +720,7 @@ class SQLAlchemySyncRepositoryService(SQLAlchemySyncRepositoryReadService[ModelT
         """
         match_fields = match_fields or self.match_fields
         validated_model = self.to_model(kwargs, "create")
-        result = self.repository.get_or_upsert(
+        return self.repository.get_or_upsert(
             *filters,
             match_fields=match_fields,
             upsert=upsert,
@@ -1111,41 +733,6 @@ class SQLAlchemySyncRepositoryService(SQLAlchemySyncRepositoryReadService[ModelT
             execution_options=execution_options,
             **validated_model.to_dict(),
         )
-        if to_schema is not None:
-            return (self.to_schema(data=result[0], schema_type=to_schema), result[1])
-        return result
-
-    @overload
-    def get_and_update(
-        self,
-        *filters: StatementFilter | ColumnElement[bool],
-        match_fields: list[str] | str | None = None,
-        load: LoadSpec | None = None,
-        execution_options: dict[str, Any] | None = None,
-        attribute_names: Iterable[str] | None = None,
-        with_for_update: bool | None = None,
-        auto_commit: bool | None = None,
-        auto_expunge: bool | None = None,
-        auto_refresh: bool | None = None,
-        to_schema: None = None,
-        **kwargs: Any,
-    ) -> tuple[ModelT, bool]: ...
-
-    @overload
-    def get_and_update(
-        self,
-        *filters: StatementFilter | ColumnElement[bool],
-        match_fields: list[str] | str | None = None,
-        load: LoadSpec | None = None,
-        execution_options: dict[str, Any] | None = None,
-        attribute_names: Iterable[str] | None = None,
-        with_for_update: bool | None = None,
-        auto_commit: bool | None = None,
-        auto_expunge: bool | None = None,
-        auto_refresh: bool | None = None,
-        to_schema: type[ModelDTOT],
-        **kwargs: Any,
-    ) -> tuple[ModelDTOT, bool]: ...
 
     def get_and_update(
         self,
@@ -1158,9 +745,8 @@ class SQLAlchemySyncRepositoryService(SQLAlchemySyncRepositoryReadService[ModelT
         auto_commit: bool | None = None,
         auto_expunge: bool | None = None,
         auto_refresh: bool | None = None,
-        to_schema: type[ModelDTOT] | None = None,
         **kwargs: Any,
-    ) -> tuple[ModelT | ModelDTOT, bool]:
+    ) -> tuple[ModelT, bool]:
         """Wrap repository instance creation.
 
         Args:
@@ -1180,7 +766,6 @@ class SQLAlchemySyncRepositoryService(SQLAlchemySyncRepositoryReadService[ModelT
                 :class:`SQLAlchemyAsyncRepository.auto_commit <SQLAlchemyAsyncRepository>`
             load: Set default relationships to be loaded
             execution_options: Set default execution options
-            to_schema: optionally convert to alternative schema object
             **kwargs: Identifier of the instance to be retrieved.
 
         Returns:
@@ -1188,7 +773,7 @@ class SQLAlchemySyncRepositoryService(SQLAlchemySyncRepositoryReadService[ModelT
         """
         match_fields = match_fields or self.match_fields
         validated_model = self.to_model(kwargs, "update")
-        result = self.repository.get_and_update(
+        return self.repository.get_and_update(
             *filters,
             match_fields=match_fields,
             attribute_names=attribute_names,
@@ -1200,35 +785,6 @@ class SQLAlchemySyncRepositoryService(SQLAlchemySyncRepositoryReadService[ModelT
             execution_options=execution_options,
             **validated_model.to_dict(),
         )
-        if to_schema is not None:
-            return (self.to_schema(data=result[0], schema_type=to_schema), result[1])
-        return result
-
-    @overload
-    def delete(
-        self,
-        item_id: Any,
-        *,
-        id_attribute: str | InstrumentedAttribute[Any] | None = None,
-        load: LoadSpec | None = None,
-        execution_options: dict[str, Any] | None = None,
-        auto_commit: bool | None = None,
-        auto_expunge: bool | None = None,
-        to_schema: None = None,
-    ) -> ModelT: ...
-
-    @overload
-    def delete(
-        self,
-        item_id: Any,
-        *,
-        id_attribute: str | InstrumentedAttribute[Any] | None = None,
-        load: LoadSpec | None = None,
-        execution_options: dict[str, Any] | None = None,
-        auto_commit: bool | None = None,
-        auto_expunge: bool | None = None,
-        to_schema: type[ModelDTOT],
-    ) -> ModelDTOT: ...
 
     def delete(
         self,
@@ -1239,8 +795,7 @@ class SQLAlchemySyncRepositoryService(SQLAlchemySyncRepositoryReadService[ModelT
         execution_options: dict[str, Any] | None = None,
         auto_commit: bool | None = None,
         auto_expunge: bool | None = None,
-        to_schema: type[ModelDTOT] | None = None,
-    ) -> ModelT | ModelDTOT:
+    ) -> ModelT:
         """Wrap repository delete operation.
 
         Args:
@@ -1253,12 +808,11 @@ class SQLAlchemySyncRepositoryService(SQLAlchemySyncRepositoryReadService[ModelT
                 Defaults to `id`, but can reference any surrogate or candidate key for the table.
             load: Set default relationships to be loaded
             execution_options: Set default execution options
-            to_schema: optionally convert to alternative schema object
 
         Returns:
             Representation of the deleted instance.
         """
-        result = self.repository.delete(
+        return self.repository.delete(
             item_id=item_id,
             auto_commit=auto_commit,
             auto_expunge=auto_expunge,
@@ -1266,37 +820,6 @@ class SQLAlchemySyncRepositoryService(SQLAlchemySyncRepositoryReadService[ModelT
             load=load,
             execution_options=execution_options,
         )
-        if to_schema is not None:
-            return self.to_schema(data=result, schema_type=to_schema)
-        return result
-
-    @overload
-    def delete_many(
-        self,
-        item_ids: list[Any],
-        *,
-        id_attribute: str | InstrumentedAttribute[Any] | None = None,
-        load: LoadSpec | None = None,
-        execution_options: dict[str, Any] | None = None,
-        chunk_size: int | None = None,
-        auto_commit: bool | None = None,
-        auto_expunge: bool | None = None,
-        to_schema: None = None,
-    ) -> Sequence[ModelT]: ...
-
-    @overload
-    def delete_many(
-        self,
-        item_ids: list[Any],
-        *,
-        id_attribute: str | InstrumentedAttribute[Any] | None = None,
-        load: LoadSpec | None = None,
-        execution_options: dict[str, Any] | None = None,
-        chunk_size: int | None = None,
-        auto_commit: bool | None = None,
-        auto_expunge: bool | None = None,
-        to_schema: type[ModelDTOT],
-    ) -> OffsetPagination[ModelDTOT]: ...
 
     def delete_many(
         self,
@@ -1308,8 +831,7 @@ class SQLAlchemySyncRepositoryService(SQLAlchemySyncRepositoryReadService[ModelT
         chunk_size: int | None = None,
         auto_commit: bool | None = None,
         auto_expunge: bool | None = None,
-        to_schema: type[ModelDTOT] | None = None,
-    ) -> Sequence[ModelT] | OffsetPagination[ModelDTOT]:
+    ) -> Sequence[ModelT]:
         """Wrap repository bulk instance deletion.
 
         Args:
@@ -1324,12 +846,11 @@ class SQLAlchemySyncRepositoryService(SQLAlchemySyncRepositoryReadService[ModelT
                 Defaults to `950` if left unset.
             load: Set default relationships to be loaded
             execution_options: Set default execution options
-            to_schema: optionally convert to alternative schema object
 
         Returns:
             Representation of removed instances.
         """
-        result = self.repository.delete_many(
+        return self.repository.delete_many(
             item_ids=item_ids,
             auto_commit=auto_commit,
             auto_expunge=auto_expunge,
@@ -1338,33 +859,6 @@ class SQLAlchemySyncRepositoryService(SQLAlchemySyncRepositoryReadService[ModelT
             load=load,
             execution_options=execution_options,
         )
-        if to_schema is not None:
-            return self.to_schema(data=result, schema_type=to_schema)
-        return result
-
-    @overload
-    def delete_where(
-        self,
-        *filters: StatementFilter | ColumnElement[bool],
-        load: LoadSpec | None = None,
-        execution_options: dict[str, Any] | None = None,
-        auto_commit: bool | None = None,
-        auto_expunge: bool | None = None,
-        to_schema: None = None,
-        **kwargs: Any,
-    ) -> Sequence[ModelT]: ...
-
-    @overload
-    def delete_where(
-        self,
-        *filters: StatementFilter | ColumnElement[bool],
-        load: LoadSpec | None = None,
-        execution_options: dict[str, Any] | None = None,
-        auto_commit: bool | None = None,
-        auto_expunge: bool | None = None,
-        to_schema: type[ModelDTOT],
-        **kwargs: Any,
-    ) -> OffsetPagination[ModelDTOT]: ...
 
     def delete_where(
         self,
@@ -1373,9 +867,8 @@ class SQLAlchemySyncRepositoryService(SQLAlchemySyncRepositoryReadService[ModelT
         execution_options: dict[str, Any] | None = None,
         auto_commit: bool | None = None,
         auto_expunge: bool | None = None,
-        to_schema: type[ModelDTOT] | None = None,
         **kwargs: Any,
-    ) -> Sequence[ModelT] | OffsetPagination[ModelDTOT]:
+    ) -> Sequence[ModelT]:
         """Wrap repository scalars operation.
 
         Args:
@@ -1386,13 +879,12 @@ class SQLAlchemySyncRepositoryService(SQLAlchemySyncRepositoryReadService[ModelT
                 :class:`SQLAlchemyAsyncRepository.auto_commit <SQLAlchemyAsyncRepository>`
             load: Set default relationships to be loaded
             execution_options: Set default execution options
-            to_schema: optionally convert to alternative schema object
             **kwargs: Instance attribute value filters.
 
         Returns:
             The list of instances deleted from the repository.
         """
-        result = self.repository.delete_where(
+        return self.repository.delete_where(
             *filters,
             auto_commit=auto_commit,
             auto_expunge=auto_expunge,
@@ -1400,6 +892,3 @@ class SQLAlchemySyncRepositoryService(SQLAlchemySyncRepositoryReadService[ModelT
             execution_options=execution_options,
             **kwargs,
         )
-        if to_schema is not None:
-            return self.to_schema(data=result, schema_type=to_schema)
-        return result

--- a/advanced_alchemy/service/typing.py
+++ b/advanced_alchemy/service/typing.py
@@ -120,10 +120,8 @@ def schema_to_dict(v: Any, exclude_unset: bool = True) -> dict[str, Any]:
         return v
     if is_pydantic_model(v):
         return v.model_dump(exclude_unset=exclude_unset)
-
     if is_msgspec_model(v) and exclude_unset:
         return {f: val for f in v.__struct_fields__ if (val := getattr(v, f, None)) != UNSET}
-
     if is_msgspec_model(v) and not exclude_unset:
         return {f: getattr(v, f, None) for f in v.__struct_fields__}
     msg = f"Unable to convert model to dictionary for '{type(v)}' types"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ maintainers = [
 name = "advanced_alchemy"
 readme = "README.md"
 requires-python = ">=3.8"
-version = "0.15.1"
+version = "0.16.0"
 
 [project.urls]
 Changelog = "https://docs.advanced-alchemy.litestar.dev/latest/changelog"

--- a/tests/fixtures/bigint/services.py
+++ b/tests/fixtures/bigint/services.py
@@ -229,7 +229,7 @@ class SlugBookAsyncService(SQLAlchemyAsyncRepositoryService[BigIntSlugBook]):
         operation: str | None = None,
     ) -> BigIntSlugBook:
         data = schema_to_dict(data)
-        if is_dict_with_field(data, "slug") and operation == "create":
+        if is_dict_without_field(data, "slug") and operation == "create":
             data["slug"] = await self.repository.get_available_slug(data["title"])
         if is_dict_without_field(data, "slug") and is_dict_with_field(data, "title") and operation == "update":
             data["slug"] = await self.repository.get_available_slug(data["title"])
@@ -251,7 +251,7 @@ class SlugBookSyncService(SQLAlchemySyncRepositoryService[BigIntSlugBook]):
         operation: str | None = None,
     ) -> BigIntSlugBook:
         data = schema_to_dict(data)
-        if is_dict_with_field(data, "slug") and operation == "create":
+        if is_dict_without_field(data, "slug") and operation == "create":
             data["slug"] = self.repository.get_available_slug(data["title"])
         if is_dict_without_field(data, "slug") and is_dict_with_field(data, "title") and operation == "update":
             data["slug"] = self.repository.get_available_slug(data["title"])
@@ -273,7 +273,7 @@ class SlugBookAsyncMockService(SQLAlchemyAsyncRepositoryService[BigIntSlugBook])
         operation: str | None = None,
     ) -> BigIntSlugBook:
         data = schema_to_dict(data)
-        if is_dict_with_field(data, "slug") and operation == "create":
+        if is_dict_without_field(data, "slug") and operation == "create":
             data["slug"] = await self.repository.get_available_slug(data["title"])
         if is_dict_without_field(data, "slug") and is_dict_with_field(data, "title") and operation == "update":
             data["slug"] = await self.repository.get_available_slug(data["title"])
@@ -295,7 +295,7 @@ class SlugBookSyncMockService(SQLAlchemySyncRepositoryService[BigIntSlugBook]):
         operation: str | None = None,
     ) -> BigIntSlugBook:
         data = schema_to_dict(data)
-        if is_dict_with_field(data, "slug") and operation == "create":
+        if is_dict_without_field(data, "slug") and operation == "create":
             data["slug"] = self.repository.get_available_slug(data["title"])
         if is_dict_without_field(data, "slug") and is_dict_with_field(data, "title") and operation == "update":
             data["slug"] = self.repository.get_available_slug(data["title"])

--- a/tests/fixtures/bigint/services.py
+++ b/tests/fixtures/bigint/services.py
@@ -4,13 +4,11 @@ from __future__ import annotations
 
 from typing import Any
 
-from msgspec import Struct
-from pydantic import BaseModel
-
 from advanced_alchemy.service import (
     SQLAlchemyAsyncRepositoryService,
     SQLAlchemySyncRepositoryService,
 )
+from advanced_alchemy.service.typing import ModelDictT, is_dict_with_field, is_dict_without_field, schema_to_dict
 from tests.fixtures.bigint.models import (
     BigIntAuthor,
     BigIntBook,
@@ -227,12 +225,13 @@ class SlugBookAsyncService(SQLAlchemyAsyncRepositoryService[BigIntSlugBook]):
 
     async def to_model(
         self,
-        data: BigIntSlugBook | dict[str, Any] | BaseModel | Struct,
+        data: ModelDictT[BigIntSlugBook],
         operation: str | None = None,
     ) -> BigIntSlugBook:
-        if isinstance(data, dict) and "slug" not in data and operation == "create":
+        data = schema_to_dict(data)
+        if is_dict_with_field(data, "slug") and operation == "create":
             data["slug"] = await self.repository.get_available_slug(data["title"])
-        if isinstance(data, dict) and "slug" not in data and "title" in data and operation == "update":
+        if is_dict_without_field(data, "slug") and is_dict_with_field(data, "title") and operation == "update":
             data["slug"] = await self.repository.get_available_slug(data["title"])
         return await super().to_model(data, operation)
 
@@ -248,12 +247,13 @@ class SlugBookSyncService(SQLAlchemySyncRepositoryService[BigIntSlugBook]):
 
     def to_model(
         self,
-        data: BigIntSlugBook | dict[str, Any] | BaseModel | Struct,
+        data: ModelDictT[BigIntSlugBook],
         operation: str | None = None,
     ) -> BigIntSlugBook:
-        if isinstance(data, dict) and "slug" not in data and operation == "create":
+        data = schema_to_dict(data)
+        if is_dict_with_field(data, "slug") and operation == "create":
             data["slug"] = self.repository.get_available_slug(data["title"])
-        if isinstance(data, dict) and "slug" not in data and "title" in data and operation == "update":
+        if is_dict_without_field(data, "slug") and is_dict_with_field(data, "title") and operation == "update":
             data["slug"] = self.repository.get_available_slug(data["title"])
         return super().to_model(data, operation)
 
@@ -269,12 +269,13 @@ class SlugBookAsyncMockService(SQLAlchemyAsyncRepositoryService[BigIntSlugBook])
 
     async def to_model(
         self,
-        data: BigIntSlugBook | dict[str, Any] | BaseModel | Struct,
+        data: ModelDictT[BigIntSlugBook],
         operation: str | None = None,
     ) -> BigIntSlugBook:
-        if isinstance(data, dict) and "slug" not in data and operation == "create":
+        data = schema_to_dict(data)
+        if is_dict_with_field(data, "slug") and operation == "create":
             data["slug"] = await self.repository.get_available_slug(data["title"])
-        if isinstance(data, dict) and "slug" not in data and "title" in data and operation == "update":
+        if is_dict_without_field(data, "slug") and is_dict_with_field(data, "title") and operation == "update":
             data["slug"] = await self.repository.get_available_slug(data["title"])
         return await super().to_model(data, operation)
 
@@ -290,11 +291,12 @@ class SlugBookSyncMockService(SQLAlchemySyncRepositoryService[BigIntSlugBook]):
 
     def to_model(
         self,
-        data: BigIntSlugBook | dict[str, Any] | BaseModel | Struct,
+        data: ModelDictT[BigIntSlugBook],
         operation: str | None = None,
     ) -> BigIntSlugBook:
-        if isinstance(data, dict) and "slug" not in data and operation == "create":
+        data = schema_to_dict(data)
+        if is_dict_with_field(data, "slug") and operation == "create":
             data["slug"] = self.repository.get_available_slug(data["title"])
-        if isinstance(data, dict) and "slug" not in data and "title" in data and operation == "update":
+        if is_dict_without_field(data, "slug") and is_dict_with_field(data, "title") and operation == "update":
             data["slug"] = self.repository.get_available_slug(data["title"])
         return super().to_model(data, operation)

--- a/tests/fixtures/uuid/services.py
+++ b/tests/fixtures/uuid/services.py
@@ -2,13 +2,18 @@
 
 from __future__ import annotations
 
-from typing import Any, cast
+from typing import Any
 
 from advanced_alchemy.service import (
     SQLAlchemyAsyncRepositoryService,
     SQLAlchemySyncRepositoryService,
 )
-from advanced_alchemy.service.typing import PydanticOrMsgspecT
+from advanced_alchemy.service.typing import (
+    PydanticOrMsgspecT,
+    is_dict_with_field,
+    is_dict_without_field,
+    schema_to_dict,
+)
 from tests.fixtures.uuid.models import (
     UUIDAuthor,
     UUIDBook,
@@ -224,10 +229,11 @@ class SlugBookAsyncService(SQLAlchemyAsyncRepositoryService[UUIDSlugBook]):
         data: UUIDSlugBook | dict[str, Any] | PydanticOrMsgspecT,
         operation: str | None = None,
     ) -> UUIDSlugBook:
-        if isinstance(data, dict) and "slug" not in data and operation == "create":
-            data["slug"] = await self.repository.get_available_slug(cast("str", data["title"]))
-        if isinstance(data, dict) and "slug" not in data and "title" in data and operation == "update":
-            data["slug"] = await self.repository.get_available_slug(cast("str", data["title"]))
+        data = schema_to_dict(data)
+        if is_dict_with_field(data, "slug") and operation == "create":
+            data["slug"] = await self.repository.get_available_slug(data["title"])
+        if is_dict_without_field(data, "slug") and is_dict_with_field(data, "title") and operation == "update":
+            data["slug"] = await self.repository.get_available_slug(data["title"])
         return await super().to_model(data, operation)
 
 
@@ -244,9 +250,10 @@ class SlugBookSyncService(SQLAlchemySyncRepositoryService[UUIDSlugBook]):
         data: UUIDSlugBook | dict[str, Any] | PydanticOrMsgspecT,
         operation: str | None = None,
     ) -> UUIDSlugBook:
-        if isinstance(data, dict) and "slug" not in data and operation == "create":
+        data = schema_to_dict(data)
+        if is_dict_with_field(data, "slug") and operation == "create":
             data["slug"] = self.repository.get_available_slug(data["title"])
-        if isinstance(data, dict) and "slug" not in data and "title" in data and operation == "update":
+        if is_dict_without_field(data, "slug") and is_dict_with_field(data, "title") and operation == "update":
             data["slug"] = self.repository.get_available_slug(data["title"])
         return super().to_model(data, operation)
 
@@ -265,9 +272,10 @@ class SlugBookAsyncMockService(SQLAlchemyAsyncRepositoryService[UUIDSlugBook]):
         data: UUIDSlugBook | dict[str, Any] | PydanticOrMsgspecT,
         operation: str | None = None,
     ) -> UUIDSlugBook:
-        if isinstance(data, dict) and "slug" not in data and operation == "create":
+        data = schema_to_dict(data)
+        if is_dict_with_field(data, "slug") and operation == "create":
             data["slug"] = await self.repository.get_available_slug(data["title"])
-        if isinstance(data, dict) and "slug" not in data and "title" in data and operation == "update":
+        if is_dict_without_field(data, "slug") and is_dict_with_field(data, "title") and operation == "update":
             data["slug"] = await self.repository.get_available_slug(data["title"])
         return await super().to_model(data, operation)
 
@@ -286,8 +294,9 @@ class SlugBookSyncMockService(SQLAlchemySyncRepositoryService[UUIDSlugBook]):
         data: UUIDSlugBook | dict[str, Any] | PydanticOrMsgspecT,
         operation: str | None = None,
     ) -> UUIDSlugBook:
-        if isinstance(data, dict) and "slug" not in data and operation == "create":
+        data = schema_to_dict(data)
+        if is_dict_with_field(data, "slug") and operation == "create":
             data["slug"] = self.repository.get_available_slug(data["title"])
-        if isinstance(data, dict) and "slug" not in data and "title" in data and operation == "update":
+        if is_dict_without_field(data, "slug") and is_dict_with_field(data, "title") and operation == "update":
             data["slug"] = self.repository.get_available_slug(data["title"])
         return super().to_model(data, operation)

--- a/tests/fixtures/uuid/services.py
+++ b/tests/fixtures/uuid/services.py
@@ -230,7 +230,7 @@ class SlugBookAsyncService(SQLAlchemyAsyncRepositoryService[UUIDSlugBook]):
         operation: str | None = None,
     ) -> UUIDSlugBook:
         data = schema_to_dict(data)
-        if is_dict_with_field(data, "slug") and operation == "create":
+        if is_dict_without_field(data, "slug") and operation == "create":
             data["slug"] = await self.repository.get_available_slug(data["title"])
         if is_dict_without_field(data, "slug") and is_dict_with_field(data, "title") and operation == "update":
             data["slug"] = await self.repository.get_available_slug(data["title"])
@@ -251,7 +251,7 @@ class SlugBookSyncService(SQLAlchemySyncRepositoryService[UUIDSlugBook]):
         operation: str | None = None,
     ) -> UUIDSlugBook:
         data = schema_to_dict(data)
-        if is_dict_with_field(data, "slug") and operation == "create":
+        if is_dict_without_field(data, "slug") and operation == "create":
             data["slug"] = self.repository.get_available_slug(data["title"])
         if is_dict_without_field(data, "slug") and is_dict_with_field(data, "title") and operation == "update":
             data["slug"] = self.repository.get_available_slug(data["title"])
@@ -273,7 +273,7 @@ class SlugBookAsyncMockService(SQLAlchemyAsyncRepositoryService[UUIDSlugBook]):
         operation: str | None = None,
     ) -> UUIDSlugBook:
         data = schema_to_dict(data)
-        if is_dict_with_field(data, "slug") and operation == "create":
+        if is_dict_without_field(data, "slug") and operation == "create":
             data["slug"] = await self.repository.get_available_slug(data["title"])
         if is_dict_without_field(data, "slug") and is_dict_with_field(data, "title") and operation == "update":
             data["slug"] = await self.repository.get_available_slug(data["title"])
@@ -295,7 +295,7 @@ class SlugBookSyncMockService(SQLAlchemySyncRepositoryService[UUIDSlugBook]):
         operation: str | None = None,
     ) -> UUIDSlugBook:
         data = schema_to_dict(data)
-        if is_dict_with_field(data, "slug") and operation == "create":
+        if is_dict_without_field(data, "slug") and operation == "create":
             data["slug"] = self.repository.get_available_slug(data["title"])
         if is_dict_without_field(data, "slug") and is_dict_with_field(data, "title") and operation == "update":
             data["slug"] = self.repository.get_available_slug(data["title"])

--- a/tests/integration/test_sqlquery_service.py
+++ b/tests/integration/test_sqlquery_service.py
@@ -110,9 +110,7 @@ def test_sync_fixture_and_query() -> None:
         fixture = open_fixture(fixture_path, USStateSyncRepository.model_type.__tablename__)  # type: ignore[has-type]
         _add_objs = state_service.create_many(
             data=[USStateStruct(**raw_obj) for raw_obj in fixture],
-            to_schema=USStateStruct,
         )
-        assert isinstance(_add_objs.items[0], USStateStruct)
         query_count = query_service.repository.count(statement=select(StateQuery))
         assert query_count > 0
         list_query_objs, list_query_count = query_service.repository.list_and_count(
@@ -123,16 +121,19 @@ def test_sync_fixture_and_query() -> None:
             data=list_query_objs,
             total=list_query_count,
         )
+
         _pydantic_paginated_objs = query_service.to_schema(
             data=list_query_objs,
             total=list_query_count,
             schema_type=StateQueryBaseModel,
         )
+        assert isinstance(_pydantic_paginated_objs.items[0], StateQueryBaseModel)
         _msgspec_paginated_objs = query_service.to_schema(
             data=list_query_objs,
             total=list_query_count,
             schema_type=StateQueryStruct,
         )
+        assert isinstance(_msgspec_paginated_objs.items[0], StateQueryStruct)
         _list_service_objs = query_service.repository.list(statement=select(StateQuery))
         assert len(_list_service_objs) >= 50
         _get_ones = query_service.repository.list(statement=select(StateQuery), state_name="Alabama")
@@ -151,10 +152,13 @@ def test_sync_fixture_and_query() -> None:
             data=_get_one_or_none_1,
             schema_type=StateQueryBaseModel,
         )
+        assert isinstance(_pydantic_obj, StateQueryBaseModel)
+
         _msgspec_objs = query_service.to_schema(
             data=_get_one_or_none_1,
             schema_type=StateQueryStruct,
         )
+        assert isinstance(_msgspec_objs, StateQueryStruct)
 
         _get_one_or_none = query_service.repository.get_one_or_none(
             statement=select(StateQuery).filter_by(state_name="Nope"),
@@ -175,9 +179,7 @@ async def test_async_fixture_and_query() -> None:
         fixture = await open_fixture_async(fixture_path, USStateSyncRepository.model_type.__tablename__)  # type: ignore[has-type]
         _add_objs = await state_service.create_many(
             data=[USStateBaseModel(**raw_obj) for raw_obj in fixture],
-            to_schema=USStateBaseModel,
         )
-        assert isinstance(_add_objs.items[0], USStateBaseModel)
         query_count = await query_service.repository.count(statement=select(StateQuery))
         assert query_count > 0
         list_query_objs, list_query_count = await query_service.repository.list_and_count(
@@ -188,16 +190,19 @@ async def test_async_fixture_and_query() -> None:
             list_query_objs,
             total=list_query_count,
         )
+
         _pydantic_paginated_objs = query_service.to_schema(
             data=list_query_objs,
             total=list_query_count,
             schema_type=StateQueryBaseModel,
         )
+        assert isinstance(_pydantic_paginated_objs.items[0], StateQueryBaseModel)
         _msgspec_paginated_objs = query_service.to_schema(
             data=list_query_objs,
             total=list_query_count,
             schema_type=StateQueryStruct,
         )
+        assert isinstance(_msgspec_paginated_objs.items[0], StateQueryStruct)
         _list_service_objs = await query_service.repository.list(statement=select(StateQuery))
         assert len(_list_service_objs) >= 50
         _get_ones = await query_service.repository.list(statement=select(StateQuery), state_name="Alabama")
@@ -216,12 +221,15 @@ async def test_async_fixture_and_query() -> None:
             data=_get_one_or_none_1,
             schema_type=StateQueryBaseModel,
         )
+        assert isinstance(_pydantic_obj, StateQueryBaseModel)
+
         _msgspec_objs = query_service.to_schema(
             data=_get_one_or_none_1,
             schema_type=StateQueryStruct,
         )
+        assert isinstance(_msgspec_objs, StateQueryStruct)
 
         _get_one_or_none = await query_service.repository.get_one_or_none(
-            statement=select(StateQuery).filter_by(state_name="Nope"),
+            select(StateQuery).filter_by(state_name="Nope"),
         )
         assert _get_one_or_none is None

--- a/tests/integration/test_sqlquery_service.py
+++ b/tests/integration/test_sqlquery_service.py
@@ -17,6 +17,12 @@ from advanced_alchemy.repository import (
 from advanced_alchemy.service import SQLAlchemyAsyncQueryService, SQLAlchemySyncQueryService
 from advanced_alchemy.service._async import SQLAlchemyAsyncRepositoryService
 from advanced_alchemy.service._sync import SQLAlchemySyncRepositoryService
+from advanced_alchemy.service.typing import (
+    is_msgspec_model,
+    is_msgspec_model_with_field,
+    is_pydantic_model,
+    is_pydantic_model_with_field,
+)
 from advanced_alchemy.utils.fixtures import open_fixture, open_fixture_async
 
 pytestmark = [  # type: ignore
@@ -153,12 +159,16 @@ def test_sync_fixture_and_query() -> None:
             schema_type=StateQueryBaseModel,
         )
         assert isinstance(_pydantic_obj, StateQueryBaseModel)
+        assert is_pydantic_model(_pydantic_obj)
+        assert is_pydantic_model_with_field(_pydantic_obj, "state_abbreviation")
 
-        _msgspec_objs = query_service.to_schema(
+        _msgspec_obj = query_service.to_schema(
             data=_get_one_or_none_1,
             schema_type=StateQueryStruct,
         )
-        assert isinstance(_msgspec_objs, StateQueryStruct)
+        assert isinstance(_msgspec_obj, StateQueryStruct)
+        assert is_msgspec_model(_msgspec_obj)
+        assert is_msgspec_model_with_field(_msgspec_obj, "state_abbreviation")
 
         _get_one_or_none = query_service.repository.get_one_or_none(
             statement=select(StateQuery).filter_by(state_name="Nope"),
@@ -222,13 +232,15 @@ async def test_async_fixture_and_query() -> None:
             schema_type=StateQueryBaseModel,
         )
         assert isinstance(_pydantic_obj, StateQueryBaseModel)
-
-        _msgspec_objs = query_service.to_schema(
+        assert is_pydantic_model(_pydantic_obj)
+        assert is_pydantic_model_with_field(_pydantic_obj, "state_abbreviation")
+        _msgspec_obj = query_service.to_schema(
             data=_get_one_or_none_1,
             schema_type=StateQueryStruct,
         )
-        assert isinstance(_msgspec_objs, StateQueryStruct)
-
+        assert isinstance(_msgspec_obj, StateQueryStruct)
+        assert is_msgspec_model(_msgspec_obj)
+        assert is_msgspec_model_with_field(_msgspec_obj, "state_abbreviation")
         _get_one_or_none = await query_service.repository.get_one_or_none(
             select(StateQuery).filter_by(state_name="Nope"),
         )


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

This PR:
- Reverts the previous `to_schema` implementation in the service layer.  This will need to be rethought as it requires too many overloads to any customized service function.  
- Ensures that the filter values for `upsert_many` is a unique list.  This is useful when you are merging a large amount of objects on a foreign key.  The lookup will only contain a single unique entry for each key instead of one for each row.
- Adds a `schema_to_dict` method to convert incoming Pydantic or Msgspec models to dictionaries
- Adds additional type guard helpers to check for a field in a dictionary, Struct, or BaseModel

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
## Closes
