### PR TITLE
feat: remove unfinished merge operation

### DIFF
--- a/advanced_alchemy/operations.py
+++ b/advanced_alchemy/operations.py
@@ -1,89 +1,9 @@
-from __future__ import annotations
+"""This module is reserved for future customer operations.
 
-from typing import TYPE_CHECKING, Any
-
-from sqlalchemy import ClauseElement, ColumnElement, UpdateBase
-from sqlalchemy.ext.compiler import compiles
-
-if TYPE_CHECKING:
-    from typing import Literal
-
-    from sqlalchemy.sql.compiler import StrSQLCompiler
-
-
-class MergeClause(ClauseElement):
-    __visit_name__ = "merge_clause"
-
-    def __init__(self, command: Literal["INSERT", "UPDATE", "DELETE"]) -> None:
-        self.on_sets: dict[str, ColumnElement[Any]] = {}
-        self.predicate: ColumnElement[bool] | None = None
-        self.command = command
-
-    def values(self, **kwargs: ColumnElement[Any]) -> MergeClause:
-        self.on_sets = kwargs
-        return self
-
-    def where(self, expr: ColumnElement[bool]) -> MergeClause:
-        self.predicate = expr
-        return self
-
-
-@compiles(MergeClause)  # type: ignore[no-untyped-call, misc]
-def visit_merge_clause(element: MergeClause, compiler: StrSQLCompiler, **kw: Any) -> str:
-    case_predicate = ""
-    if element.predicate is not None:
-        case_predicate = f" AND {element.predicate._compiler_dispatch(compiler, **kw)!s}"  # noqa: SLF001
-
-    if element.command == "INSERT":
-        sets, sets_tos = list(element.on_sets), list(element.on_sets.values())
-        if kw.get("deterministic", False):
-            sorted_on_sets = dict(sorted(element.on_sets.items(), key=lambda x: x[0]))
-            sets, sets_tos = list(sorted_on_sets), list(sorted_on_sets.values())
-
-        merge_insert = ", ".join(sets)
-        values = ", ".join(e._compiler_dispatch(compiler, **kw) for e in sets_tos)  # noqa: SLF001
-        return f"WHEN NOT MATCHED{case_predicate} THEN {element.command} ({merge_insert}) VALUES ({values})"
-
-    set_list = list(element.on_sets.items())
-    if kw.get("deterministic", False):
-        set_list.sort(key=lambda x: x[0])
-
-    # merge update or merge delete
-    merge_action = ""
-    values = ""
-
-    if element.on_sets:
-        values = ", ".join(
-            f"{name} = {column._compiler_dispatch(compiler, **kw)}" for name, column in set_list  # noqa: SLF001
-        )
-        merge_action = f" SET {values}"
-
-    return f"WHEN MATCHED{case_predicate} THEN {element.command}{merge_action}"
-
-
-class Merge(UpdateBase):
-    __visit_name__ = "merge"
-    _bind = None
-    inherit_cache = True
-
-    def __init__(self, into: Any, using: Any, on: Any) -> None:
-        self.into = into
-        self.using = using
-        self.on = on
-        self.clauses: list[ClauseElement] = []
-
-    def when_matched(self, operations: set[Literal["UPDATE", "DELETE", "INSERT"]]) -> MergeClause:
-        for op in operations:
-            self.clauses.append(clause := MergeClause(op))
-        return clause
-
-
-@compiles(Merge)  # type: ignore[no-untyped-call, misc]
-def visit_merge(element: Merge, compiler: StrSQLCompiler, **kw: Any) -> str:
-    clauses = " ".join(clause._compiler_dispatch(compiler, **kw) for clause in element.clauses)  # noqa: SLF001
-    sql_text = f"MERGE INTO {element.into} USING {element.using} ON {element.on}"
-
-    if clauses:
-        sql_text += f" {clauses}"
-
-    return sql_text
+This could include things like:
+- Merge
+- Create Table as Select
+- Copy To
+- Copy From
+- etc.
+"""

