### PR TITLE
fix(cli): Change the argument name back

### DIFF
--- a/advanced_alchemy/extensions/litestar/cli.py
+++ b/advanced_alchemy/extensions/litestar/cli.py
@@ -370,7 +370,7 @@ def drop_all(app: Litestar, no_prompt: bool) -> None:
 )
 @option(
     "--dir",
-    "fixtures",
+    "dump_dir",
     help="Directory to save the JSON files. Defaults to WORKDIR/fixtures",
     type=ClickPath(path_type=Path), # pyright: ignore[reportCallIssue, reportUntypedFunctionDecorator, reportArgumentType]
     default=Path.cwd() / "fixtures",


### PR DESCRIPTION
Changes the argument name so that it matches the name given in `click.option`.