### PR TITLE
feat: Improved typing of `ModelDictT`

### DIFF
--- a/advanced_alchemy/service/typing.py
+++ b/advanced_alchemy/service/typing.py
@@ -42,7 +42,7 @@ try:
     # this is from pydantic 2.8.  We should check for it before using it.
     from pydantic import FailFast  # pyright: ignore[reportAssignmentType]
 
-    PYDANTIC_USE_FAILFAST: Final[bool] = True
+    PYDANTIC_USE_FAILFAST: Final[bool] = False
 except ImportError:
     PYDANTIC_USE_FAILFAST: Final[bool] = False  # type: ignore # pyright: ignore[reportConstantRedefinition,reportGeneralTypeIssues]  # noqa: PGH003
 

--- a/advanced_alchemy/service/typing.py
+++ b/advanced_alchemy/service/typing.py
@@ -11,15 +11,11 @@ from functools import lru_cache
 from typing import (
     TYPE_CHECKING,
     Any,
-    ClassVar,
     Dict,
     Final,
-    Generic,
     List,
-    Protocol,
     Union,
     cast,
-    runtime_checkable,
 )
 
 from typing_extensions import Annotated, TypeAlias, TypeGuard, TypeVar
@@ -32,25 +28,23 @@ T = TypeVar("T")  # pragma: nocover
 if TYPE_CHECKING:
     from pydantic import BaseModel  # pyright: ignore[reportAssignmentType]
     from pydantic.type_adapter import TypeAdapter  # pyright: ignore[reportUnusedImport, reportAssignmentType]
-else:
-    try:
-        from pydantic import BaseModel  # pyright: ignore[reportAssignmentType]
-        from pydantic.type_adapter import TypeAdapter  # pyright: ignore[reportUnusedImport, reportAssignmentType]
+try:
+    from pydantic import BaseModel  # pyright: ignore[reportAssignmentType]
+    from pydantic.type_adapter import TypeAdapter  # pyright: ignore[reportUnusedImport, reportAssignmentType]
 
-        PYDANTIC_INSTALLED: Final[bool] = True
-    except ImportError:  # pragma: nocover
-        PYDANTIC_INSTALLED: Final[bool] = False  # type: ignore # pyright: ignore[reportConstantRedefinition,reportGeneralTypeIssues]  # noqa: PGH003
+    PYDANTIC_INSTALLED: Final[bool] = True
+except ImportError:  # pragma: nocover
+    PYDANTIC_INSTALLED: Final[bool] = False  # type: ignore # pyright: ignore[reportConstantRedefinition,reportGeneralTypeIssues]  # noqa: PGH003
 
 if TYPE_CHECKING:
     from pydantic import FailFast  # pyright: ignore[reportAssignmentType]
-else:
-    try:
-        # this is from pydantic 2.8.  We should check for it before using it.
-        from pydantic import FailFast  # pyright: ignore[reportAssignmentType]
+try:
+    # this is from pydantic 2.8.  We should check for it before using it.
+    from pydantic import FailFast  # pyright: ignore[reportAssignmentType]
 
-        PYDANTIC_USE_FAILFAST: Final[bool] = True
-    except ImportError:
-        PYDANTIC_USE_FAILFAST: Final[bool] = False  # type: ignore # pyright: ignore[reportConstantRedefinition,reportGeneralTypeIssues]  # noqa: PGH003
+    PYDANTIC_USE_FAILFAST: Final[bool] = True
+except ImportError:
+    PYDANTIC_USE_FAILFAST: Final[bool] = False  # type: ignore # pyright: ignore[reportConstantRedefinition,reportGeneralTypeIssues]  # noqa: PGH003
 
 
 @lru_cache(typed=True)
@@ -64,25 +58,27 @@ def get_type_adapter(f: type[T]) -> TypeAdapter[T]:
 
 
 if TYPE_CHECKING:
-    from msgspec import UNSET, Struct, UnsetType, convert  # pyright: ignore[reportAssignmentType,reportUnusedImport]
-else:
-    try:
-        from msgspec import UNSET, Struct, UnsetType, convert  # pyright: ignore[reportAssignmentType,reportUnusedImport]
+    from msgspec import UNSET, Struct, convert  # pyright: ignore[reportAssignmentType,reportUnusedImport]
+try:
+    from msgspec import (  # pyright: ignore[reportAssignmentType,reportUnusedImport]
+        UNSET,
+        Struct,
+        convert,
+    )
 
