### PR TITLE
docs: correct invalid link to FastAPI example

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,7 +333,7 @@ or the [project-specific GitHub discussions page][project-discussions].
 [project-discussions]: https://github.com/litestar-org/advanced-alchemy/discussions
 [project-docs]: https://docs.advanced-alchemy.litestar.dev
 [install-guide]: https://docs.advanced-alchemy.litestar.dev/latest/#installation
-[fastapi-example]: https://github.com/litestar-org/advanced-alchemy/blob/main/examples/fastapi.py
+[fastapi-example]: https://github.com/litestar-org/advanced-alchemy/blob/main/examples/fastapi_service.py
 [flask-example]: https://github.com/litestar-org/advanced-alchemy/blob/main/examples/flask/flask_services.py
 [litestar-example]: https://github.com/litestar-org/advanced-alchemy/blob/main/examples/litestar.py
 [standalone-example]: https://github.com/litestar-org/advanced-alchemy/blob/main/examples/standalone.py

--- a/docs/PYPI_README.md
+++ b/docs/PYPI_README.md
@@ -10,7 +10,7 @@
 [project-discussions]: https://github.com/litestar-org/advanced-alchemy/discussions
 [project-docs]: https://docs.advanced-alchemy.litestar.dev
 [install-guide]: https://docs.advanced-alchemy.litestar.dev/latest/#installation
-[fastapi-example]: https://github.com/litestar-org/advanced-alchemy/blob/main/examples/fastapi.py
+[fastapi-example]: https://github.com/litestar-org/advanced-alchemy/blob/main/examples/fastapi_service.py
 [flask-example]: https://github.com/litestar-org/advanced-alchemy/blob/main/examples/flask/flask_services.py
 [litestar-example]: https://github.com/litestar-org/advanced-alchemy/blob/main/examples/litestar.py
 [standalone-example]: https://github.com/litestar-org/advanced-alchemy/blob/main/examples/standalone.py


### PR DESCRIPTION
Correct an invalid link to the updated FastAPI example