### PR TITLE
fix(sanic): bind session to session class instead of to the session maker

### DIFF
--- a/advanced_alchemy/extensions/sanic.py
+++ b/advanced_alchemy/extensions/sanic.py
@@ -96,6 +96,10 @@ class SanicAdvancedAlchemy(Extension, Generic[EngineT, SessionT, SessionMakerT])
             else self.sqlalchemy_config.get_engine()
         )
         self.session_maker = self.sqlalchemy_config.create_session_maker()
+
+        session_maker = cast("SessionMakerT", self.session_maker)
+        self.session_class = session_maker.class_
+
         self.app: Sanic
 
     async def _do_commit(self, session: Session | AsyncSession) -> None:
@@ -181,7 +185,7 @@ class SanicAdvancedAlchemy(Extension, Generic[EngineT, SessionT, SessionMakerT])
                 self.get_sessionmaker_from_request,
             )
             bootstrap.add_dependency(
-                type(self.session_maker),
+                self.session_class,
                 self.get_session_from_request,
             )
 


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

binds session into sanic extension as expected

in the original code, session maker was defined and then the dependency for session overwrites it with a session maker as the type.  this seems non-ideal -- you can't get the session maker and when you ask for the session maker you get a session object

instead, this looks at the sessionmaker `class_` property for adding the sanic dependency

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
## Closes

fixes #267