### PR TITLE
fix: correct regex mappings for duplicate and foreign key errors

### DIFF
--- a/advanced_alchemy/exceptions.py
+++ b/advanced_alchemy/exceptions.py
@@ -9,7 +9,7 @@ from sqlalchemy.exc import MultipleResultsFound, SQLAlchemyError
 
 from advanced_alchemy.utils.deprecation import deprecated
 
-FOREIGN_KEY_REGEXES = {
+DUPLICATE_KEY_REGEXES = {
     "postgresql": [
         re.compile(
             r"^.*duplicate\s+key.*\"(?P<columns>[^\"]+)\"\s*\n.*Key\s+\((?P<key>.*)\)=\((?P<value>.*)\)\s+already\s+exists.*$",
@@ -33,7 +33,7 @@ FOREIGN_KEY_REGEXES = {
     "cockroach": [],
 }
 
-DUPLICATE_KEY_REGEXES = {
+FOREIGN_KEY_REGEXES = {
     "postgresql": [
         re.compile(
             r".*on table \"(?P<table>[^\"]+)\" violates "


### PR DESCRIPTION

<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description
Swap the variable names for DUPLICATE_KEY_REGEXES and FOREIGN_KEY_REGEXES to correctly match their contents. 
This ensures that the error detection for duplicate keys and foreign key violations works as intended across different database backends.


<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
## Closes
#262 