### PR TITLE
fix: disable `FailFast` usage

### DIFF
--- a/advanced_alchemy/service/typing.py
+++ b/advanced_alchemy/service/typing.py
@@ -60,7 +60,7 @@ try:
     # this is from pydantic 2.8.  We should check for it before using it.
     from pydantic import FailFast  # pyright: ignore[reportAssignmentType]
 
-    PYDANTIC_USE_FAILFAST: Final[bool] = True
+    PYDANTIC_USE_FAILFAST: Final[bool] = False
 except ImportError:
 
     class FailFast:  # type: ignore[no-redef] # pragma: nocover


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

-

`FailFast` raises an exception in cases where it can't be applied to a schema.  Disabling this until the behavior can be better understood.

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
## Closes
