### PR TITLE
feat(litestar): add default NotFoundError exception handler

### DIFF
--- a/advanced_alchemy/extensions/litestar/plugins/__init__.py
+++ b/advanced_alchemy/extensions/litestar/plugins/__init__.py
@@ -4,7 +4,9 @@ from typing import TYPE_CHECKING, Sequence
 
 from litestar.plugins import InitPluginProtocol
 
+from advanced_alchemy.exceptions import NotFoundError
 from advanced_alchemy.extensions.litestar.plugins import _slots_base
+from advanced_alchemy.extensions.litestar.plugins.exception_handlers import not_found_error_handler
 from advanced_alchemy.extensions.litestar.plugins.init import (
     EngineConfig,
     SQLAlchemyAsyncConfig,
@@ -44,6 +46,10 @@ class SQLAlchemyPlugin(InitPluginProtocol, _slots_base.SlotsBase):
             app_config: The :class:`AppConfig <.config.app.AppConfig>` instance.
         """
         app_config.plugins.extend([SQLAlchemyInitPlugin(config=self._config), SQLAlchemySerializationPlugin()])
+
+        if not app_config.exception_handlers.get(NotFoundError):
+            app_config.exception_handlers[NotFoundError] = not_found_error_handler
+
         return app_config
 
 

--- a/advanced_alchemy/extensions/litestar/plugins/exception_handlers.py
+++ b/advanced_alchemy/extensions/litestar/plugins/exception_handlers.py
@@ -1,0 +1,11 @@
+from litestar import MediaType, Request, Response
+
+from advanced_alchemy.exceptions import NotFoundError
+
+
+def not_found_error_handler(_request: Request, _exc: NotFoundError) -> Response:
+    return Response(
+        media_type=MediaType.JSON,
+        content={"detail": "Not Found", "status_code": 404},
+        status_code=404,
+    )


### PR DESCRIPTION

<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

Add a default exception handler for NotFoundError in the SQLAlchemyPlugin. The handler returns a standardized 404 response with JSON content.

The handler is automatically registered if no other handler for NotFoundError is configured.


<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
## Closes

#275 