### PR TITLE
fix: added if statement to prevent ``script_location`` from being overwritten

### DIFF
--- a/advanced_alchemy/alembic/commands.py
+++ b/advanced_alchemy/alembic/commands.py
@@ -244,5 +244,6 @@ class AlembicCommands:
             },
         )
         self.config = AlembicCommandConfig(**kwargs)
-        self.config.set_main_option("script_location", self.sqlalchemy_config.alembic_config.script_location)
+        if not self.config.get_main_option("script_location"):
+            self.config.set_main_option("script_location", self.sqlalchemy_config.alembic_config.script_location)
         return self.config


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

- Fix overwritten `alembic.ini` `script_location` by default value in `self.sqlalchemy_config.alembic_config.script_location`