--- a/advanced_alchemy/repository/_async.py
+++ b/advanced_alchemy/repository/_async.py
@@ -34,7 +34,6 @@ from sqlalchemy import func as sql_func
 from sqlalchemy.orm import InstrumentedAttribute
 
 from advanced_alchemy.exceptions import ErrorMessages, NotFoundError, RepositoryError, wrap_sqlalchemy_exception
-from advanced_alchemy.operations import Merge
 from advanced_alchemy.repository._util import (
     DEFAULT_ERROR_MESSAGE_TEMPLATES,
     FilterableRepository,
@@ -1717,24 +1716,6 @@ class SQLAlchemyAsyncRepository(SQLAlchemyAsyncRepositoryProtocol[ModelT], Filte
             )
             self._expunge(instance, auto_expunge=auto_expunge)
             return instance
-
-    def _supports_merge_operations(self, force_disable_merge: bool = False) -> bool:
-        return (
-            (
-                self._dialect.server_version_info is not None
-                and self._dialect.server_version_info[0] >= POSTGRES_VERSION_SUPPORTING_MERGE
-                and self._dialect.name == "postgresql"
-            )
-            or self._dialect.name == "oracle"
-        ) and not force_disable_merge
-
-    def _get_merge_stmt(
-        self,
-        into: Any,
-        using: Any,
-        on: Any,
-    ) -> Merge:
-        return Merge(into=into, using=using, on=on)
 
     async def upsert_many(
         self,

--- a/advanced_alchemy/repository/_sync.py
+++ b/advanced_alchemy/repository/_sync.py
@@ -36,7 +36,6 @@ from sqlalchemy import func as sql_func
 from sqlalchemy.orm import InstrumentedAttribute, Session
 
 from advanced_alchemy.exceptions import ErrorMessages, NotFoundError, RepositoryError, wrap_sqlalchemy_exception
-from advanced_alchemy.operations import Merge
 from advanced_alchemy.repository._util import (
     DEFAULT_ERROR_MESSAGE_TEMPLATES,
     FilterableRepository,
@@ -1718,24 +1717,6 @@ class SQLAlchemySyncRepository(SQLAlchemySyncRepositoryProtocol[ModelT], Filtera
             )
             self._expunge(instance, auto_expunge=auto_expunge)
             return instance
-
-    def _supports_merge_operations(self, force_disable_merge: bool = False) -> bool:
-        return (
-            (
-                self._dialect.server_version_info is not None
-                and self._dialect.server_version_info[0] >= POSTGRES_VERSION_SUPPORTING_MERGE
-                and self._dialect.name == "postgresql"
-            )
-            or self._dialect.name == "oracle"
-        ) and not force_disable_merge
-
-    def _get_merge_stmt(
-        self,
-        into: Any,
-        using: Any,
-        on: Any,
-    ) -> Merge:
-        return Merge(into=into, using=using, on=on)
 
     def upsert_many(
         self,

--- a/tests/unit/test_repository.py
+++ b/tests/unit/test_repository.py
@@ -256,7 +256,6 @@ async def test_sqlalchemy_repo_upsert_many(
 
     mock_instances = [MagicMock(), MagicMock(), MagicMock()]
     monkeypatch.setattr(mock_repo, "model_type", UUIDModel)
-    mocker.patch.object(mock_repo, "_supports_merge_operations", return_value=False)
     mocker.patch.object(mock_repo.session, "scalars", return_value=mock_instances)
     mocker.patch.object(mock_repo, "list", return_value=mock_instances)
     mocker.patch.object(mock_repo, "add_many", return_value=mock_instances)


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

It turns out that the existing merge code in the `operations` folder will require a bit more work before it's ready to be used in the repository.  

I've left the Merge PR open with this full code and I'm proposing we remove some of these long standing unused references.  We can re-add this when it's ready to be used again.

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
## Closes
