### PR TITLE
docs: add discord link in navbar

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -202,6 +202,7 @@ html_theme_options = {
     "logo_target": "/",
     "accent_color": "amber",
     "github_url": "https://github.com/litestar-org/advanced-alchemy",
+    "discord_url": "https://discord.gg/dSDXd4mKhp",
     "navigation_with_keys": True,
     "globaltoc_expand_depth": 2,
     "light_logo": "_static/logo-default.png",


### PR DESCRIPTION
 Hello,
 
 this add for the sibuya theme the discord link in the top bar
 
As we have a specific url in litestar discord, I can update the PR
I set the link to : https://discord.gg/dSDXd4mKhp
But we can use: https://discord.gg/litestar

That the message along the custom invite link.

<img width="665" alt="image" src="https://github.com/user-attachments/assets/d3d060c2-81ff-42e5-99db-f5064b33cd5c" />
