### PR TITLE
docs: update autopytabs min version of python to 3.9 and max version to 3.13

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -79,6 +79,9 @@ nitpicky = True
 nitpick_ignore: list[str] = []
 nitpick_ignore_regex: list[str] = []
 
+auto_pytabs_min_version = (3, 9)
+auto_pytabs_max_version = (3, 13)
+
 napoleon_google_docstring = True
 napoleon_include_special_with_doc = True
 napoleon_use_admonition_for_examples = True


### PR DESCRIPTION
This PR set the minimum python version for examples to 3.9 instead of default 3.7
Also it set the maximum to 3.13 instead of default 3.12
