### PR TITLE
refactor: Fix types for ModelProtocal and BasicAttributes

### DIFF
--- a/advanced_alchemy/base.py
+++ b/advanced_alchemy/base.py
@@ -124,9 +124,10 @@ def merge_table_arguments(cls: type[DeclarativeBase], table_args: TableArgsType 
 class ModelProtocol(Protocol):
     """The base SQLAlchemy model protocol."""
 
-    __table__: FromClause
-    __mapper__: Mapper[Any]
-    __name__: str
+    if TYPE_CHECKING:
+        __table__: FromClause
+        __mapper__: Mapper[Any]
+        __name__: str
 
     def to_dict(self, exclude: set[str] | None = None) -> dict[str, Any]:
         """Convert model to dictionary.
@@ -203,9 +204,10 @@ class AuditColumns:
 class BasicAttributes:
     """Basic attributes for SQLALchemy tables and queries."""
 
-    __name__: str
-    __table__: FromClause
-    __mapper__: Mapper[Any]
+    if TYPE_CHECKING:
+        __name__: str
+        __table__: FromClause
+        __mapper__: Mapper[Any]
 
     def to_dict(self, exclude: set[str] | None = None) -> dict[str, Any]:
         """Convert model to dictionary.


### PR DESCRIPTION
## Description
It's imposible to get_type_hints() otherwise without monkey patching or other shenanigans due to `FromClause` not being imported in runtime.

About `__name__` and `__mapper__`. With monkey patching get_type_hints() on BigIntAuditBase results into:
` {'created_at': sqlalchemy.orm.base.Mapped[datetime.datetime], 'updated_at': sqlalchemy.orm.base.Mapped[datetime.datetime], '__name__': <class 'str'>, '__mapper__': sqlalchemy.orm.mapper.Mapper[typing.Any], '__table__': <class 'sqlalchemy.sql.selectable.FromClause'>}`
clearly `__name__`, `__mapper__`, `__table__` should not be there

## MRE
```
from typing import get_type_hints
from advanced_alchemy.base import BigIntAuditBase
get_type_hints(BigIntAuditBase)
```

## Closes
https://github.com/litestar-org/advanced-alchemy/issues/242