### PR TITLE
remove "ModelProtocol" bound from a ModelT typing

### DIFF
--- a/advanced_alchemy/repository/typing.py
+++ b/advanced_alchemy/repository/typing.py
@@ -23,7 +23,7 @@ __all__ = (
 )
 
 T = TypeVar("T")
-ModelT = TypeVar("ModelT", bound="base.ModelProtocol")
+ModelT = TypeVar("ModelT")
 SelectT = TypeVar("SelectT", bound="Select[Any]")
 RowT = TypeVar("RowT", bound=Tuple[Any, ...])
 RowMappingT = TypeVar("RowMappingT", bound="RowMapping")


### PR DESCRIPTION
Bounding ModelT to ModelProtocol makes it difficult to implement SQLAlchemy ORM imperative mapping and use this library Repositories together.

According to Clean Architecture, domain layer (where mapped classes would be) should not depend on any third party libraries.

I think it's unnecessary to have this bound, cuz it's limit's us in terms of mapping to a declarative one.