### PR TITLE
feat: `AsyncAttrs` & remove `noload` default

### DIFF
--- a/advanced_alchemy/base.py
+++ b/advanced_alchemy/base.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 from uuid import UUID
 
 from sqlalchemy import Date, MetaData, String
+from sqlalchemy.ext.asyncio import AsyncAttrs
 from sqlalchemy.orm import (
     DeclarativeBase,
     Mapper,
@@ -296,19 +297,20 @@ def create_registry(
 orm_registry = create_registry()
 
 
-class UUIDBase(_UUIDPrimaryKey, CommonTableAttributes, DeclarativeBase):
+class UUIDBase(_UUIDPrimaryKey, CommonTableAttributes, DeclarativeBase, AsyncAttrs):
     """Base for all SQLAlchemy declarative models with UUID v4 primary keys.
 
     .. seealso::
         :class:`advanced_alchemy.mixins.UUIDPrimaryKey`
         :class:`CommonTableAttributes`
         :class:`DeclarativeBase`
+        :class:`AsyncAttrs`
     """
 
     registry = orm_registry
 
 
-class UUIDAuditBase(CommonTableAttributes, _UUIDPrimaryKey, _AuditColumns, DeclarativeBase):
+class UUIDAuditBase(CommonTableAttributes, _UUIDPrimaryKey, _AuditColumns, DeclarativeBase, AsyncAttrs):
     """Base for declarative models with UUID v4 primary keys and audit columns.
 
     .. seealso::
@@ -316,24 +318,26 @@ class UUIDAuditBase(CommonTableAttributes, _UUIDPrimaryKey, _AuditColumns, Decla
         :class:`advanced_alchemy.mixins.UUIDPrimaryKey`
         :class:`advanced_alchemy.mixins.AuditColumns`
         :class:`DeclarativeBase`
+        :class:`AsyncAttrs`
     """
 
     registry = orm_registry
 
 
-class UUIDv6Base(_UUIDv6PrimaryKey, CommonTableAttributes, DeclarativeBase):
+class UUIDv6Base(_UUIDv6PrimaryKey, CommonTableAttributes, DeclarativeBase, AsyncAttrs):
     """Base for all SQLAlchemy declarative models with UUID v6 primary keys.
 
     .. seealso::
         :class:`advanced_alchemy.mixins.UUIDv6PrimaryKey`
         :class:`CommonTableAttributes`
         :class:`DeclarativeBase`
+        :class:`AsyncAttrs`
     """
 
     registry = orm_registry
 
 
-class UUIDv6AuditBase(CommonTableAttributes, _UUIDv6PrimaryKey, _AuditColumns, DeclarativeBase):
+class UUIDv6AuditBase(CommonTableAttributes, _UUIDv6PrimaryKey, _AuditColumns, DeclarativeBase, AsyncAttrs):
     """Base for declarative models with UUID v6 primary keys and audit columns.
 
     .. seealso::
@@ -341,24 +345,26 @@ class UUIDv6AuditBase(CommonTableAttributes, _UUIDv6PrimaryKey, _AuditColumns, D
         :class:`advanced_alchemy.mixins.UUIDv6PrimaryKey`
         :class:`advanced_alchemy.mixins.AuditColumns`
         :class:`DeclarativeBase`
+        :class:`AsyncAttrs`
     """
 
     registry = orm_registry
 
 
-class UUIDv7Base(_UUIDv7PrimaryKey, CommonTableAttributes, DeclarativeBase):
+class UUIDv7Base(_UUIDv7PrimaryKey, CommonTableAttributes, DeclarativeBase, AsyncAttrs):
     """Base for all SQLAlchemy declarative models with UUID v7 primary keys.
 
     .. seealso::
         :class:`advanced_alchemy.mixins.UUIDv7PrimaryKey`
         :class:`CommonTableAttributes`
         :class:`DeclarativeBase`
+        :class:`AsyncAttrs`
     """
 
     registry = orm_registry
 
 
-class UUIDv7AuditBase(CommonTableAttributes, _UUIDv7PrimaryKey, _AuditColumns, DeclarativeBase):
+class UUIDv7AuditBase(CommonTableAttributes, _UUIDv7PrimaryKey, _AuditColumns, DeclarativeBase, AsyncAttrs):
     """Base for declarative models with UUID v7 primary keys and audit columns.
 
     .. seealso::
@@ -366,24 +372,26 @@ class UUIDv7AuditBase(CommonTableAttributes, _UUIDv7PrimaryKey, _AuditColumns, D
         :class:`advanced_alchemy.mixins.UUIDv7PrimaryKey`
         :class:`advanced_alchemy.mixins.AuditColumns`
         :class:`DeclarativeBase`
+        :class:`AsyncAttrs`
     """
 
     registry = orm_registry
 
 
-class NanoIDBase(_NanoIDPrimaryKey, CommonTableAttributes, DeclarativeBase):
+class NanoIDBase(_NanoIDPrimaryKey, CommonTableAttributes, DeclarativeBase, AsyncAttrs):
     """Base for all SQLAlchemy declarative models with Nano ID primary keys.
 
     .. seealso::
         :class:`advanced_alchemy.mixins.NanoIDPrimaryKey`
         :class:`CommonTableAttributes`
         :class:`DeclarativeBase`
+        :class:`AsyncAttrs`
     """
 
     registry = orm_registry
 
 
-class NanoIDAuditBase(CommonTableAttributes, _NanoIDPrimaryKey, _AuditColumns, DeclarativeBase):
+class NanoIDAuditBase(CommonTableAttributes, _NanoIDPrimaryKey, _AuditColumns, DeclarativeBase, AsyncAttrs):
     """Base for declarative models with Nano ID primary keys and audit columns.
 
     .. seealso::
@@ -391,24 +399,26 @@ class NanoIDAuditBase(CommonTableAttributes, _NanoIDPrimaryKey, _AuditColumns, D
         :class:`advanced_alchemy.mixins.NanoIDPrimaryKey`
         :class:`advanced_alchemy.mixins.AuditColumns`
         :class:`DeclarativeBase`
+        :class:`AsyncAttrs`
     """
 
     registry = orm_registry
 
 
-class BigIntBase(_BigIntPrimaryKey, CommonTableAttributes, DeclarativeBase):
+class BigIntBase(_BigIntPrimaryKey, CommonTableAttributes, DeclarativeBase, AsyncAttrs):
     """Base for all SQLAlchemy declarative models with BigInt primary keys.
 
     .. seealso::
         :class:`advanced_alchemy.mixins.BigIntPrimaryKey`
         :class:`CommonTableAttributes`
         :class:`DeclarativeBase`
+        :class:`AsyncAttrs`
     """
 
     registry = orm_registry
 
 
-class BigIntAuditBase(CommonTableAttributes, _BigIntPrimaryKey, _AuditColumns, DeclarativeBase):
+class BigIntAuditBase(CommonTableAttributes, _BigIntPrimaryKey, _AuditColumns, DeclarativeBase, AsyncAttrs):
     """Base for declarative models with BigInt primary keys and audit columns.
 
     .. seealso::
@@ -416,28 +426,31 @@ class BigIntAuditBase(CommonTableAttributes, _BigIntPrimaryKey, _AuditColumns, D
         :class:`advanced_alchemy.mixins.BigIntPrimaryKey`
         :class:`advanced_alchemy.mixins.AuditColumns`
         :class:`DeclarativeBase`
+        :class:`AsyncAttrs`
     """
 
     registry = orm_registry
 
 
-class DefaultBase(CommonTableAttributes, DeclarativeBase):
+class DefaultBase(CommonTableAttributes, DeclarativeBase, AsyncAttrs):
     """Base for all SQLAlchemy declarative models.  No primary key is added.
 
     .. seealso::
         :class:`CommonTableAttributes`
         :class:`DeclarativeBase`
+        :class:`AsyncAttrs`
     """
 
     registry = orm_registry
 
 
-class SQLQuery(BasicAttributes, DeclarativeBase):
+class SQLQuery(BasicAttributes, DeclarativeBase, AsyncAttrs):
     """Base for all SQLAlchemy custom mapped objects.
 
     .. seealso::
         :class:`BasicAttributes`
         :class:`DeclarativeBase`
+        :class:`AsyncAttrs`
     """
 
     __allow_unmapped__ = True

--- a/advanced_alchemy/repository/_util.py
+++ b/advanced_alchemy/repository/_util.py
@@ -5,7 +5,14 @@ from typing import TYPE_CHECKING, Any, Iterable, Literal, Protocol, Sequence, Un
 from sqlalchemy import (
     Select,
 )
-from sqlalchemy.orm import InstrumentedAttribute, MapperProperty, RelationshipProperty, joinedload, noload, selectinload
+from sqlalchemy.orm import (
+    InstrumentedAttribute,
+    MapperProperty,
+    RelationshipProperty,
+    joinedload,
+    lazyload,
+    selectinload,
+)
 from sqlalchemy.orm.strategy_options import (
     _AbstractLoad,  # pyright: ignore[reportPrivateUsage]  # pyright: ignore[reportPrivateUsage]
 )
@@ -133,7 +140,7 @@ def get_abstract_loader_options(
     """
     loads: list[_AbstractLoad] = []
     if cycle_count == 0 and not inherit_lazy_relationships:
-        loads.append(noload("*"))
+        loads.append(lazyload("*"))
     if cycle_count == 0 and merge_with_default and default_loader_options is not None:
         loads.extend(default_loader_options)
     options_have_wildcards = default_options_have_wildcards

--- a/uv.lock
+++ b/uv.lock
@@ -1300,16 +1300,16 @@ wheels = [
 
 [[package]]
 name = "fastapi"
-version = "0.115.5"
+version = "0.115.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
     { name = "starlette" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ae/29/f71316b9273b6552a263748e49cd7b83898dc9499a663d30c7b9cb853cb8/fastapi-0.115.5.tar.gz", hash = "sha256:0e7a4d0dc0d01c68df21887cce0945e72d3c48b9f4f79dfe7a7d53aa08fbb289", size = 301047 }
+sdist = { url = "https://files.pythonhosted.org/packages/93/72/d83b98cd106541e8f5e5bfab8ef2974ab45a62e8a6c5b5e6940f26d2ed4b/fastapi-0.115.6.tar.gz", hash = "sha256:9ec46f7addc14ea472958a96aae5b5de65f39721a46aaf5705c480d9a8b76654", size = 301336 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/54/c4/148d5046a96c428464557264877ae5a9338a83bbe0df045088749ec89820/fastapi-0.115.5-py3-none-any.whl", hash = "sha256:596b95adbe1474da47049e802f9a65ab2ffa9c2b07e7efee70eb8a66c9f2f796", size = 94866 },
+    { url = "https://files.pythonhosted.org/packages/52/b3/7e4df40e585df024fac2f80d1a2d579c854ac37109675db2b0cc22c0bb9e/fastapi-0.115.6-py3-none-any.whl", hash = "sha256:e9240b29e36fa8f4bb7290316988e90c381e5092e0cbe84e7818cc3713bcf305", size = 94843 },
 ]
 
 [package.optional-dependencies]
@@ -2031,14 +2031,14 @@ wheels = [
 
 [[package]]
 name = "mako"
-version = "1.3.6"
+version = "1.3.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markupsafe" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fa/0b/29bc5a230948bf209d3ed3165006d257e547c02c3c2a96f6286320dfe8dc/mako-1.3.6.tar.gz", hash = "sha256:9ec3a1583713479fae654f83ed9fa8c9a4c16b7bb0daba0e6bbebff50c0d983d", size = 390206 }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/27/5af876b41cebd9d76fa8333b83ef9121726893f725952022edd194a1671e/mako-1.3.7.tar.gz", hash = "sha256:20405b1232e0759f0e7d87b01f6bb94fce0761747f1cb876ecf90bd512d0b639", size = 392052 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/48/22/bc14c6f02e6dccaafb3eba95764c8f096714260c2aa5f76f654fd16a23dd/Mako-1.3.6-py3-none-any.whl", hash = "sha256:a91198468092a2f1a0de86ca92690fb0cfc43ca90ee17e15d93662b4c04b241a", size = 78557 },
+    { url = "https://files.pythonhosted.org/packages/a7/d8/c516e830071b849ad60ee1026315bb8566381ac648ac8bda314569b4b7e2/Mako-1.3.7-py3-none-any.whl", hash = "sha256:d18f990ad57f800ce8e76cbfb0b74afe471c293517e9f5003ace6dad5aa72c36", size = 78949 },
 ]
 
 [[package]]
@@ -2845,16 +2845,16 @@ wheels = [
 
 [[package]]
 name = "pydantic"
-version = "2.10.2"
+version = "2.10.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-types" },
     { name = "pydantic-core" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/41/86/a03390cb12cf64e2a8df07c267f3eb8d5035e0f9a04bb20fb79403d2a00e/pydantic-2.10.2.tar.gz", hash = "sha256:2bc2d7f17232e0841cbba4641e65ba1eb6fafb3a08de3a091ff3ce14a197c4fa", size = 785401 }
+sdist = { url = "https://files.pythonhosted.org/packages/45/0f/27908242621b14e649a84e62b133de45f84c255eecb350ab02979844a788/pydantic-2.10.3.tar.gz", hash = "sha256:cb5ac360ce894ceacd69c403187900a02c4b20b693a9dd1d643e1effab9eadf9", size = 786486 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d5/74/da832196702d0c56eb86b75bfa346db9238617e29b0b7ee3b8b4eccfe654/pydantic-2.10.2-py3-none-any.whl", hash = "sha256:cfb96e45951117c3024e6b67b25cdc33a3cb7b2fa62e239f7af1378358a1d99e", size = 456364 },
+    { url = "https://files.pythonhosted.org/packages/62/51/72c18c55cf2f46ff4f91ebcc8f75aa30f7305f3d726be3f4ebffb4ae972b/pydantic-2.10.3-py3-none-any.whl", hash = "sha256:be04d85bbc7b65651c5f8e6b9976ed9c6f41782a55524cef079a34a0bb82144d", size = 456997 },
 ]
 
 [[package]]
@@ -4258,7 +4258,7 @@ wheels = [
 
 [[package]]
 name = "typer"
-version = "0.14.0"
+version = "0.15.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
@@ -4266,9 +4266,9 @@ dependencies = [
     { name = "shellingham" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0d/7e/24af5b9aaa0872f9f6dc5dcf789dc3e57ceb23b4c570b852cd4db0d98f14/typer-0.14.0.tar.gz", hash = "sha256:af58f737f8d0c0c37b9f955a6d39000b9ff97813afcbeef56af5e37cf743b45a", size = 98836 }
+sdist = { url = "https://files.pythonhosted.org/packages/69/82/5bb5c124bcb7b7f14006791b172df0d731cbd10b377bb336685e7ebf0166/typer-0.15.0.tar.gz", hash = "sha256:8995452a598922ed8d8ad8c06ca63a218881ab601f5fa6fb0c511f7776497c7e", size = 99794 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bb/d8/a3ab71d5587b42b832a7ef2e65b3e51a18f8da32b6ce169637d4d21995ed/typer-0.14.0-py3-none-any.whl", hash = "sha256:f476233a25770ab3e7b2eebf7c68f3bc702031681a008b20167573a4b7018f09", size = 44707 },
+    { url = "https://files.pythonhosted.org/packages/e9/88/9ba31984811331d55bd384c603cdad189b3503c6c8e66366064f10983f3f/typer-0.15.0-py3-none-any.whl", hash = "sha256:bd16241db7e0f989ce1a0d8faa5aa1e43b9b9ac3fd1d4b8bcff91503d6717e38", size = 44733 },
 ]
 
 [[package]]


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

This PR adds the `AsyncAttrs` to the default delarative bases for convenience.

It also changes the `inherit_lazy_relationships == False` behvaior to use `lazyload`.  SQLAlchemy will be deprecating `noload` in version 2.1 

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
## Closes