-        MSGSPEC_INSTALLED: Final[bool] = True
-    except ImportError:  # pragma: nocover
-        MSGSPEC_INSTALLED: Final[bool] = False  # type: ignore # pyright: ignore[reportConstantRedefinition,reportGeneralTypeIssues]  # noqa: PGH003
+    MSGSPEC_INSTALLED: Final[bool] = True
+except ImportError:  # pragma: nocover
+    MSGSPEC_INSTALLED: Final[bool] = False  # type: ignore # pyright: ignore[reportConstantRedefinition,reportGeneralTypeIssues]  # noqa: PGH003
 
 
 if TYPE_CHECKING:
     from litestar.dto.data_structures import DTOData  # pyright: ignore[reportAssignmentType,reportUnusedImport]
-else:
-    try:
-        from litestar.dto.data_structures import DTOData  # pyright: ignore[reportAssignmentType,reportUnusedImport]
+try:
+    from litestar.dto.data_structures import DTOData  # pyright: ignore[reportAssignmentType,reportUnusedImport]
 
-        LITESTAR_INSTALLED: Final[bool] = True
-    except ImportError:
-        LITESTAR_INSTALLED: Final[bool] = False  # type: ignore # pyright: ignore[reportConstantRedefinition,reportGeneralTypeIssues]  # noqa: PGH003
+    LITESTAR_INSTALLED: Final[bool] = True
+except ImportError:
+    LITESTAR_INSTALLED: Final[bool] = False  # type: ignore # pyright: ignore[reportConstantRedefinition,reportGeneralTypeIssues]  # noqa: PGH003
 
 FilterTypeT = TypeVar("FilterTypeT", bound="StatementFilter")
 ModelDTOT = TypeVar("ModelDTOT", bound="Struct | BaseModel")

--- a/advanced_alchemy/service/typing.py
+++ b/advanced_alchemy/service/typing.py
@@ -27,52 +27,29 @@ from advanced_alchemy.filters import StatementFilter  # noqa: TCH001
 from advanced_alchemy.repository.typing import ModelT
 
 T = TypeVar("T")  # pragma: nocover
-try:
+
+if TYPE_CHECKING:
     from pydantic import BaseModel  # pyright: ignore[reportAssignmentType]
     from pydantic.type_adapter import TypeAdapter  # pyright: ignore[reportUnusedImport, reportAssignmentType]
+else:
+    try:
+        from pydantic import BaseModel  # pyright: ignore[reportAssignmentType]
+        from pydantic.type_adapter import TypeAdapter  # pyright: ignore[reportUnusedImport, reportAssignmentType]
 
-    PYDANTIC_INSTALLED: Final[bool] = True
-except ImportError:  # pragma: nocover
+        PYDANTIC_INSTALLED: Final[bool] = True
+    except ImportError:  # pragma: nocover
+        PYDANTIC_INSTALLED: Final[bool] = False  # type: ignore # pyright: ignore[reportConstantRedefinition,reportGeneralTypeIssues]  # noqa: PGH003
 
-    @runtime_checkable
-    class BaseModel(Protocol):  # type: ignore[no-redef] # pragma: nocover
-        """Placeholder Implementation"""
-
-        model_fields: ClassVar[dict[str, Any]]
-
-        def model_dump(*args: Any, **kwargs: Any) -> dict[str, Any]:
-            """Placeholder"""
-            return {}
-
-    class TypeAdapter(Generic[T]):  # type: ignore[no-redef] # pragma: nocover
-        """Placeholder Implementation"""
-
-        def __init__(self, *args: Any, **kwargs: Any) -> None:  # pragma: nocover
-            """Init"""
-
-        def validate_python(self, data: Any, *args: Any, **kwargs: Any) -> T:  # pragma: nocover
-            """Stub"""
-            return cast("T", data)
-
-    PYDANTIC_INSTALLED: Final[bool] = False  # type: ignore # pyright: ignore[reportConstantRedefinition,reportGeneralTypeIssues]  # noqa: PGH003
-
-try:
-    # this is from pydantic 2.8.  We should check for it before using it.
+if TYPE_CHECKING:
     from pydantic import FailFast  # pyright: ignore[reportAssignmentType]
+else:
+    try:
+        # this is from pydantic 2.8.  We should check for it before using it.
+        from pydantic import FailFast  # pyright: ignore[reportAssignmentType]
 
