### PR TITLE
fix(litestar): simplify session type hints in service providers

### DIFF
--- a/advanced_alchemy/extensions/litestar/providers.py
+++ b/advanced_alchemy/extensions/litestar/providers.py
@@ -46,8 +46,8 @@ from advanced_alchemy.service import (
 
 if TYPE_CHECKING:
     from sqlalchemy import Select
-    from sqlalchemy.ext.asyncio import AsyncSession, async_scoped_session
-    from sqlalchemy.orm import Session, scoped_session
+    from sqlalchemy.ext.asyncio import AsyncSession
+    from sqlalchemy.orm import Session
 
     from advanced_alchemy.config import SQLAlchemyAsyncConfig, SQLAlchemySyncConfig
 
@@ -179,7 +179,7 @@ def create_service_provider(
     if issubclass(service_class, SQLAlchemyAsyncRepositoryService) or service_class is SQLAlchemyAsyncRepositoryService:  # type: ignore[comparison-overlap]
 
         async def provide_async_service(
-            db_session: "Optional[Union[AsyncSession, async_scoped_session[AsyncSession]]]" = None,
+            db_session: "Optional[AsyncSession]" = None,
         ) -> "AsyncGenerator[AsyncServiceT_co, None]":  # type: ignore[union-attr,unused-ignore]
             async with service_class.new(  # type: ignore[union-attr,unused-ignore]
                 session=db_session,  # type: ignore[arg-type, unused-ignore]
@@ -196,7 +196,7 @@ def create_service_provider(
         return provide_async_service
 
     def provide_sync_service(
-        db_session: "Optional[Union[Session, scoped_session[Session]]]" = None,
+        db_session: "Optional[Session]" = None,
     ) -> "Generator[SyncServiceT_co, None, None]":
         with service_class.new(
             session=db_session,  # type: ignore[arg-type, unused-ignore]


### PR DESCRIPTION
Remove unnecessary scoped session type hints from service provider functions.

Prevents the following exception from being incorrectly raised:

`TypeError: Type unions may not contain more than one custom type - type typing.Union[sqlalchemy.ext.asyncio.session.AsyncSession, sqlalchemy.ext.asyncio.scoping.async_scoped_session[sqlalchemy.ext.asyncio.session.AsyncSession], NoneType] is not supported.`