### PR TITLE
feat: add database create and drop commands

### DIFF
--- a/advanced_alchemy/cli.py
+++ b/advanced_alchemy/cli.py
@@ -399,4 +399,27 @@ def add_migration_commands(database_group: Group | None = None) -> Group:  # noq
 
         return run(_dump_tables)
 
+    @database_group.command(name="create", help="Create a new database.")
+    @bind_key_option
+    @no_prompt_option
+    def create_database(bind_key: str | None, no_prompt: bool) -> None:  # pyright: ignore[reportUnusedFunction]
+        from rich.prompt import Confirm
+        from advanced_alchemy.utils.databases import create_database as _create_database
+
+        ctx = click.get_current_context()
+        sqlalchemy_config = get_config_by_bind_key(ctx, bind_key)
+
+        db_name = sqlalchemy_config.get_engine().url.database
+
+        console.rule("[yellow]Starting database creation process[/]", align="left")
+        input_confirmed = (
+            True if no_prompt else Confirm.ask(f"[bold]Are you sure you want to create a new database `{db_name}`?[/]")
+        )
+        if input_confirmed:
+            _create_database(sqlalchemy_config)
+
+    @database_group.command(name="drop", help="Drop the current database.")
+    def drop_database() -> None:  # pyright: ignore[reportUnusedFunction]
+        raise NotImplementedError
+
     return database_group

