### PR TITLE
fix: standardize on `autocommit_include_redirect`

### DIFF
--- a/advanced_alchemy/extensions/flask/config.py
+++ b/advanced_alchemy/extensions/flask/config.py
@@ -80,7 +80,7 @@ class SQLAlchemySyncConfig(_SQLAlchemySyncConfig):
 
     app: Flask | None = None
     """The Flask application instance."""
-    commit_mode: Literal["manual", "autocommit", "autocommit_with_redirect"] = "manual"
+    commit_mode: Literal["manual", "autocommit", "autocommit_include_redirect"] = "manual"
     """The commit mode to use for database sessions."""
 
     def create_session_maker(self) -> Callable[[], Session]:
@@ -130,7 +130,7 @@ class SQLAlchemySyncConfig(_SQLAlchemySyncConfig):
             db_session = cast("Optional[Session]", g.pop(f"advanced_alchemy_session_{self.bind_key}", None))
             if db_session is not None:
                 if (self.commit_mode == "autocommit" and 200 <= response.status_code < 300) or (  # noqa: PLR2004
-                    self.commit_mode == "autocommit_with_redirect" and 200 <= response.status_code < 400  # noqa: PLR2004
+                    self.commit_mode == "autocommit_include_redirect" and 200 <= response.status_code < 400  # noqa: PLR2004
                 ):
                     db_session.commit()
                 db_session.close()
@@ -167,7 +167,7 @@ class SQLAlchemyAsyncConfig(_SQLAlchemyAsyncConfig):
 
     app: Flask | None = None
     """The Flask application instance."""
-    commit_mode: Literal["manual", "autocommit", "autocommit_with_redirect"] = "manual"
+    commit_mode: Literal["manual", "autocommit", "autocommit_include_redirect"] = "manual"
     """The commit mode to use for database sessions."""
 
     def create_session_maker(self) -> Callable[[], AsyncSession]:
@@ -224,7 +224,7 @@ class SQLAlchemyAsyncConfig(_SQLAlchemyAsyncConfig):
             if db_session is not None:
                 p = getattr(db_session, "_session_portal", None) or portal
                 if (self.commit_mode == "autocommit" and 200 <= response.status_code < 300) or (  # noqa: PLR2004
-                    self.commit_mode == "autocommit_with_redirect" and 200 <= response.status_code < 400  # noqa: PLR2004
+                    self.commit_mode == "autocommit_include_redirect" and 200 <= response.status_code < 400  # noqa: PLR2004
                 ):
                     _ = p.call(db_session.commit)
                 _ = p.call(db_session.close)

--- a/docs/usage/frameworks/flask.rst
+++ b/docs/usage/frameworks/flask.rst
@@ -141,7 +141,7 @@ Both sync and async configurations support these options:
      - Create tables on startup
      - ``False``
    * - ``commit_mode``
-     - ``"autocommit", "autocommit_with_redirect", "manual"``
+     - ``"autocommit", "autocommit_include_redirect", "manual"``
      - Session commit behavior
      - ``"manual"``
 
@@ -152,7 +152,7 @@ The ``commit_mode`` option controls how database sessions are committed:
 
 - ``"manual"`` (default): No automatic commits
 - ``"autocommit"``: Commit on successful responses (2xx status codes)
-- ``"autocommit_with_redirect"``: Commit on successful responses and redirects (2xx and 3xx status codes)
+- ``"autocommit_include_redirect"``: Commit on successful responses and redirects (2xx and 3xx status codes)
 
 Services
 --------

--- a/tests/unit/test_extensions/test_flask.py
+++ b/tests/unit/test_extensions/test_flask.py
@@ -281,12 +281,14 @@ def test_sync_autocommit(setup_database: Path) -> None:
         assert result.scalar_one().name == "test"
 
 
-def test_sync_autocommit_with_redirect(setup_database: Path) -> None:
+def test_sync_autocommit_include_redirect(setup_database: Path) -> None:
     app = Flask(__name__)
 
     with app.test_client() as client:
         config = SQLAlchemySyncConfig(
-            connection_string=f"sqlite:///{setup_database}", commit_mode="autocommit_with_redirect", metadata=metadata
+            connection_string=f"sqlite:///{setup_database}",
+            commit_mode="autocommit_include_redirect",
+            metadata=metadata,
         )
 
         extension = AdvancedAlchemy(config, app)
@@ -298,7 +300,7 @@ def test_sync_autocommit_with_redirect(setup_database: Path) -> None:
             session.add(User(name="test_redirect"))
             return "", 302, {"Location": "/redirected"}
 
-        # Test redirect response (should commit with AUTOCOMMIT_WITH_REDIRECT)
+        # Test redirect response (should commit with autocommit_include_redirect)
         response = client.post("/test")
         assert response.status_code == 302
 
@@ -366,13 +368,13 @@ def test_async_autocommit(setup_database: Path) -> None:
     extension.portal_provider.stop()
 
 
-def test_async_autocommit_with_redirect(setup_database: Path) -> None:
+def test_async_autocommit_include_redirect(setup_database: Path) -> None:
     app = Flask(__name__)
 
     with app.test_client() as client:
         config = SQLAlchemyAsyncConfig(
             connection_string=f"sqlite+aiosqlite:///{setup_database}",
-            commit_mode="autocommit_with_redirect",
+            commit_mode="autocommit_include_redirect",
             metadata=metadata,
         )
         extension = AdvancedAlchemy(config, app)
@@ -385,7 +387,7 @@ def test_async_autocommit_with_redirect(setup_database: Path) -> None:
             session.add(user)
             return "", 302, {"Location": "/redirected"}
 
-        # Test redirect response (should commit with AUTOCOMMIT_WITH_REDIRECT)
+        # Test redirect response (should commit with autocommit_include_redirect)
         response = client.post("/test")
         assert response.status_code == 302
         session = extension.get_session()


### PR DESCRIPTION
The flask plugin incorrectly used the term `autocommit_with_redirect` instead of the existing `autocommit_include_redirect`.  

This changes makes the name consistent before we bump to a `1.x` release