-    PYDANTIC_USE_FAILFAST: Final[bool] = False
-except ImportError:
-
-    class FailFast:  # type: ignore[no-redef] # pragma: nocover
-        """Placeholder Implementation for FailFast"""
-
-        def __init__(self, *args: Any, **kwargs: Any) -> None:  # pragma: nocover
-            """Init"""
-
-        def __call__(self, *args: Any, **kwargs: Any) -> None:  # pragma: nocover
-            """Placeholder"""
-
-    PYDANTIC_USE_FAILFAST: Final[bool] = False  # type: ignore # pyright: ignore[reportConstantRedefinition,reportGeneralTypeIssues]  # noqa: PGH003
+        PYDANTIC_USE_FAILFAST: Final[bool] = True
+    except ImportError:
+        PYDANTIC_USE_FAILFAST: Final[bool] = False  # type: ignore # pyright: ignore[reportConstantRedefinition,reportGeneralTypeIssues]  # noqa: PGH003
 
 
 @lru_cache(typed=True)
@@ -85,51 +62,26 @@ def get_type_adapter(f: type[T]) -> TypeAdapter[T]:
     return TypeAdapter(f)
 
 
-try:
+if TYPE_CHECKING:
     from msgspec import UNSET, Struct, UnsetType, convert  # pyright: ignore[reportAssignmentType,reportUnusedImport]
+else:
+    try:
+        from msgspec import UNSET, Struct, UnsetType, convert  # pyright: ignore[reportAssignmentType,reportUnusedImport]
 
-    MSGSPEC_INSTALLED: Final[bool] = True
-except ImportError:  # pragma: nocover
-    import enum
+        MSGSPEC_INSTALLED: Final[bool] = True
+    except ImportError:  # pragma: nocover
+        MSGSPEC_INSTALLED: Final[bool] = False  # type: ignore # pyright: ignore[reportConstantRedefinition,reportGeneralTypeIssues]  # noqa: PGH003
 
-    @runtime_checkable
-    class Struct(Protocol):  # type: ignore[no-redef]
-        """Placeholder Implementation"""
 
-        __struct_fields__: ClassVar[tuple[str, ...]]
-
-    def convert(*args: Any, **kwargs: Any) -> Any:  # type: ignore[no-redef] # noqa: ARG001
-        """Placeholder implementation"""
-        return {}
-
-    class UnsetType(enum.Enum):  # type: ignore[no-redef] # pragma: nocover
-        UNSET = "UNSET"
-
-    UNSET = UnsetType.UNSET  # pyright: ignore[reportConstantRedefinition,reportGeneralTypeIssues]
-    MSGSPEC_INSTALLED: Final[bool] = False  # type: ignore # pyright: ignore[reportConstantRedefinition,reportGeneralTypeIssues]  # noqa: PGH003
-
-try:
+if TYPE_CHECKING:
     from litestar.dto.data_structures import DTOData  # pyright: ignore[reportAssignmentType,reportUnusedImport]
+else:
+    try:
+        from litestar.dto.data_structures import DTOData  # pyright: ignore[reportAssignmentType,reportUnusedImport]
 
-    LITESTAR_INSTALLED: Final[bool] = True
-except ImportError:
-
-    class DTOData(Generic[T]):  # type: ignore[no-redef] # pragma: nocover
-        """Placeholder implementation"""
-
-        def create_instance(*args: Any, **kwargs: Any) -> T:  # type: ignore[no-redef]
-            """Placeholder implementation"""
-            return cast("T", kwargs)
-
-        def update_instance(*args: Any, **kwargs: Any) -> T:  # type: ignore[no-redef]
-            """Placeholder implementation"""
-            return cast("T", kwargs)
-
-        def as_builtins(*args: Any, **kwargs: Any) -> dict[str, Any]:  # type: ignore[no-redef]
-            """Placeholder implementation"""
-            return {}
-
-    LITESTAR_INSTALLED: Final[bool] = False  # type: ignore # pyright: ignore[reportConstantRedefinition,reportGeneralTypeIssues]  # noqa: PGH003
+        LITESTAR_INSTALLED: Final[bool] = True
+    except ImportError:
+        LITESTAR_INSTALLED: Final[bool] = False  # type: ignore # pyright: ignore[reportConstantRedefinition,reportGeneralTypeIssues]  # noqa: PGH003
 
 FilterTypeT = TypeVar("FilterTypeT", bound="StatementFilter")
 ModelDTOT = TypeVar("ModelDTOT", bound="Struct | BaseModel")

--- a/advanced_alchemy/service/typing.py
+++ b/advanced_alchemy/service/typing.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 from collections.abc import Sequence
 from functools import lru_cache
 from typing import (
+    TYPE_CHECKING,
     Any,
     ClassVar,
     Dict,


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->

## Description

Fixes typing issues in service

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
## Closes

https://github.com/litestar-org/advanced-alchemy/issues/265

This still doesn't solve the problem of UnknownVariableType if the subtypes of ModelDictT are not installed (eg: Pydantic)
But at least it solves the problem of incompatibilities when they are installed