--- a/advanced_alchemy/utils/databases.py
+++ b/advanced_alchemy/utils/databases.py
@@ -109,8 +109,7 @@ async def create_database_async(engine: AsyncEngine, database: str | None, encod
             pass
     else:
         async with engine.begin() as conn:
-            sql = f"CREATE DATABASE {database}"
-            await conn.execute(text(sql))
+            await conn.execute(text(f"CREATE DATABASE {database}"))
 
     await engine.dispose()
 
@@ -165,14 +164,10 @@ async def drop_database_async(engine: AsyncEngine, database: str | None) -> None
             version = conn.dialect.server_version_info
             sql = _disconnect_users_sql(version, database)
             await conn.execute(text(sql))
-
-            # Drop the database.
-            sql = f"DROP DATABASE {database}"
-            await conn.execute(text(sql))
+            await conn.execute(text(f"DROP DATABASE {database}"))
     else:
         async with engine.begin() as conn:
-            sql = f"DROP DATABASE {database}"
-            await conn.execute(text(sql))
+            await conn.execute(text(f"DROP DATABASE {database}"))
 
     await engine.dispose()
 
@@ -188,13 +183,9 @@ def drop_database_sync(engine: Engine, database: str | None) -> None:
             version = conn.dialect.server_version_info
             sql = _disconnect_users_sql(version, database)
             conn.execute(text(sql))
-
-            # Drop the database.
-            sql = f"DROP DATABASE {database}"
-            conn.execute(text(sql))
+            conn.execute(text(f"DROP DATABASE {database}"))
     else:
         with engine.begin() as conn:
-            sql = f"DROP DATABASE {database}"
-            conn.execute(text(sql))
+            conn.execute(text(f"DROP DATABASE {database}"))
 
     engine.dispose()

--- a/advanced_alchemy/utils/databases.py
+++ b/advanced_alchemy/utils/databases.py
@@ -1,17 +1,21 @@
 from __future__ import annotations
 
 import asyncio
+import os
 from copy import copy
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from sqlalchemy import Engine, text
 from sqlalchemy.ext.asyncio import AsyncEngine
 
-from advanced_alchemy.config.asyncio import SQLAlchemyAsyncConfig
-from advanced_alchemy.config.sync import SQLAlchemySyncConfig
+from advanced_alchemy.utils.dataclass import Empty
 
 if TYPE_CHECKING:
     from sqlalchemy.engine.url import URL
+
+    from advanced_alchemy.config.asyncio import SQLAlchemyAsyncConfig
+    from advanced_alchemy.config.sync import SQLAlchemySyncConfig
 
 
 def set_engine_database_url(url: URL, database: str | None) -> URL:
@@ -44,14 +48,13 @@ def create_database(config: SQLAlchemyAsyncConfig | SQLAlchemySyncConfig, encodi
         config.engine_config.isolation_level = "AUTOCOMMIT"
 
     engine = config.create_engine_callable(str(url))
-
-    if isinstance(engine, Engine):
-        create_sync_database(engine, database, encoding)
+    if isinstance(engine, AsyncEngine):
+        asyncio.run(create_database_async(engine, database, encoding))
     else:
-        asyncio.run(create_async_database(engine, database, encoding))
+        create_database_sync(engine, database, encoding)
 
 
-def create_sync_database(engine: Engine, database: str | None, encoding: str = "utf8") -> None:
+def create_database_sync(engine: Engine, database: str | None, encoding: str = "utf8") -> None:
     dialect_name = engine.url.get_dialect().name
     if dialect_name == "postgresql":
         with engine.begin() as conn:
@@ -77,7 +80,7 @@ def create_sync_database(engine: Engine, database: str | None, encoding: str = "
     engine.dispose()
 
 
-async def create_async_database(engine: AsyncEngine, database: str | None, encoding: str = "utf8") -> None:
+async def create_database_async(engine: AsyncEngine, database: str | None, encoding: str = "utf8") -> None:
     dialect_name = engine.url.get_dialect().name
     if dialect_name == "postgresql":
         async with engine.begin() as conn:
@@ -101,3 +104,97 @@ async def create_async_database(engine: AsyncEngine, database: str | None, encod
             await conn.execute(text(sql))
 
     await engine.dispose()
+
+
+def drop_database(config: SQLAlchemyAsyncConfig | SQLAlchemySyncConfig) -> None:
+    url = config.get_engine().url
+    database = url.database
+    dialect_name = url.get_dialect().name
+    dialect_driver = url.get_dialect().driver
+
+    if dialect_name == "postgresql":
+        url = set_engine_database_url(url, database="postgres")
+    elif dialect_name == "mssql":
+        url = set_engine_database_url(url, database="master")
+    elif dialect_name == "cockroachdb":
+        url = set_engine_database_url(url, database="defaultdb")
+    elif dialect_name != "sqlite":
+        url = set_engine_database_url(url, database=None)
+
+    if dialect_name == "mssql" and dialect_driver in {"pymssql", "pyodbc"}:
+        if config.engine_config.connect_args is Empty:
+            config.engine_config.connect_args = {}
+        else:
+            config.engine_config.connect_args["autocommit"] = True  # type: ignore  # noqa: PGH003
+    elif dialect_name == "postgresql" and dialect_driver in {
+        "asyncpg",
+        "pg8000",
+        "psycopg",
+        "psycopg2",
+        "psycopg2cffi",
+    }:
+        config.engine_config.isolation_level = "AUTOCOMMIT"
+
+    engine = config.create_engine_callable(str(url))
+    if isinstance(engine, AsyncEngine):
+        asyncio.run(drop_database_async(engine, database))
+    else:
+        drop_database_sync(engine, database)
+
+
+async def drop_database_async(engine: AsyncEngine, database: str | None) -> None:
+    dialect_name = engine.url.get_dialect().name
+    if dialect_name == "sqlite" and database != ":memory:":
+        if database:
+            Path(database).unlink()
+    elif dialect_name == "postgresql":
+        async with engine.begin() as conn:
+            # Disconnect all users from the database we are dropping.
+            version = conn.dialect.server_version_info
+            pid_column = ("pid" if version >= (9, 2) else "procpid") if version else "procpid"
+            sql = f"""
+            SELECT pg_terminate_backend(pg_stat_activity.{pid_column})
+            FROM pg_stat_activity
+            WHERE pg_stat_activity.datname = '{database}'
+            AND {pid_column} <> pg_backend_pid();
+            """  # noqa: S608
+            await conn.execute(text(sql))
+
+            # Drop the database.
+            sql = f"DROP DATABASE {database}"
+            await conn.execute(text(sql))
+    else:
+        async with engine.begin() as conn:
+            sql = f"DROP DATABASE {database}"
+            await conn.execute(text(sql))
+
+    await engine.dispose()
+
+
+def drop_database_sync(engine: Engine, database: str | None) -> None:
+    dialect_name = engine.url.get_dialect().name
+    if dialect_name == "sqlite" and database != ":memory:":
+        if database:
+            Path(database).unlink()
+    elif dialect_name == "postgresql":
+        with engine.begin() as conn:
+            # Disconnect all users from the database we are dropping.
+            version = conn.dialect.server_version_info
+            pid_column = ("pid" if version >= (9, 2) else "procpid") if version else "procpid"
+            sql = f"""
+            SELECT pg_terminate_backend(pg_stat_activity.{pid_column})
+            FROM pg_stat_activity
+            WHERE pg_stat_activity.datname = '{database}'
+            AND {pid_column} <> pg_backend_pid();
+            """  # noqa: S608
+            conn.execute(text(sql))
+
+            # Drop the database.
+            sql = f"DROP DATABASE {database}"
+            conn.execute(text(sql))
+    else:
+        with engine.begin() as conn:
+            sql = f"DROP DATABASE {database}"
+            conn.execute(text(sql))
+
+    engine.dispose()

--- a/advanced_alchemy/utils/databases.py
+++ b/advanced_alchemy/utils/databases.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import asyncio
+from copy import copy
+from typing import TYPE_CHECKING
+
+from sqlalchemy import Engine, text
+from sqlalchemy.ext.asyncio import AsyncEngine
+
+from advanced_alchemy.config.asyncio import SQLAlchemyAsyncConfig
+from advanced_alchemy.config.sync import SQLAlchemySyncConfig
+
+if TYPE_CHECKING:
+    from sqlalchemy.engine.url import URL
+
+
+def set_engine_database_url(url: URL, database: str | None) -> URL:
+    if hasattr(url, "_replace"):
+        new_url = url._replace(database=database)
+    else:  # SQLAlchemy <1.4
+        new_url = copy(url)
+        new_url.database = database  # type: ignore  # noqa: PGH003
+    return new_url
+
+
+def create_database(config: SQLAlchemyAsyncConfig | SQLAlchemySyncConfig, encoding: str = "utf8") -> None:
+    url = config.get_engine().url
+    database = url.database
+    dialect_name = url.get_dialect().name
+    dialect_driver = url.get_dialect().driver
+
+    if dialect_name == "postgresql":
+        url = set_engine_database_url(url, database="postgres")
+    elif dialect_name == "mssql":
+        url = set_engine_database_url(url, database="master")
+    elif dialect_name == "cockroachdb":
+        url = set_engine_database_url(url, database="defaultdb")
+    elif dialect_name != "sqlite":
+        url = set_engine_database_url(url, database=None)
+
+    if (dialect_name == "mssql" and dialect_driver in {"pymssql", "pyodbc"}) or (
+        dialect_name == "postgresql" and dialect_driver in {"asyncpg", "pg8000", "psycopg", "psycopg2", "psycopg2cffi"}
+    ):
+        config.engine_config.isolation_level = "AUTOCOMMIT"
+
+    engine = config.create_engine_callable(str(url))
+
+    if isinstance(engine, Engine):
+        create_sync_database(engine, database, encoding)
+    else:
+        asyncio.run(create_async_database(engine, database, encoding))
+
+
+def create_sync_database(engine: Engine, database: str | None, encoding: str = "utf8") -> None:
+    dialect_name = engine.url.get_dialect().name
+    if dialect_name == "postgresql":
+        with engine.begin() as conn:
+            sql = f"CREATE DATABASE {database} ENCODING '{encoding}'"
+            conn.execute(text(sql))
+
+    elif dialect_name == "mysql":
+        with engine.begin() as conn:
+            sql = f"CREATE DATABASE {database} CHARACTER SET = '{encoding}'"
+            conn.execute(text(sql))
+
+    elif dialect_name == "sqlite" and database != ":memory:":
+        if database:
+            with engine.begin() as conn:
+                conn.execute(text("CREATE TABLE DB(id int)"))
+                conn.execute(text("DROP TABLE DB"))
+
+    else:
+        with engine.begin() as conn:
+            sql = f"CREATE DATABASE {database}"
+            conn.execute(text(sql))
+
+    engine.dispose()
+
+
+async def create_async_database(engine: AsyncEngine, database: str | None, encoding: str = "utf8") -> None:
+    dialect_name = engine.url.get_dialect().name
+    if dialect_name == "postgresql":
+        async with engine.begin() as conn:
+            sql = f"CREATE DATABASE {database} ENCODING '{encoding}'"
+            await conn.execute(text(sql))
+
+    elif dialect_name == "mysql":
+        async with engine.begin() as conn:
+            sql = f"CREATE DATABASE {database} CHARACTER SET = '{encoding}'"
+            await conn.execute(text(sql))
+
+    elif dialect_name == "sqlite" and database != ":memory:":
+        if database:
+            async with engine.begin() as conn:
+                await conn.execute(text("CREATE TABLE DB(id int)"))
+                await conn.execute(text("DROP TABLE DB"))
+
+    else:
+        async with engine.begin() as conn:
+            sql = f"CREATE DATABASE {database}"
+            await conn.execute(text(sql))
+
+    await engine.dispose()

--- a/advanced_alchemy/utils/databases.py
+++ b/advanced_alchemy/utils/databases.py
@@ -73,12 +73,13 @@ def create_database_sync(engine: Engine, database: str | None, encoding: str = "
             sql = f"CREATE DATABASE {database} CHARACTER SET = '{encoding}'"
             conn.execute(text(sql))
 
-    elif dialect_name == "sqlite" and database != ":memory:":
-        if database:
+    elif dialect_name == "sqlite":
+        if database and database != ":memory:":
             with engine.begin() as conn:
                 conn.execute(text("CREATE TABLE DB(id int)"))
                 conn.execute(text("DROP TABLE DB"))
-
+        else:
+            pass
     else:
         with engine.begin() as conn:
             sql = f"CREATE DATABASE {database}"
@@ -99,12 +100,13 @@ async def create_database_async(engine: AsyncEngine, database: str | None, encod
             sql = f"CREATE DATABASE {database} CHARACTER SET = '{encoding}'"
             await conn.execute(text(sql))
 
-    elif dialect_name == "sqlite" and database != ":memory:":
-        if database:
+    elif dialect_name == "sqlite":
+        if database and database != ":memory:":
             async with engine.begin() as conn:
                 await conn.execute(text("CREATE TABLE DB(id int)"))
                 await conn.execute(text("DROP TABLE DB"))
-
+        else:
+            pass
     else:
         async with engine.begin() as conn:
             sql = f"CREATE DATABASE {database}"
@@ -154,8 +156,8 @@ def _disconnect_users_sql(version: tuple[int, int] | None, database: str | None)
 
 async def drop_database_async(engine: AsyncEngine, database: str | None) -> None:
     dialect_name = engine.url.get_dialect().name
-    if dialect_name == "sqlite" and database != ":memory:":
-        if database:
+    if dialect_name == "sqlite":
+        if database and database != ":memory:":
             Path(database).unlink()
     elif dialect_name == "postgresql":
         async with engine.begin() as conn:
@@ -177,8 +179,8 @@ async def drop_database_async(engine: AsyncEngine, database: str | None) -> None
 
 def drop_database_sync(engine: Engine, database: str | None) -> None:
     dialect_name = engine.url.get_dialect().name
-    if dialect_name == "sqlite" and database != ":memory:":
-        if database:
+    if dialect_name == "sqlite":
+        if database and database != ":memory:":
             Path(database).unlink()
     elif dialect_name == "postgresql":
         with engine.begin() as conn:

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -156,3 +156,5 @@ def test_cli_group_creation() -> None:
     assert "make-migrations" in cli_group.commands
     assert "drop-all" in cli_group.commands
     assert "dump-data" in cli_group.commands
+    assert "create" in cli_group.commands
+    assert "drop" in cli_group.commands

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -145,6 +145,26 @@ def test_dump_data(cli_runner: CliRunner, database_cli: Group, mock_context: Mag
     assert result.exit_code == 0
 
 
+def test_create(cli_runner: CliRunner, database_cli: Group, mock_context: MagicMock, tmp_path: Path) -> None:
+    """Test create the database."""
+
+    result = cli_runner.invoke(
+        database_cli,
+        ["--config", "tests.unit.fixtures.configs", "create", "--encoding", "latin1", "--no-prompt"],
+    )
+    assert result.exit_code == 0
+
+
+def test_drop(cli_runner: CliRunner, database_cli: Group, mock_context: MagicMock, tmp_path: Path) -> None:
+    """Test drop the database."""
+
+    result = cli_runner.invoke(
+        database_cli,
+        ["--config", "tests.unit.fixtures.configs", "drop", "--no-prompt"],
+    )
+    assert result.exit_code == 0
+
+
 def test_cli_group_creation() -> None:
     """Test that the CLI group is created correctly."""
     cli_group = add_migration_commands()


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

This code adds two generic database commands, `create` and `drop` for creating an new database and dropping an existing one respectively. It was briefly discussed some here: #365 . A lot of the code was taken from [SQLAlechemy Utils database.py](https://github.com/kvesteri/sqlalchemy-utils/blob/master/sqlalchemy_utils/functions/database.py) 

Currently, it still needs integration testing, so far I've only tested it locally with sqlite.

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
## Closes
