### PR TITLE
fix: fully qualify all `datetime` module references

### DIFF
--- a/advanced_alchemy/_listeners.py
+++ b/advanced_alchemy/_listeners.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+import datetime
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
@@ -22,4 +22,4 @@ def touch_updated_timestamp(session: Session, *_: Any) -> None:
     """
     for instance in session.dirty:
         if hasattr(instance, "updated_at"):
-            instance.updated_at = datetime.now(timezone.utc)
+            instance.updated_at = datetime.datetime.now(datetime.timezone.utc)

--- a/advanced_alchemy/base.py
+++ b/advanced_alchemy/base.py
@@ -4,8 +4,8 @@
 from __future__ import annotations
 
 import contextlib
+import datetime
 import re
-from datetime import date, datetime
 from typing import TYPE_CHECKING, Any, Iterator, Optional, Protocol, cast, runtime_checkable
 from uuid import UUID
 
@@ -286,8 +286,8 @@ def create_registry(
     type_annotation_map: dict[Any, type[TypeEngine[Any]] | TypeEngine[Any]] = {
         UUID: GUID,
         core_uuid.UUID: GUID,
-        datetime: DateTimeUTC,
-        date: Date,
+        datetime.datetime: DateTimeUTC,
+        datetime.date: Date,
         dict: JsonB,
         DataclassProtocol: JsonB,
     }

--- a/advanced_alchemy/filters.py
+++ b/advanced_alchemy/filters.py
@@ -11,13 +11,13 @@ Features:
 Example:
     Basic usage with a datetime filter::
 
-        from datetime import datetime
+        import datetime
         from advanced_alchemy.filters import BeforeAfter
 
         filter = BeforeAfter(
             field_name="created_at",
-            before=datetime.now(),
-            after=datetime(2023, 1, 1),
+            before=datetime.datetime.now(),
+            after=datetime.datetime(2023, 1, 1),
         )
         statement = filter.append_to_statement(select(Model), Model)
 
@@ -34,10 +34,10 @@ See Also:
 
 from __future__ import annotations
 
+import datetime  # noqa: TC003
 from abc import ABC, abstractmethod
 from collections import abc  # noqa: TC003
 from dataclasses import dataclass
-from datetime import datetime  # noqa: TC003
 from operator import attrgetter
 from typing import TYPE_CHECKING, Any, Generic, Literal, cast
 
@@ -153,9 +153,9 @@ class BeforeAfter(StatementFilter):
 
     field_name: str
     """Name of the model attribute to filter on."""
-    before: datetime | None
+    before: datetime.datetime | None
     """Filter results where field is earlier than this value."""
-    after: datetime | None
+    after: datetime.datetime | None
     """Filter results where field is later than this value."""
 
     def append_to_statement(self, statement: StatementTypeT, model: type[ModelT]) -> StatementTypeT:
@@ -199,9 +199,9 @@ class OnBeforeAfter(StatementFilter):
 
     field_name: str
     """Name of the model attribute to filter on."""
-    on_or_before: datetime | None
+    on_or_before: datetime.datetime | None
     """Filter results where field is on or earlier than this value."""
-    on_or_after: datetime | None
+    on_or_after: datetime.datetime | None
     """Filter results where field is on or later than this value."""
 
     def append_to_statement(self, statement: StatementTypeT, model: type[ModelT]) -> StatementTypeT:

--- a/advanced_alchemy/mixins/audit.py
+++ b/advanced_alchemy/mixins/audit.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import datetime, timezone
+import datetime
 
 from sqlalchemy.orm import Mapped, declarative_mixin, mapped_column, validates
 
@@ -11,20 +11,20 @@ from advanced_alchemy.types import DateTimeUTC
 class AuditColumns:
     """Created/Updated At Fields Mixin."""
 
-    created_at: Mapped[datetime] = mapped_column(
+    created_at: Mapped[datetime.datetime] = mapped_column(
         DateTimeUTC(timezone=True),
-        default=lambda: datetime.now(timezone.utc),
+        default=lambda: datetime.datetime.now(datetime.timezone.utc),
     )
     """Date/time of instance creation."""
-    updated_at: Mapped[datetime] = mapped_column(
+    updated_at: Mapped[datetime.datetime] = mapped_column(
         DateTimeUTC(timezone=True),
-        default=lambda: datetime.now(timezone.utc),
-        onupdate=lambda: datetime.now(timezone.utc),
+        default=lambda: datetime.datetime.now(datetime.timezone.utc),
+        onupdate=lambda: datetime.datetime.now(datetime.timezone.utc),
     )
     """Date/time of instance last update."""
 
     @validates("created_at", "updated_at")
-    def validate_tz_info(self, _: str, value: datetime) -> datetime:
+    def validate_tz_info(self, _: str, value: datetime.datetime) -> datetime.datetime:
         if value.tzinfo is None:
-            value = value.replace(tzinfo=timezone.utc)
+            value = value.replace(tzinfo=datetime.timezone.utc)
         return value

--- a/advanced_alchemy/repository/memory/_async.py
+++ b/advanced_alchemy/repository/memory/_async.py
@@ -40,9 +40,9 @@ from advanced_alchemy.utils.dataclass import Empty, EmptyType
 from advanced_alchemy.utils.text import slugify
 
 if TYPE_CHECKING:
+    import datetime
     from collections import abc
     from collections.abc import Iterable
-    from datetime import datetime
 
     from sqlalchemy.ext.asyncio import AsyncSession
     from sqlalchemy.ext.asyncio.scoping import async_scoped_session
@@ -231,14 +231,14 @@ class SQLAlchemyAsyncMockRepository(SQLAlchemyAsyncRepositoryProtocol[ModelT]):
         self,
         result: list[ModelT],
         field_name: str,
-        before: datetime | None = None,
-        after: datetime | None = None,
-        on_or_before: datetime | None = None,
-        on_or_after: datetime | None = None,
+        before: datetime.datetime | None = None,
+        after: datetime.datetime | None = None,
+        on_or_before: datetime.datetime | None = None,
+        on_or_after: datetime.datetime | None = None,
     ) -> list[ModelT]:
         result_: list[ModelT] = []
         for item in result:
-            attr: datetime = getattr(item, field_name)
+            attr: datetime.datetime = getattr(item, field_name)
             if before is not None and attr < before:
                 result_.append(item)
             if after is not None and attr > after:

--- a/advanced_alchemy/repository/memory/_sync.py
+++ b/advanced_alchemy/repository/memory/_sync.py
@@ -42,9 +42,9 @@ from advanced_alchemy.utils.dataclass import Empty, EmptyType
 from advanced_alchemy.utils.text import slugify
 
 if TYPE_CHECKING:
+    import datetime
     from collections import abc
     from collections.abc import Iterable
-    from datetime import datetime
 
     from sqlalchemy.orm.scoping import scoped_session
     from sqlalchemy.orm.strategy_options import _AbstractLoad  # pyright: ignore[reportPrivateUsage]
@@ -232,14 +232,14 @@ class SQLAlchemySyncMockRepository(SQLAlchemySyncRepositoryProtocol[ModelT]):
         self,
         result: list[ModelT],
         field_name: str,
-        before: datetime | None = None,
-        after: datetime | None = None,
-        on_or_before: datetime | None = None,
-        on_or_after: datetime | None = None,
+        before: datetime.datetime | None = None,
+        after: datetime.datetime | None = None,
+        on_or_before: datetime.datetime | None = None,
+        on_or_after: datetime.datetime | None = None,
     ) -> list[ModelT]:
         result_: list[ModelT] = []
         for item in result:
-            attr: datetime = getattr(item, field_name)
+            attr: datetime.datetime = getattr(item, field_name)
             if before is not None and attr < before:
                 result_.append(item)
             if after is not None and attr > after:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -2,9 +2,9 @@
 # ruff: noqa: FIX002 PLR0911 ARG001 ERA001
 from __future__ import annotations
 
+import datetime
 import os
 import warnings
-from datetime import datetime
 from functools import partial
 from typing import TYPE_CHECKING, Any
 
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
 warnings.filterwarnings("ignore", category=SAWarning)
 
 # -- Project information -----------------------------------------------------
-current_year = datetime.now().year  # noqa: DTZ005
+current_year = datetime.datetime.now().year  # noqa: DTZ005
 project = __project__
 copyright = f"{current_year}, Litestar Organization"  # noqa: A001
 release = os.getenv("_ADVANCED-ALCHEMY_DOCS_BUILD_VERSION", __version__.rsplit(".")[0])

--- a/docs/usage/frameworks/fastapi.rst
+++ b/docs/usage/frameworks/fastapi.rst
@@ -45,7 +45,7 @@ Define your SQLAlchemy models and Pydantic schemas:
 
 .. code-block:: python
 
-    from datetime import date
+    import datetime
     from uuid import UUID
     from sqlalchemy import ForeignKey
     from sqlalchemy.orm import Mapped, mapped_column, relationship
@@ -71,15 +71,15 @@ Define your SQLAlchemy models and Pydantic schemas:
     class Author(BaseModel):
         id: UUID | None
         name: str
-        dob: date | None = None
+        dob: datetime.date | None = None
 
     class AuthorCreate(BaseModel):
         name: str
-        dob: date | None = None
+        dob: datetime.date | None = None
 
     class AuthorUpdate(BaseModel):
         name: str | None = None
-        dob: date | None = None
+        dob: datetime.date | None = None
 
 Repository and Service
 ----------------------

--- a/docs/usage/frameworks/litestar.rst
+++ b/docs/usage/frameworks/litestar.rst
@@ -44,7 +44,7 @@ Define your SQLAlchemy models using Advanced Alchemy's enhanced base classes:
 
 .. code-block:: python
 
-    from datetime import date
+    import datetime
     from uuid import UUID
     from sqlalchemy import ForeignKey
     from sqlalchemy.orm import Mapped, mapped_column, relationship
@@ -54,7 +54,7 @@ Define your SQLAlchemy models using Advanced Alchemy's enhanced base classes:
     class AuthorModel(UUIDBase):
         __tablename__ = "author"
         name: Mapped[str]
-        dob: Mapped[date | None]
+        dob: Mapped[datetime.date | None]
         books: Mapped[list[BookModel]] = relationship(back_populates="author", lazy="selectin")
 
     class BookModel(UUIDAuditBase):
@@ -70,7 +70,7 @@ Define Pydantic schemas for input validation and response serialization:
 
 .. code-block:: python
 
-    from datetime import date
+    import datetime
     from pydantic import BaseModel, ConfigDict
     from uuid import UUID
     from typing import Optional
@@ -83,17 +83,17 @@ Define Pydantic schemas for input validation and response serialization:
         """Author response schema."""
         id: UUID
         name: str
-        dob: Optional[date] = None
+        dob: Optional[datetime.date] = None
 
     class AuthorCreate(BaseSchema):
         """Schema for creating authors."""
         name: str
-        dob: Optional[date] = None
+        dob: Optional[datetime.date] = None
 
     class AuthorUpdate(BaseSchema):
         """Schema for updating authors."""
         name: Optional[str] = None
-        dob: Optional[date] = None
+        dob: Optional[datetime.date] = None
 
     class Book(BaseSchema):
         """Book response schema with author details."""

--- a/docs/usage/modeling.rst
+++ b/docs/usage/modeling.rst
@@ -66,7 +66,7 @@ Let's start with a simple blog post model:
 
     from advanced_alchemy.base import BigIntAuditBase
     from sqlalchemy.orm import Mapped, mapped_column
-    from datetime import datetime
+    import datetime
     from typing import Optional
 
     class Post(BigIntAuditBase):
@@ -83,7 +83,7 @@ Let's start with a simple blog post model:
         title: Mapped[str] = mapped_column(index=True)
         content: Mapped[str]
         published: Mapped[bool] = mapped_column(default=False)
-        published_at: Mapped[Optional[datetime]] = mapped_column(default=None)
+        published_at: Mapped[Optional[datetime.datetime]] = mapped_column(default=None)
 
 Many-to-Many Relationships
 --------------------------
@@ -253,7 +253,7 @@ Here's an example showing a class to generate a server-side UUID primary key for
 
 .. code-block:: python
 
-    from datetime import datetime
+    import datetime
     from uuid import UUID, uuid4
 
     from advanced_alchemy.base import CommonTableAttributes, orm_registry
@@ -294,7 +294,7 @@ Here's an example showing a class to generate a server-side UUID primary key for
         email: Mapped[str] = mapped_column(unique=True)
         full_name: Mapped[str]
         is_active: Mapped[bool] = mapped_column(default=True)
-        last_login: Mapped[datetime | None] = mapped_column(default=None)
+        last_login: Mapped[datetime.datetime | None] = mapped_column(default=None)
 
 
 With this foundation in place, let's look at the repository pattern.

--- a/docs/usage/repositories.rst
+++ b/docs/usage/repositories.rst
@@ -84,7 +84,7 @@ Advanced Alchemy provides powerful filtering capabilities:
 
 .. code-block:: python
 
-    from datetime import datetime, timedelta
+    import datetime
 
     async def get_recent_posts(session: AsyncSession) -> list[Post]:
         repository = PostRepository(session=session)
@@ -92,7 +92,7 @@ Advanced Alchemy provides powerful filtering capabilities:
         # Create filter for posts from last week
         return await repository.list(
             Post.published == True,
-            Post.created_at > (datetime.utcnow() - timedelta(days=7))
+            Post.created_at > (datetime.datetime.utcnow() - timedelta(days=7))
         )
 
 Pagination

--- a/docs/usage/services.rst
+++ b/docs/usage/services.rst
@@ -27,7 +27,7 @@ Let's build upon our blog example by creating services for posts and tags:
 
     from advanced_alchemy.service import SQLAlchemyAsyncRepositoryService
     from pydantic import BaseModel
-    from datetime import datetime
+    import datetime
     from typing import Optional, List
     from uuid import UUID
 
@@ -47,9 +47,9 @@ Let's build upon our blog example by creating services for posts and tags:
         title: str
         content: str
         published: bool
-        published_at: Optional[datetime]
-        created_at: datetime
-        updated_at: datetime
+        published_at: Optional[datetime.datetime]
+        created_at: datetime.datetime
+        updated_at: datetime.datetime
         tags: List["TagResponse"]
 
         model_config = {"from_attributes": True}
@@ -200,7 +200,7 @@ Services can handle complex business logic involving multiple repositories:
             """Publish or unpublish a post with timestamp."""
             data = PostUpdate(
                 published=publish,
-                published_at=datetime.utcnow() if publish else None,
+                published_at=datetime.datetime.utcnow() if publish else None,
             )
             post = await self.post_service.update(
                 item_id=post_id,
@@ -217,7 +217,7 @@ Services can handle complex business logic involving multiple repositories:
             """Get trending posts based on view count and recency."""
             posts = await self.post_service.list(
                 Post.published == True,
-                Post.created_at > (datetime.utcnow() - timedelta(days=days)),
+                Post.created_at > (datetime.datetime.utcnow() - timedelta(days=days)),
                 Post.view_count >= min_views,
                 order_by=[Post.view_count.desc()],
             )

--- a/examples/fastapi.py
+++ b/examples/fastapi.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
+import datetime  # noqa: TC003
 from contextlib import asynccontextmanager
-from datetime import date  # noqa: TC003
 from typing import AsyncGenerator, List
 from uuid import UUID  # noqa: TC003
 
@@ -36,7 +36,7 @@ class AuthorModel(UUIDBase):
     # we can optionally provide the table name instead of auto-generating it
     __tablename__ = "author"
     name: Mapped[str]
-    dob: Mapped[date | None]
+    dob: Mapped[datetime.date | None]
     books: Mapped[List[BookModel]] = relationship(back_populates="author", lazy="noload")  # noqa: UP006
 
 
@@ -56,17 +56,17 @@ class BookModel(UUIDAuditBase):
 class Author(BaseModel):
     id: UUID | None
     name: str
-    dob: date | None = None
+    dob: datetime.date | None = None
 
 
 class AuthorCreate(BaseModel):
     name: str
-    dob: date | None = None
+    dob: datetime.date | None = None
 
 
 class AuthorUpdate(BaseModel):
     name: str | None = None
-    dob: date | None = None
+    dob: datetime.date | None = None
 
 
 class AuthorRepository(SQLAlchemyAsyncRepository[AuthorModel]):

--- a/examples/litestar/litestar_repo_only.py
+++ b/examples/litestar/litestar_repo_only.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import date  # noqa: TC003
+import datetime  # noqa: TC003
 from typing import TYPE_CHECKING, List, Optional
 from uuid import UUID  # noqa: TC003
 
@@ -37,7 +37,7 @@ class AuthorModel(UUIDBase):
     # we can optionally provide the table name instead of auto-generating it
     __tablename__ = "author"
     name: Mapped[str]
-    dob: Mapped[Optional[date]]  # noqa: UP007
+    dob: Mapped[Optional[datetime.date]]  # noqa: UP007
     books: Mapped[List[BookModel]] = relationship(back_populates="author", lazy="noload")  # noqa: UP006
 
 
@@ -57,17 +57,17 @@ class BookModel(UUIDAuditBase):
 class Author(BaseModel):
     id: UUID | None
     name: str
-    dob: date | None = None
+    dob: datetime.date | None = None
 
 
 class AuthorCreate(BaseModel):
     name: str
-    dob: date | None = None
+    dob: datetime.date | None = None
 
 
 class AuthorUpdate(BaseModel):
     name: str | None = None
-    dob: date | None = None
+    dob: datetime.date | None = None
 
 
 class AuthorRepository(SQLAlchemyAsyncRepository[AuthorModel]):

--- a/examples/litestar/litestar_service.py
+++ b/examples/litestar/litestar_service.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import date  # noqa: TC003
+import datetime  # noqa: TC003
 from typing import TYPE_CHECKING, AsyncGenerator, List, Optional
 from uuid import UUID  # noqa: TC003
 
@@ -39,7 +39,7 @@ class AuthorModel(UUIDBase):
     # we can optionally provide the table name instead of auto-generating it
     __tablename__ = "author"
     name: Mapped[str]
-    dob: Mapped[Optional[date]]  # noqa: UP007
+    dob: Mapped[Optional[datetime.date]]  # noqa: UP007
     books: Mapped[List[BookModel]] = relationship(back_populates="author", lazy="noload")  # noqa: UP006
 
 
@@ -59,17 +59,17 @@ class BookModel(UUIDAuditBase):
 class Author(BaseModel):
     id: UUID | None
     name: str
-    dob: date | None = None
+    dob: datetime.date | None = None
 
 
 class AuthorCreate(BaseModel):
     name: str
-    dob: date | None = None
+    dob: datetime.date | None = None
 
 
 class AuthorUpdate(BaseModel):
     name: str | None = None
-    dob: date | None = None
+    dob: datetime.date | None = None
 
 
 class AuthorRepository(SQLAlchemyAsyncRepository[AuthorModel]):

--- a/examples/sanic.py
+++ b/examples/sanic.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import date  # noqa: TC003
+import datetime  # noqa: TC003
 from typing import Any, List
 from uuid import UUID  # noqa: TC003
 
@@ -23,7 +23,7 @@ class AuthorModel(UUIDBase):
     # we can optionally provide the table name instead of auto-generating it
     __tablename__ = "author"
     name: Mapped[str]
-    dob: Mapped[date | None]
+    dob: Mapped[datetime.date | None]
     books: Mapped[List[BookModel]] = relationship(back_populates="author", lazy="noload")  # noqa: UP006
 
 

--- a/tests/fixtures/bigint/models.py
+++ b/tests/fixtures/bigint/models.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import date, datetime
+import datetime
 from typing import List
 
 from sqlalchemy import Column, FetchedValue, ForeignKey, String, Table, func
@@ -20,7 +20,7 @@ class BigIntAuthor(BigIntAuditBase):
 
     name: Mapped[str] = mapped_column(String(length=100))
     string_field: Mapped[str] = mapped_column(String(20), default="static value", nullable=True)
-    dob: Mapped[date] = mapped_column(nullable=True)
+    dob: Mapped[datetime.date] = mapped_column(nullable=True)
     books: Mapped[List[BigIntBook]] = relationship(
         lazy="selectin",
         back_populates="author",
@@ -58,7 +58,7 @@ class BigIntSlugBook(BigIntBase, SlugKey):
 class BigIntEventLog(BigIntAuditBase):
     """The event log domain object."""
 
-    logged_at: Mapped[datetime] = mapped_column(default=datetime.now())  # pyright: ignore
+    logged_at: Mapped[datetime.datetime] = mapped_column(default=datetime.datetime.now())  # pyright: ignore
     payload: Mapped[dict] = mapped_column(default=lambda: {})  # pyright: ignore
 
 
@@ -66,7 +66,7 @@ class BigIntModelWithFetchedValue(BigIntBase):
     """The ModelWithFetchedValue BigIntBase."""
 
     val: Mapped[int]  # pyright: ignore
-    updated: Mapped[datetime] = mapped_column(  # pyright: ignore
+    updated: Mapped[datetime.datetime] = mapped_column(  # pyright: ignore
         server_default=func.current_timestamp(),
         onupdate=func.current_timestamp(),
         server_onupdate=FetchedValue(),

--- a/tests/fixtures/uuid/models.py
+++ b/tests/fixtures/uuid/models.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import date, datetime
+import datetime
 from typing import List
 from uuid import UUID
 
@@ -26,7 +26,7 @@ class UUIDAuthor(UUIDAuditBase):
 
     name: Mapped[str] = mapped_column(String(length=100))  # pyright: ignore
     string_field: Mapped[str] = mapped_column(String(20), default="static value", nullable=True)  # pyright: ignore
-    dob: Mapped[date] = mapped_column(nullable=True)  # pyright: ignore
+    dob: Mapped[datetime.date] = mapped_column(nullable=True)  # pyright: ignore
     books: Mapped[List[UUIDBook]] = relationship(
         lazy="selectin",
         back_populates="author",
@@ -60,7 +60,7 @@ class UUIDSlugBook(UUIDBase, SlugKey):
 class UUIDEventLog(UUIDAuditBase):
     """The event log domain object."""
 
-    logged_at: Mapped[datetime] = mapped_column(default=datetime.now())  # pyright: ignore
+    logged_at: Mapped[datetime.datetime] = mapped_column(default=datetime.datetime.now())  # pyright: ignore
     payload: Mapped[dict] = mapped_column(default={})  # pyright: ignore
 
 
@@ -83,7 +83,7 @@ class UUIDModelWithFetchedValue(UUIDv6Base):
     """The ModelWithFetchedValue UUIDBase."""
 
     val: Mapped[int]  # pyright: ignore
-    updated: Mapped[datetime] = mapped_column(  # pyright: ignore
+    updated: Mapped[datetime.datetime] = mapped_column(  # pyright: ignore
         server_default=func.current_timestamp(),
         onupdate=func.current_timestamp(),
         server_onupdate=FetchedValue(),

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -1,18 +1,22 @@
 from __future__ import annotations
 
-from datetime import datetime, timezone
+import datetime
 from typing import Any, Dict, List
 
 
 def update_raw_records(raw_authors: List[Dict[str, Any]], raw_rules: List[Dict[str, Any]]) -> None:
     for raw_author in raw_authors:
-        raw_author["dob"] = datetime.strptime(raw_author["dob"], "%Y-%m-%d").date()
-        raw_author["created_at"] = datetime.strptime(raw_author["created_at"], "%Y-%m-%dT%H:%M:%S").astimezone(
-            timezone.utc,
+        raw_author["dob"] = datetime.datetime.strptime(raw_author["dob"], "%Y-%m-%d").date()
+        raw_author["created_at"] = datetime.datetime.strptime(raw_author["created_at"], "%Y-%m-%dT%H:%M:%S").astimezone(
+            datetime.timezone.utc,
         )
-        raw_author["updated_at"] = datetime.strptime(raw_author["updated_at"], "%Y-%m-%dT%H:%M:%S").astimezone(
-            timezone.utc,
+        raw_author["updated_at"] = datetime.datetime.strptime(raw_author["updated_at"], "%Y-%m-%dT%H:%M:%S").astimezone(
+            datetime.timezone.utc,
         )
     for raw_rule in raw_rules:
-        raw_rule["created_at"] = datetime.strptime(raw_rule["created_at"], "%Y-%m-%dT%H:%M:%S").astimezone(timezone.utc)
-        raw_rule["updated_at"] = datetime.strptime(raw_rule["updated_at"], "%Y-%m-%dT%H:%M:%S").astimezone(timezone.utc)
+        raw_rule["created_at"] = datetime.datetime.strptime(raw_rule["created_at"], "%Y-%m-%dT%H:%M:%S").astimezone(
+            datetime.timezone.utc
+        )
+        raw_rule["updated_at"] = datetime.datetime.strptime(raw_rule["updated_at"], "%Y-%m-%dT%H:%M:%S").astimezone(
+            datetime.timezone.utc
+        )

--- a/tests/integration/test_repository.py
+++ b/tests/integration/test_repository.py
@@ -5,9 +5,9 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import datetime
 import os
 from collections.abc import Generator, Iterator
-from datetime import date, datetime, timedelta, timezone
 from typing import TYPE_CHECKING, Any, AsyncGenerator, Dict, List, Literal, Type, Union, cast
 from unittest.mock import NonCallableMagicMock
 from uuid import UUID, uuid4
@@ -180,7 +180,7 @@ def fx_raw_log_events_uuid() -> RawRecordData:
         {
             "id": "f34545b9-663c-4fce-915d-dd1ae9cea42a",
             "logged_at": "0001-01-01T00:00:00",
-            "payload": {"foo": "bar", "baz": datetime.now()},
+            "payload": {"foo": "bar", "baz": datetime.datetime.now()},
             "created_at": "0001-01-01T00:00:00",
             "updated_at": "0001-01-01T00:00:00",
         },
@@ -787,19 +787,19 @@ async def seed_db_async(
     """Return an asynchronous session for the current engine"""
     # convert date/time strings to dt objects.
     for raw_author in raw_authors:
-        raw_author["dob"] = datetime.strptime(raw_author["dob"], "%Y-%m-%d").date()
-        raw_author["created_at"] = datetime.strptime(raw_author["created_at"], "%Y-%m-%dT%H:%M:%S").astimezone(
-            timezone.utc,
+        raw_author["dob"] = datetime.datetime.strptime(raw_author["dob"], "%Y-%m-%d").date()
+        raw_author["created_at"] = datetime.datetime.strptime(raw_author["created_at"], "%Y-%m-%dT%H:%M:%S").astimezone(
+            datetime.timezone.utc,
         )
         raw_author["updated_at"] = datetime.strptime(raw_author["updated_at"], "%Y-%m-%dT%H:%M:%S").astimezone(
-            timezone.utc,
+            datetime.timezone.utc,
         )
     for raw_author in raw_rules:
         raw_author["created_at"] = datetime.strptime(raw_author["created_at"], "%Y-%m-%dT%H:%M:%S").astimezone(
-            timezone.utc,
+            datetime.timezone.utc,
         )
         raw_author["updated_at"] = datetime.strptime(raw_author["updated_at"], "%Y-%m-%dT%H:%M:%S").astimezone(
-            timezone.utc,
+            datetime.timezone.utc,
         )
 
     if isinstance(async_engine, NonCallableMagicMock):
@@ -1205,7 +1205,7 @@ async def test_repo_list_and_count_method_empty(book_repo: BookRepository) -> No
 
 @pytest.fixture()
 def frozen_datetime() -> Generator[Coordinates, None, None]:
-    with travel(datetime.utcnow, tick=False) as frozen:  # pyright: ignore[reportDeprecated,reportCallIssue]
+    with travel(datetime.datetime.utcnow, tick=False) as frozen:  # pyright: ignore[reportDeprecated,reportCallIssue]
         yield frozen
 
 
@@ -1233,7 +1233,7 @@ async def test_repo_created_updated(
     original_update_dt = author.updated_at
     assert author.created_at is not None
     assert author.updated_at is not None
-    frozen_datetime.shift(delta=timedelta(seconds=5))
+    frozen_datetime.shift(delta=datetime.timedelta(seconds=5))
     # looks odd, but we want to get correct type checking here
     if repository_pk_type == "uuid":
         author = cast(models_uuid.UUIDAuthor, author)
@@ -1284,7 +1284,7 @@ async def test_repo_created_updated_no_listener(
     original_update_dt = author.updated_at
     assert author.created_at is not None
     assert author.updated_at is not None
-    frozen_datetime.shift(delta=timedelta(seconds=5))
+    frozen_datetime.shift(delta=datetime.timedelta(seconds=5))
     # looks odd, but we want to get correct type checking here
     if repository_pk_type == "uuid":
         author = cast(models_uuid.UUIDAuthor, author)
@@ -1643,7 +1643,7 @@ async def test_repo_upsert_many_method_match_not_on_input(
 async def test_repo_filter_before_after(author_repo: AnyAuthorRepository) -> None:
     before_filter = BeforeAfter(
         field_name="created_at",
-        before=datetime.strptime("2023-05-01T00:00:00", "%Y-%m-%dT%H:%M:%S").astimezone(timezone.utc),
+        before=datetime.datetime.strptime("2023-05-01T00:00:00", "%Y-%m-%dT%H:%M:%S").astimezone(datetime.timezone.utc),
         after=None,
     )
     existing_obj = await maybe_async(author_repo.list(before_filter))
@@ -1651,7 +1651,7 @@ async def test_repo_filter_before_after(author_repo: AnyAuthorRepository) -> Non
 
     after_filter = BeforeAfter(
         field_name="created_at",
-        after=datetime.strptime("2023-03-01T00:00:00", "%Y-%m-%dT%H:%M:%S").astimezone(timezone.utc),
+        after=datetime.datetime.strptime("2023-03-01T00:00:00", "%Y-%m-%dT%H:%M:%S").astimezone(datetime.timezone.utc),
         before=None,
     )
     existing_obj = await maybe_async(author_repo.list(after_filter))
@@ -1661,7 +1661,9 @@ async def test_repo_filter_before_after(author_repo: AnyAuthorRepository) -> Non
 async def test_repo_filter_on_before_after(author_repo: AnyAuthorRepository) -> None:
     before_filter = OnBeforeAfter(
         field_name="created_at",
-        on_or_before=datetime.strptime("2023-05-01T00:00:00", "%Y-%m-%dT%H:%M:%S").astimezone(timezone.utc),
+        on_or_before=datetime.datetime.strptime("2023-05-01T00:00:00", "%Y-%m-%dT%H:%M:%S").astimezone(
+            datetime.timezone.utc
+        ),
         on_or_after=None,
     )
     existing_obj = await maybe_async(
@@ -1671,7 +1673,9 @@ async def test_repo_filter_on_before_after(author_repo: AnyAuthorRepository) -> 
 
     after_filter = OnBeforeAfter(
         field_name="created_at",
-        on_or_after=datetime.strptime("2023-03-01T00:00:00", "%Y-%m-%dT%H:%M:%S").astimezone(timezone.utc),
+        on_or_after=datetime.datetime.strptime("2023-03-01T00:00:00", "%Y-%m-%dT%H:%M:%S").astimezone(
+            datetime.timezone.utc
+        ),
         on_or_before=None,
     )
     existing_obj = await maybe_async(
@@ -2207,7 +2211,7 @@ async def test_service_update_method_no_item_id(author_service: AuthorService, f
 
 
 async def test_service_update_method_data_is_dict(author_service: AuthorService, first_author_id: Any) -> None:
-    new_date = datetime.date(datetime.now())
+    new_date = datetime.datetime.date(datetime.datetime.now())
     updated_obj = await maybe_async(
         author_service.update(item_id=first_author_id, data={"dob": new_date}),
     )
@@ -2221,7 +2225,7 @@ async def test_service_update_method_data_is_dict_with_none_value(
     first_author_id: Any,
 ) -> None:
     updated_obj = await maybe_async(author_service.update(item_id=first_author_id, data={"dob": None}))
-    assert cast(Union[date, None], updated_obj.dob) is None
+    assert cast(Union[datetime.date, None], updated_obj.dob) is None
     # ensure the other fields are not affected
     assert updated_obj.name == "Agatha Christie"
 

--- a/tests/integration/test_repository.py
+++ b/tests/integration/test_repository.py
@@ -791,14 +791,14 @@ async def seed_db_async(
         raw_author["created_at"] = datetime.datetime.strptime(raw_author["created_at"], "%Y-%m-%dT%H:%M:%S").astimezone(
             datetime.timezone.utc,
         )
-        raw_author["updated_at"] = datetime.strptime(raw_author["updated_at"], "%Y-%m-%dT%H:%M:%S").astimezone(
+        raw_author["updated_at"] = datetime.datetime.strptime(raw_author["updated_at"], "%Y-%m-%dT%H:%M:%S").astimezone(
             datetime.timezone.utc,
         )
     for raw_author in raw_rules:
-        raw_author["created_at"] = datetime.strptime(raw_author["created_at"], "%Y-%m-%dT%H:%M:%S").astimezone(
+        raw_author["created_at"] = datetime.datetime.strptime(raw_author["created_at"], "%Y-%m-%dT%H:%M:%S").astimezone(
             datetime.timezone.utc,
         )
-        raw_author["updated_at"] = datetime.strptime(raw_author["updated_at"], "%Y-%m-%dT%H:%M:%S").astimezone(
+        raw_author["updated_at"] = datetime.datetime.strptime(raw_author["updated_at"], "%Y-%m-%dT%H:%M:%S").astimezone(
             datetime.timezone.utc,
         )
 

--- a/tests/integration/test_repository.py
+++ b/tests/integration/test_repository.py
@@ -272,7 +272,7 @@ def fx_raw_log_events_bigint() -> RawRecordData:
         {
             "id": 2025,
             "logged_at": "0001-01-01T00:00:00",
-            "payload": {"foo": "bar", "baz": datetime.now()},
+            "payload": {"foo": "bar", "baz": datetime.datetime.now()},
             "created_at": "0001-01-01T00:00:00",
             "updated_at": "0001-01-01T00:00:00",
         },
@@ -1332,7 +1332,7 @@ async def test_repo_add_method(
     author_model: AuthorModel,
 ) -> None:
     exp_count = len(raw_authors) + 1
-    new_author = author_model(name="Testing", dob=datetime.now().date())
+    new_author = author_model(name="Testing", dob=datetime.datetime.now().date())
     obj = await maybe_async(author_repo.add(new_author))
     count = await maybe_async(author_repo.count())
     assert exp_count == count
@@ -1350,8 +1350,8 @@ async def test_repo_add_many_method(
     objs = await maybe_async(
         author_repo.add_many(
             [
-                author_model(name="Testing 2", dob=datetime.now().date()),
-                author_model(name="Cody", dob=datetime.now().date()),
+                author_model(name="Testing 2", dob=datetime.datetime.now().date()),
+                author_model(name="Cody", dob=datetime.datetime.now().date()),
             ],
         ),
     )
@@ -1460,7 +1460,7 @@ async def test_repo_get_or_upsert_method(author_repo: AnyAuthorRepository, first
 
 
 async def test_repo_get_or_upsert_match_filter(author_repo: AnyAuthorRepository, first_author_id: Any) -> None:
-    now = datetime.now()
+    now = datetime.datetime.now()
     existing_obj, existing_created = await maybe_async(
         author_repo.get_or_upsert(match_fields="name", name="Agatha Christie", dob=now.date()),
     )
@@ -1473,7 +1473,7 @@ async def test_repo_get_or_upsert_match_filter_no_upsert(
     author_repo: AnyAuthorRepository,
     first_author_id: Any,
 ) -> None:
-    now = datetime.now()
+    now = datetime.datetime.now()
     existing_obj, existing_created = await maybe_async(
         author_repo.get_or_upsert(match_fields="name", upsert=False, name="Agatha Christie", dob=now.date()),
     )
@@ -1491,7 +1491,7 @@ async def test_repo_get_and_update(author_repo: AnyAuthorRepository, first_autho
 
 
 async def test_repo_get_and_upsert_match_filter(author_repo: AnyAuthorRepository, first_author_id: Any) -> None:
-    now = datetime.now()
+    now = datetime.datetime.now()
     with pytest.raises(NotFoundError):
         _ = await maybe_async(
             author_repo.get_and_update(match_fields="name", name="Agatha Christie123", dob=now.date()),
@@ -2146,7 +2146,7 @@ async def test_service_create_method(
     author_model: AuthorModel,
 ) -> None:
     exp_count = len(raw_authors) + 1
-    new_author = author_model(name="Testing", dob=datetime.now().date())
+    new_author = author_model(name="Testing", dob=datetime.datetime.now().date())
     obj = await maybe_async(author_service.create(new_author))
     count = await maybe_async(author_service.count())
     assert exp_count == count
@@ -2164,8 +2164,8 @@ async def test_service_create_many_method(
     objs = await maybe_async(
         author_service.create_many(
             [
-                author_model(name="Testing 2", dob=datetime.now().date()),
-                author_model(name="Cody", dob=datetime.now().date()),
+                author_model(name="Testing 2", dob=datetime.datetime.now().date()),
+                author_model(name="Cody", dob=datetime.datetime.now().date()),
             ],
         ),
     )

--- a/tests/integration/test_repository.py
+++ b/tests/integration/test_repository.py
@@ -1524,7 +1524,7 @@ async def test_repo_upsert_method(
     assert upsert2_insert_obj.name == "Another Author"
     _ = await maybe_async(author_repo.get_one(name="Leo Tolstoy"))
     # ensures that it still works even if the ID isn't set on an existing key
-    new_dob = datetime.strptime("2028-09-09", "%Y-%m-%d").date()
+    new_dob = datetime.datetime.strptime("2028-09-09", "%Y-%m-%d").date()
     upsert3_update_obj = await maybe_async(
         author_repo.upsert(
             author_model(name="Leo Tolstoy", dob=new_dob),

--- a/tests/unit/test_extensions/test_litestar/test_dto.py
+++ b/tests/unit/test_extensions/test_litestar/test_dto.py
@@ -210,7 +210,7 @@ async def test_write_dto_for_model_field_unsupported_default(
     type."""
 
     class Model(base):  # type: ignore
