### PR TITLE
docs: update color theme to match litestar

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -188,6 +188,7 @@ html_context = {
 
 html_theme_options = {
     "logo_target": "/",
+    "accent_color": "amber",
     "github_url": "https://github.com/litestar-org/advanced-alchemy",
     "navigation_with_keys": True,
     "globaltoc_expand_depth": 2,


### PR DESCRIPTION
Changed the default color of shibuya (purple) to amber to match Litestar color.

However, its the default color defined by Shibuya, maybe we have somewhere the colors used by the Litestar repo?

