### PR TITLE
chore: add 3.13 to test ci workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,7 +96,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     uses: ./.github/workflows/test.yml
     with:
       coverage: ${{ matrix.python-version == '3.12' }}


### PR DESCRIPTION
This PR adds the 3.13 to the test in the CI

pyproject file already had the 3.13.

@cofin I do not know how to update the badge in the README to remove 3.8 (shields.io)

Also, should I update the CI to run on 3.13 instead of 3.12  ? (type checking, etc)