### PR TITLE
fix: make sure `anyio` is optional

### DIFF
--- a/advanced_alchemy/service/_async.py
+++ b/advanced_alchemy/service/_async.py
@@ -25,7 +25,6 @@ from advanced_alchemy.repository._util import (
 from advanced_alchemy.repository.typing import ModelT, OrderingPair
 from advanced_alchemy.service._util import ResultConverter
 from advanced_alchemy.service.typing import (
-    UNSET,  # pyright: ignore[reportAttributeAccessIssue]
     BulkModelDictT,
     ModelDictListT,
     ModelDictT,
@@ -330,6 +329,8 @@ class SQLAlchemyAsyncRepositoryReadService(Generic[ModelT], ResultConverter):
             )
 
         if is_msgspec_model(data):
+            from msgspec import UNSET
+
             return model_from_dict(
                 model=self.repository.model_type,
                 **{f: val for f in data.__struct_fields__ if (val := getattr(data, f, None)) != UNSET},

--- a/advanced_alchemy/service/_sync.py
+++ b/advanced_alchemy/service/_sync.py
@@ -27,7 +27,6 @@ from advanced_alchemy.repository._util import (
 from advanced_alchemy.repository.typing import ModelT, OrderingPair
 from advanced_alchemy.service._util import ResultConverter
 from advanced_alchemy.service.typing import (
-    UNSET,  # pyright: ignore[reportAttributeAccessIssue]
     BulkModelDictT,
     ModelDictListT,
     ModelDictT,
@@ -331,6 +330,8 @@ class SQLAlchemySyncRepositoryReadService(Generic[ModelT], ResultConverter):
             )
 
         if is_msgspec_model(data):
+            from msgspec import UNSET
+
             return model_from_dict(
                 model=self.repository.model_type,
                 **{f: val for f in data.__struct_fields__ if (val := getattr(data, f, None)) != UNSET},

--- a/advanced_alchemy/utils/fixtures.py
+++ b/advanced_alchemy/utils/fixtures.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
-from pathlib import Path
-from typing import Any
-
-from anyio import Path as AsyncPath
+from typing import TYPE_CHECKING, Any
 
 from advanced_alchemy._serialization import decode_json
+from advanced_alchemy.exceptions import MissingDependencyError
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from anyio import Path as AsyncPath
 
 __all__ = ("open_fixture", "open_fixture_async")
 
@@ -23,6 +26,8 @@ def open_fixture(fixtures_path: Path | AsyncPath, fixture_name: str) -> Any:
     Returns:
         Any: The parsed JSON data
     """
+    from pathlib import Path
+
     fixture = Path(fixtures_path / f"{fixture_name}.json")
     if fixture.exists():
         with fixture.open(mode="r", encoding="utf-8") as f:
@@ -45,6 +50,12 @@ async def open_fixture_async(fixtures_path: Path | AsyncPath, fixture_name: str)
     Returns:
         Any: The parsed JSON data
     """
+    try:
+        from anyio import Path as AsyncPath
+    except ImportError as exc:
+        msg = "The `anyio` library is required to use this function. Please install it with `pip install anyio`."
+        raise MissingDependencyError(msg) from exc
+
     fixture = AsyncPath(fixtures_path / f"{fixture_name}.json")
     if await fixture.exists():
         async with await fixture.open(mode="r", encoding="utf-8") as f:


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

`anyio` is installed with nearly all web frameworks, so I'd prefer to not add it as a required dependency.

However, when running standalone, you would receive this exception for fixtures

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
## Closes
