### PR TITLE
feat: add convenience hooks for `to_model` operations

### DIFF
--- a/advanced_alchemy/service/_async.py
+++ b/advanced_alchemy/service/_async.py
@@ -396,8 +396,8 @@ class SQLAlchemyAsyncRepositoryReadService(ResultConverter, Generic[ModelT, SQLA
             "delete": self.to_model_on_delete,
             "upsert": self.to_model_on_upsert,
         }
-        if operation and operation_map.get(operation):
-            data = await operation_map[operation](data)
+        if operation and (op := operation_map.get(operation)):
+            data = await op(data)
         if is_dict(data):
             return model_from_dict(model=self.model_type, **data)
         if is_pydantic_model(data):

--- a/advanced_alchemy/service/_async.py
+++ b/advanced_alchemy/service/_async.py
@@ -333,6 +333,50 @@ class SQLAlchemyAsyncRepositoryReadService(ResultConverter, Generic[ModelT, SQLA
             ),
         )
 
+    async def to_model_on_create(self, data: ModelDictT[ModelT]) -> ModelDictT[ModelT]:
+        """Convenience method to allow for custom behavior on create.
+
+        Args:
+            data: The data to be converted to a model.
+
+        Returns:
+            The data to be converted to a model.
+        """
+        return data
+
+    async def to_model_on_update(self, data: ModelDictT[ModelT]) -> ModelDictT[ModelT]:
+        """Convenience method to allow for custom behavior on update.
+
+        Args:
+            data: The data to be converted to a model.
+
+        Returns:
+            The data to be converted to a model.
+        """
+        return data
+
+    async def to_model_on_delete(self, data: ModelDictT[ModelT]) -> ModelDictT[ModelT]:
+        """Convenience method to allow for custom behavior on delete.
+
+        Args:
+            data: The data to be converted to a model.
+
+        Returns:
+            The data to be converted to a model.
+        """
+        return data
+
+    async def to_model_on_upsert(self, data: ModelDictT[ModelT]) -> ModelDictT[ModelT]:
+        """Convenience method to allow for custom behavior on upsert.
+
+        Args:
+            data: The data to be converted to a model.
+
+        Returns:
+            The data to be converted to a model.
+        """
+        return data
+
     async def to_model(
         self,
         data: ModelDictT[ModelT],
@@ -346,6 +390,14 @@ class SQLAlchemyAsyncRepositoryReadService(ResultConverter, Generic[ModelT, SQLA
         Returns:
             Representation of created instances.
         """
+        operation_map = {
+            "create": self.to_model_on_create,
+            "update": self.to_model_on_update,
+            "delete": self.to_model_on_delete,
+            "upsert": self.to_model_on_upsert,
+        }
+        if operation and operation_map.get(operation):
+            data = await operation_map[operation](data)
         if is_dict(data):
             return model_from_dict(model=self.model_type, **data)
         if is_pydantic_model(data):

--- a/advanced_alchemy/service/_sync.py
+++ b/advanced_alchemy/service/_sync.py
@@ -347,6 +347,50 @@ class SQLAlchemySyncRepositoryReadService(ResultConverter, Generic[ModelT, SQLAl
             ),
         )
 
+    def to_model_on_create(self, data: ModelDictT[ModelT]) -> ModelDictT[ModelT]:
+        """Convenience method to allow for custom behavior on create.
+
+        Args:
+            data: The data to be converted to a model.
+
+        Returns:
+            The data to be converted to a model.
+        """
+        return data
+
+    def to_model_on_update(self, data: ModelDictT[ModelT]) -> ModelDictT[ModelT]:
+        """Convenience method to allow for custom behavior on update.
+
+        Args:
+            data: The data to be converted to a model.
+
+        Returns:
+            The data to be converted to a model.
+        """
+        return data
+
+    def to_model_on_delete(self, data: ModelDictT[ModelT]) -> ModelDictT[ModelT]:
+        """Convenience method to allow for custom behavior on delete.
+
+        Args:
+            data: The data to be converted to a model.
+
+        Returns:
+            The data to be converted to a model.
+        """
+        return data
+
+    def to_model_on_upsert(self, data: ModelDictT[ModelT]) -> ModelDictT[ModelT]:
+        """Convenience method to allow for custom behavior on upsert.
+
+        Args:
+            data: The data to be converted to a model.
+
+        Returns:
+            The data to be converted to a model.
+        """
+        return data
+
     def to_model(
         self,
         data: ModelDictT[ModelT],
@@ -360,6 +404,14 @@ class SQLAlchemySyncRepositoryReadService(ResultConverter, Generic[ModelT, SQLAl
         Returns:
             Representation of created instances.
         """
+        operation_map = {
+            "create": self.to_model_on_create,
+            "update": self.to_model_on_update,
+            "delete": self.to_model_on_delete,
+            "upsert": self.to_model_on_upsert,
+        }
+        if operation and operation_map.get(operation):
+            data = operation_map[operation](data)
         if is_dict(data):
             return model_from_dict(model=self.model_type, **data)
         if is_pydantic_model(data):

--- a/advanced_alchemy/service/_sync.py
+++ b/advanced_alchemy/service/_sync.py
@@ -410,8 +410,8 @@ class SQLAlchemySyncRepositoryReadService(ResultConverter, Generic[ModelT, SQLAl
             "delete": self.to_model_on_delete,
             "upsert": self.to_model_on_upsert,
         }
-        if operation and operation_map.get(operation):
-            data = operation_map[operation](data)
+        if operation and (op := operation_map.get(operation)):
+            data = op(data)
         if is_dict(data):
             return model_from_dict(model=self.model_type, **data)
         if is_pydantic_model(data):


### PR DESCRIPTION
The service layer has always has a `to_model` function that accepts data and optionally an operation name.  It would return a SQLAlchemy model no matter the input you gave it.

It is possible to move business logic into this `to_model` layer for populating fields on insert.  (i.e. slug fields or tags, etc.).

When having logic for `insert`, `update`, `delete`, and `upsert`, that function can be a bit overwhelcoming.  Now, there are helper functions that you can use that is specific to each DML hook:

* `to_model_on_create`
* `to_model_on_update`
* `to_model_on_delete`
* `to_model_on_upsert`