### PR TITLE
feat(litestar): add session to namespace signature

### DIFF
--- a/advanced_alchemy/extensions/litestar/plugins/init/plugin.py
+++ b/advanced_alchemy/extensions/litestar/plugins/init/plugin.py
@@ -6,7 +6,8 @@ from litestar.di import Provide
 from litestar.dto import DTOData
 from litestar.params import Dependency, Parameter
 from litestar.plugins import CLIPlugin, InitPluginProtocol
-
+from sqlalchemy.orm import Session, scoped_session
+from sqlalchemy.ext.asyncio import AsyncSession, async_scoped_session
 from advanced_alchemy.exceptions import ImproperConfigurationError, RepositoryError
 from advanced_alchemy.extensions.litestar.exception_handler import exception_to_http_response
 from advanced_alchemy.extensions.litestar.plugins import _slots_base
@@ -52,6 +53,10 @@ signature_namespace_values: dict[str, Any] = {
     "ModelDTOT": ModelDTOT,
     "ModelDictListT": ModelDictListT,
     "ModelOrRowMappingT": ModelOrRowMappingT,
+    "Session": Session,
+    "scoped_session": scoped_session,
+    "AsyncSession": AsyncSession,
+    "async_scoped_session": async_scoped_session,
 }
 
 


### PR DESCRIPTION
The new filter providers expect that the sessions are in the signature namespace.  This ensures there are no issues when configuring the plugin.