### PR TITLE
feat: `litestar` DTO enhancements

### DIFF
--- a/advanced_alchemy/extensions/litestar/dto.py
+++ b/advanced_alchemy/extensions/litestar/dto.py
@@ -96,12 +96,18 @@ class SQLAlchemyDTOConfig(DTOConfig):
     """
 
     def __post_init__(self) -> None:
-        self.exclude = {f.key if isinstance(f, InstrumentedAttribute) else f for f in self.exclude}  # type: ignore[misc]
-        self.include = {f.key if isinstance(f, InstrumentedAttribute) else f for f in self.include}  # type: ignore[misc]
-        self.rename_fields = {  # type: ignore[misc]
-            f.key if isinstance(f, InstrumentedAttribute) else f: v for f, v in self.rename_fields.items()
-        }
         super().__post_init__()
+        object.__setattr__(
+            self, "exclude", {f.key if isinstance(f, InstrumentedAttribute) else f for f in self.exclude}
+        )
+        object.__setattr__(
+            self, "include", {f.key if isinstance(f, InstrumentedAttribute) else f for f in self.include}
+        )
+        object.__setattr__(
+            self,
+            "rename_fields",
+            {f.key if isinstance(f, InstrumentedAttribute) else f: v for f, v in self.rename_fields.items()},
+        )
 
 
 class SQLAlchemyDTO(AbstractDTO[T], Generic[T]):

--- a/tests/unit/test_extensions/test_litestar/test_dto.py
+++ b/tests/unit/test_extensions/test_litestar/test_dto.py
@@ -689,10 +689,11 @@ class Base(DeclarativeBase):
     id: Mapped[int] = mapped_column(primary_key=True)
 
 class Child(Base):
-    ...
+    __tablename__ = "child"
+    test_model_id: Mapped[int] = mapped_column(ForeignKey("test_model.id"))
 
 class TestModel(Base):
-    child_id: Mapped[int] = mapped_column(ForeignKey("child.id"))
+    __tablename__ = "test_model"
     child: WriteOnlyMapped[Child] = relationship(Child)
 
 dto_type = SQLAlchemyDTO[Annotated[TestModel, SQLAlchemyDTOConfig()]]
@@ -700,9 +701,9 @@ dto_type = SQLAlchemyDTO[Annotated[TestModel, SQLAlchemyDTOConfig()]]
     )
     model = await get_model_from_dto(
         module.dto_type,
-        module.B,
+        module.TestModel,
         asgi_connection,
-        b'{"id": 2, "child_id": 1, "child": {"id": 1}}',
+        b'{"id": 2, "child": {"id": 1, "test_model_id": 2}}',
     )
     assert isinstance(model, module.TestModel)
-    assert isinstance(model.child, module.Child)
+    assert isinstance(model.child.instance, module.Child)


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

The Litestar DTO has been enhanced with:
- The SQLAlchemyDTOConfig's `exclude`, `include`, and `rename_fields` fields will now accept string or `InstrumentedAttributes`
- DTO supports `WriteOnlyMapped` and `DynamicMapped`

Closes #306 and #250 

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
## Closes
