### PR TITLE
feat: add hash to config classes

### DIFF
--- a/advanced_alchemy/config/asyncio.py
+++ b/advanced_alchemy/config/asyncio.py
@@ -71,6 +71,12 @@ class SQLAlchemyAsyncConfig(GenericSQLAlchemyConfig[AsyncEngine, AsyncSession, a
     The configuration options are documented in the Alembic documentation.
     """
 
+    def __hash__(self) -> int:
+        return super().__hash__()
+
+    def __eq__(self, other: object) -> bool:
+        return super().__eq__(other)
+
     @asynccontextmanager
     async def get_session(
         self,

--- a/advanced_alchemy/config/common.py
+++ b/advanced_alchemy/config/common.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Callable, ClassVar, Generic, Union, cast
+from uuid import NAMESPACE_DNS, uuid3
 
 from typing_extensions import TypeVar
 
@@ -201,6 +202,14 @@ class GenericSQLAlchemyConfig(Generic[EngineT, SessionT, SessionMakerT]):
             from advanced_alchemy._listeners import touch_updated_timestamp
 
             event.listen(Session, "before_flush", touch_updated_timestamp)
+
+    def __hash__(self) -> int:
+        return hash((uuid3(NAMESPACE_DNS, str(self)), self.__class__.__name__, self.metadata))
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, type(self)):
+            return False
+        return self.__hash__() == other.__hash__()
 
     @property
     def engine_config_dict(self) -> dict[str, Any]:

--- a/advanced_alchemy/config/common.py
+++ b/advanced_alchemy/config/common.py
@@ -204,7 +204,7 @@ class GenericSQLAlchemyConfig(Generic[EngineT, SessionT, SessionMakerT]):
             event.listen(Session, "before_flush", touch_updated_timestamp)
 
     def __hash__(self) -> int:
-        return hash((uuid3(NAMESPACE_DNS, str(self)), self.__class__.__name__, self.metadata))
+        return hash((uuid3(NAMESPACE_DNS, str(self)), self.__class__.__name__, self.metadata, self.bind_key))
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, type(self)):

--- a/advanced_alchemy/config/sync.py
+++ b/advanced_alchemy/config/sync.py
@@ -55,6 +55,12 @@ class SQLAlchemySyncConfig(GenericSQLAlchemyConfig[Engine, Session, sessionmaker
     The configuration options are documented in the Alembic documentation.
     """
 
+    def __hash__(self) -> int:
+        return super().__hash__()
+
+    def __eq__(self, other: object) -> bool:
+        return super().__eq__(other)
+
     @contextmanager
     def get_session(self) -> Generator[Session, None, None]:
         """Get a session context manager.


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

Adds hash function to `SQLAlchemySyncConfig` and `SQLAlchemyAsyncConfig` classes.


<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
## Closes
Closes #357 