-        field: Mapped[datetime] = mapped_column(default=func.now())
+        field: Mapped[datetime.datetime] = mapped_column(default=func.now())
 
     with pytest.raises(ValueError):
         await get_model_from_dto(SQLAlchemyDTO[Annotated[Model, SQLAlchemyDTOConfig()]], Model, asgi_connection, b"")
@@ -221,7 +221,7 @@ async def test_dto_for_private_model_field(
     asgi_connection: Request[Any, Any, Any],
 ) -> None:
     class Model(base):  # type: ignore
-        field: Mapped[datetime] = mapped_column(
+        field: Mapped[datetime.datetime] = mapped_column(
             info={DTO_FIELD_META_KEY: DTOField(mark=Mark.PRIVATE)},
         )
 
@@ -233,9 +233,9 @@ async def test_dto_for_private_model_field(
     serializable = dto_instance.data_to_encodable_type(  # pyright: ignore[reportUnknownMemberType,reportUnknownVariableType]
         Model(
             id=UUID("0956ca9e-5671-4d7d-a862-b98e6368ed2c"),
-            created=datetime.min,
-            updated=datetime.min,
-            field=datetime.min,
+            created=datetime.datetime.min,
+            updated=datetime.datetime.min,
+            field=datetime.datetime.min,
         ),
     )
     assert b"field" not in encode_json(serializable)
@@ -246,7 +246,7 @@ async def test_dto_for_non_mapped_model_field(
     asgi_connection: Request[Any, Any, Any],
 ) -> None:
     class Model(base):  # type: ignore
-        field: ClassVar[datetime]
+        field: ClassVar[datetime.datetime]
 
     dto_type = SQLAlchemyDTO[Annotated[Model, SQLAlchemyDTOConfig()]]
     raw = b'{"id": "97108ac1-ffcb-411d-8b1e-d9183399f63b","created":"0001-01-01T00:00:00","updated":"0001-01-01T00:00:00","field":"0001-01-01T00:00:00"}'

--- a/tests/unit/test_extensions/test_litestar/test_dto.py
+++ b/tests/unit/test_extensions/test_litestar/test_dto.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
+import datetime
 import sys
-from datetime import date, datetime
 from typing import TYPE_CHECKING, ClassVar, Dict, List, Type
 from uuid import UUID, uuid4
 
@@ -36,12 +36,12 @@ if TYPE_CHECKING:
 def fx_base() -> Type[DeclarativeBase]:
     class Base(DeclarativeBase):
         id: Mapped[UUID] = mapped_column(default=uuid4, primary_key=True)
-        created: Mapped[datetime] = mapped_column(
-            default=datetime.now,
+        created: Mapped[datetime.datetime] = mapped_column(
+            default=datetime.datetime.now,
             info={DTO_FIELD_META_KEY: DTOField(mark=Mark.READ_ONLY)},
         )
-        updated: Mapped[datetime] = mapped_column(
-            default=datetime.now,
+        updated: Mapped[datetime.datetime] = mapped_column(
+            default=datetime.datetime.now,
             info={DTO_FIELD_META_KEY: DTOField(mark=Mark.READ_ONLY)},
         )
 
@@ -58,7 +58,7 @@ def fx_base() -> Type[DeclarativeBase]:
 def fx_author_model(base: DeclarativeBase) -> Type[DeclarativeBase]:
     class Author(base):  # type: ignore
         name: Mapped[str]
-        dob: Mapped[date]
+        dob: Mapped[datetime.date]
 
     return Author
 
@@ -112,7 +112,7 @@ async def test_model_write_dto(
         {
             "id": UUID("97108ac1-ffcb-411d-8b1e-d9183399f63b"),
             "name": "Agatha Christie",
-            "dob": date(1890, 9, 15),
+            "dob": datetime.date(1890, 9, 15),
         },
     )
 
@@ -130,7 +130,7 @@ async def test_model_read_dto(
         {
             "id": UUID("97108ac1-ffcb-411d-8b1e-d9183399f63b"),
             "name": "Agatha Christie",
-            "dob": date(1890, 9, 15),
+            "dob": datetime.date(1890, 9, 15),
         },
     )
 
@@ -145,7 +145,7 @@ async def test_model_list_dto(author_model: Type[DeclarativeBase], asgi_connecti
         {
             "id": UUID("97108ac1-ffcb-411d-8b1e-d9183399f63b"),
             "name": "Agatha Christie",
-            "dob": date(1890, 9, 15),
+            "dob": datetime.date(1890, 9, 15),
         },
     )
 

--- a/tests/unit/test_repository.py
+++ b/tests/unit/test_repository.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
+import datetime
 from collections.abc import Collection
-from datetime import datetime
 from typing import TYPE_CHECKING, Any, Generator, Union, cast
 from unittest.mock import AsyncMock, MagicMock
 from uuid import uuid4
@@ -627,7 +627,7 @@ async def test_sqlalchemy_repo_list_with_before_after_filter(
     mocker.patch.object(mock_repo.model_type.updated_at, "__gt__", return_value="gt")
     mocker.patch.object(BeforeAfter, "append_to_statement", return_value=statement)
     mock_repo_execute.return_value = MagicMock()
-    await maybe_async(mock_repo.list(BeforeAfter("updated_at", datetime.max, datetime.min)))
+    await maybe_async(mock_repo.list(BeforeAfter("updated_at", datetime.datetime.max, datetime.datetime.min)))
     mock_repo._execute.assert_called_with(statement, uniquify=False)  # pyright: ignore[reportFunctionMemberAccess,reportPrivateUsage]
 
 
@@ -644,7 +644,7 @@ async def test_sqlalchemy_repo_list_with_on_before_after_filter(
     mocker.patch.object(OnBeforeAfter, "append_to_statement", return_value=statement)
 
     mock_repo_execute.return_value = MagicMock()
-    await maybe_async(mock_repo.list(OnBeforeAfter("updated_at", datetime.max, datetime.min)))
+    await maybe_async(mock_repo.list(OnBeforeAfter("updated_at", datetime.datetime.max, datetime.datetime.min)))
     mock_repo._execute.assert_called_with(statement, uniquify=False)  # pyright: ignore[reportFunctionMemberAccess,reportPrivateUsage]
 
 
@@ -820,14 +820,14 @@ def test_filter_in_collection_noop_if_collection_empty(mock_repo: SQLAlchemyAsyn
 @pytest.mark.parametrize(
     ("before", "after"),
     [
-        (datetime.max, datetime.min),
-        (None, datetime.min),
-        (datetime.max, None),
+        (datetime.datetime.max, datetime.datetime.min),
+        (None, datetime.datetime.min),
+        (datetime.datetime.max, None),
     ],
 )
 def test_filter_on_datetime_field(
-    before: datetime,
-    after: datetime,
+    before: datetime.datetime,
+    after: datetime.datetime,
     mock_repo: SQLAlchemyAsyncRepository[Any],
     mocker: MockerFixture,
     monkeypatch: MonkeyPatch,


### PR DESCRIPTION
All date time references are now full qualified to prevent any forward resolution issues with

`from datetime import datetime`

and 

`import datetime`