### PR TITLE
feat(sanic)!: Refactor Sanic extension for multi-config support

### DIFF
--- a/advanced_alchemy/extensions/sanic/__init__.py
+++ b/advanced_alchemy/extensions/sanic/__init__.py
@@ -1,18 +1,21 @@
 from advanced_alchemy import base, exceptions, filters, mixins, operations, repository, service, types, utils
+from advanced_alchemy.alembic.commands import AlembicCommands
 from advanced_alchemy.config import (
     AlembicAsyncConfig,
     AlembicSyncConfig,
     AsyncSessionConfig,
     SyncSessionConfig,
 )
-from advanced_alchemy.extensions.sanic.config import SQLAlchemyAsyncConfig, SQLAlchemySyncConfig
+from advanced_alchemy.extensions.sanic.config import EngineConfig, SQLAlchemyAsyncConfig, SQLAlchemySyncConfig
 from advanced_alchemy.extensions.sanic.extension import AdvancedAlchemy
 
 __all__ = (
     "AdvancedAlchemy",
     "AlembicAsyncConfig",
+    "AlembicCommands",
     "AlembicSyncConfig",
     "AsyncSessionConfig",
+    "EngineConfig",
     "SQLAlchemyAsyncConfig",
     "SQLAlchemySyncConfig",
     "SyncSessionConfig",

--- a/advanced_alchemy/extensions/sanic/__init__.py
+++ b/advanced_alchemy/extensions/sanic/__init__.py
@@ -3,18 +3,16 @@ from advanced_alchemy.config import (
     AlembicAsyncConfig,
     AlembicSyncConfig,
     AsyncSessionConfig,
-    SQLAlchemyAsyncConfig,
-    SQLAlchemySyncConfig,
     SyncSessionConfig,
 )
-from advanced_alchemy.extensions.sanic.extension import AdvancedAlchemy, CommitStrategyExecutor
+from advanced_alchemy.extensions.sanic.config import SQLAlchemyAsyncConfig, SQLAlchemySyncConfig
+from advanced_alchemy.extensions.sanic.extension import AdvancedAlchemy
 
 __all__ = (
     "AdvancedAlchemy",
     "AlembicAsyncConfig",
     "AlembicSyncConfig",
     "AsyncSessionConfig",
-    "CommitStrategyExecutor",
     "SQLAlchemyAsyncConfig",
     "SQLAlchemySyncConfig",
     "SyncSessionConfig",

--- a/advanced_alchemy/extensions/sanic/config.py
+++ b/advanced_alchemy/extensions/sanic/config.py
@@ -1,0 +1,511 @@
+"""Configuration classes for Sanic integration.
+
+This module provides configuration classes for integrating SQLAlchemy with Sanic applications,
+including both synchronous and asynchronous database configurations.
+"""
+
+import asyncio
+import contextlib
+from dataclasses import dataclass, field
+from typing import Any, Callable, Optional, cast
+
+from click import echo
+from sanic import HTTPResponse, Request, Sanic
+from sqlalchemy.exc import OperationalError
+
+from advanced_alchemy.exceptions import ImproperConfigurationError
+
+try:
+    from sanic_ext import Extend
+
+    SANIC_INSTALLED = True
+except ModuleNotFoundError:  # pragma: no cover
+    SANIC_INSTALLED = False  # pyright: ignore[reportConstantRedefinition]
+    Extend = type("Extend", (), {})  # type: ignore  # noqa: PGH003
+
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
+from sqlalchemy.orm import Session, sessionmaker
+from typing_extensions import Literal
+
+from advanced_alchemy._serialization import decode_json, encode_json
+from advanced_alchemy.base import metadata_registry
+from advanced_alchemy.config import EngineConfig as _EngineConfig
+from advanced_alchemy.config.asyncio import SQLAlchemyAsyncConfig as _SQLAlchemyAsyncConfig
+from advanced_alchemy.config.sync import SQLAlchemySyncConfig as _SQLAlchemySyncConfig
+from advanced_alchemy.service import schema_dump
+
+
+def _make_unique_context_key(app: "Sanic[Any, Any]", key: str) -> str:  # pragma: no cover
+    """Generates a unique context key for the Sanic application.
+
+    Ensures that the key does not already exist in the application's state.
+
+    Args:
+        app (sanic.Sanic): The Sanic application instance.
+        key (str): The base key name.
+
+    Returns:
+        str: A unique key name.
+    """
+    i = 0
+    while True:
+        if not hasattr(app.ctx, key):
+            return key
+        key = f"{key}_{i}"
+        i += i
+
+
+def serializer(value: Any) -> str:
+    """Serialize JSON field values.
+
+    Args:
+        value: Any JSON serializable value.
+
+    Returns:
+        str: JSON string representation of the value.
+    """
+    return encode_json(schema_dump(value))
+
+
+@dataclass
+class EngineConfig(_EngineConfig):
+    """Configuration for SQLAlchemy's Engine.
+
+    This class extends the base EngineConfig with Sanic-specific JSON serialization options.
+
+    For details see: https://docs.sqlalchemy.org/en/20/core/engines.html
+
+    Attributes:
+        json_deserializer: Callable for converting JSON strings to Python objects.
+        json_serializer: Callable for converting Python objects to JSON strings.
+    """
+
+    json_deserializer: Callable[[str], Any] = decode_json
+    """For dialects that support the :class:`~sqlalchemy.types.JSON` datatype, this is a Python callable that will
+    convert a JSON string to a Python object.  But default, this uses the built-in serializers."""
+    json_serializer: Callable[[Any], str] = serializer
+    """For dialects that support the JSON datatype, this is a Python callable that will render a given object as JSON.
+    By default, By default, the built-in serializer is used."""
+
+
+@dataclass
+class SQLAlchemyAsyncConfig(_SQLAlchemyAsyncConfig):
+    """SQLAlchemy Async config for Sanic."""
+
+    _app: "Optional[Sanic[Any, Any]]" = None
+    """The Sanic application instance."""
+    commit_mode: Literal["manual", "autocommit", "autocommit_include_redirect"] = "manual"
+    """The commit mode to use for database sessions."""
+    engine_key: str = "db_engine"
+    """Key to use for the dependency injection of database engines."""
+    session_key: str = "db_session"
+    """Key to use for the dependency injection of database sessions."""
+    session_maker_key: str = "session_maker_class"
+    """Key under which to store the SQLAlchemy :class:`sessionmaker <sqlalchemy.orm.sessionmaker>` in the application state instance.
+    """
+
+    engine_config: EngineConfig = field(default_factory=EngineConfig)  # pyright: ignore[reportIncompatibleVariableOverride]
+    """Configuration for the SQLAlchemy engine.
+
+    The configuration options are documented in the SQLAlchemy documentation.
+    """
+
+    async def create_all_metadata(self) -> None:  # pragma: no cover
+        """Create all metadata tables in the database."""
+        if self.engine_instance is None:
+            self.engine_instance = self.get_engine()
+        async with self.engine_instance.begin() as conn:
+            try:
+                await conn.run_sync(
+                    metadata_registry.get(None if self.bind_key == "default" else self.bind_key).create_all
+                )
+                await conn.commit()
+            except OperationalError as exc:
+                echo(f" * Could not create target metadata. Reason: {exc}")
+            else:
+                echo(" * Created target metadata.")
+
+    @property
+    def app(self) -> "Sanic[Any, Any]":
+        """The Sanic application instance."""
+        if self._app is None:
+            msg = "The Sanic application instance is not set."
+            raise ImproperConfigurationError(msg)
+        return self._app
+
+    def init_app(self, app: "Sanic[Any, Any]", bootstrap: "Extend") -> None:  # pyright: ignore[reportUnknownParameterType,reportInvalidTypeForm]
+        """Initialize the Sanic application with this configuration.
+
+        Args:
+            app: The Sanic application instance.
+            bootstrap: The Sanic extension bootstrap.
+        """
+        self._app = app
+        self.bind_key = self.bind_key or "default"
+        _ = self.create_session_maker()
+        self.session_key = _make_unique_context_key(app, f"advanced_alchemy_async_session_{self.session_key}")
+        self.engine_key = _make_unique_context_key(app, f"advanced_alchemy_async_engine_{self.engine_key}")
+        self.session_maker_key = _make_unique_context_key(
+            app, f"advanced_alchemy_async_session_maker_{self.session_maker_key}"
+        )
+        self.startup(bootstrap)  # pyright: ignore[reportUnknownMemberType,reportUnknownArgumentType]
+
+    def startup(self, bootstrap: "Extend") -> None:  # pyright: ignore[reportUnknownParameterType,reportInvalidTypeForm]
+        """Initialize the Sanic application with this configuration.
+
+        Args:
+            bootstrap: The Sanic extension bootstrap.
+        """
+
+        @self.app.before_server_start  # pyright: ignore[reportUnknownMemberType]
+        async def on_startup(_: Any) -> None:  # pyright: ignore[reportUnusedFunction]
+            setattr(self.app.ctx, self.engine_key, self.get_engine())  # pyright: ignore[reportUnknownMemberType,reportUnknownArgumentType,reportOptionalMemberAccess]
+            setattr(self.app.ctx, self.session_maker_key, self.create_session_maker())  # pyright: ignore[reportUnknownMemberType,reportUnknownArgumentType,reportOptionalMemberAccess]
+            bootstrap.add_dependency(  # pyright: ignore[reportUnknownMemberType]
+                AsyncEngine,
+                self.get_engine_from_request,
+            )
+            bootstrap.add_dependency(  # pyright: ignore[reportUnknownMemberType]
+                async_sessionmaker[AsyncSession],
+                self.get_sessionmaker_from_request,
+            )
+            bootstrap.add_dependency(  # pyright: ignore[reportUnknownMemberType]
+                AsyncSession,
+                self.get_session_from_request,
+            )
+            await self.on_startup()
+
+        @self.app.after_server_stop  # pyright: ignore[reportUnknownMemberType]
+        async def on_shutdown(_: Any) -> None:  # pyright: ignore[reportUnusedFunction]
+            if self.engine_instance is not None:
+                await self.engine_instance.dispose()
+            if hasattr(self.app.ctx, self.engine_key):  # pyright: ignore[reportUnknownMemberType,reportUnknownArgumentType,reportOptionalMemberAccess]
+                delattr(self.app.ctx, self.engine_key)  # pyright: ignore[reportUnknownMemberType,reportUnknownArgumentType,reportOptionalMemberAccess]
+            if hasattr(self.app.ctx, self.session_maker_key):  # pyright: ignore[reportUnknownMemberType,reportUnknownArgumentType,reportOptionalMemberAccess]
+                delattr(self.app.ctx, self.session_maker_key)  # pyright: ignore[reportUnknownMemberType,reportUnknownArgumentType,reportOptionalMemberAccess]
+
+        @self.app.middleware("request")  # pyright: ignore[reportUnknownMemberType]
+        async def on_request(request: Request) -> None:  # pyright: ignore[reportUnusedFunction]
+            session = cast("Optional[AsyncSession]", getattr(request.ctx, self.session_key, None))
+            if session is None:
+                setattr(request.ctx, self.session_key, self.get_session())
+
+        @self.app.middleware("response")  # type: ignore[arg-type]
+        async def on_response(request: Request, response: HTTPResponse) -> None:  # pyright: ignore[reportUnusedFunction]
+            session = cast("Optional[AsyncSession]", getattr(request.ctx, self.session_key, None))
+            if session is not None:
+                await self.session_handler(session=session, request=request, response=response)
+
+    async def on_startup(self) -> None:
+        """Initialize the Sanic application with this configuration."""
+        if self.create_all:
+            await self.create_all_metadata()
+
+    def create_session_maker(self) -> Callable[[], "AsyncSession"]:
+        """Get a session maker. If none exists yet, create one.
+
+        Returns:
+            Callable[[], Session]: Session factory used by the plugin.
+        """
+        if self.session_maker:
+            return self.session_maker
+
+        session_kws = self.session_config_dict
+        if self.engine_instance is None:
+            self.engine_instance = self.get_engine()
+        if session_kws.get("bind") is None:
+            session_kws["bind"] = self.engine_instance
+        self.session_maker = self.session_maker_class(**session_kws)
+        return self.session_maker
+
+    async def session_handler(
+        self, session: "AsyncSession", request: "Request", response: "HTTPResponse"
+    ) -> None:  # pragma: no cover
+        """Handles the session after a request is processed.
+
+        Applies the commit strategy and ensures the session is closed.
+
+        Args:
+            session (sqlalchemy.ext.asyncio.AsyncSession):
+                The database session.
+            request (sanic.Request):
+                The incoming HTTP request.
+            response (sanic.HTTPResponse):
+                The outgoing HTTP response.
+
+        Returns:
+            None
+        """
+        try:
+            if (self.commit_mode == "autocommit" and 200 <= response.status < 300) or (  # noqa: PLR2004
+                self.commit_mode == "autocommit_include_redirect" and 200 <= response.status < 400  # noqa: PLR2004
+            ):
+                await session.commit()
+            else:
+                await session.rollback()
+        finally:
+            await session.close()
+            with contextlib.suppress(AttributeError, KeyError):
+                delattr(request.ctx, self.session_key)
+
+    def get_engine_from_request(self, request: "Request") -> AsyncEngine:
+        """Retrieve the engine from the request context.
+
+        Args:
+            request (sanic.Request): The incoming request.
+
+        Returns:
+            AsyncEngine: The SQLAlchemy engine.
+        """
+        return cast("AsyncEngine", getattr(request.app.ctx, self.engine_key, self.get_engine()))  # pragma: no cover
+
+    def get_sessionmaker_from_request(self, request: "Request") -> async_sessionmaker[AsyncSession]:
+        """Retrieve the session maker from the request context.
+
+        Args:
+            request (sanic.Request): The incoming request.
+
+        Returns:
+            SessionMakerT: The session maker.
+        """
+        return cast(
+            async_sessionmaker[AsyncSession], getattr(request.app.ctx, self.session_maker_key, None)
+        )  # pragma: no cover
+
+    def get_session_from_request(self, request: Request) -> AsyncSession:
+        """Retrieve the session from the request context.
+
+        Args:
+            request (sanic.Request): The incoming request.
+
+        Returns:
+            SessionT: The session associated with the request.
+        """
+        return cast("AsyncSession", getattr(request.ctx, self.session_key, None))  # pragma: no cover
+
+    async def close_engine(self) -> None:  # pragma: no cover
+        """Close the engine."""
+        if self.engine_instance is not None:
+            await self.engine_instance.dispose()
+
+    async def on_shutdown(self) -> None:  # pragma: no cover
+        """Handles the shutdown event by disposing of the SQLAlchemy engine.
+
+        Ensures that all connections are properly closed during application shutdown.
+
+        Returns:
+            None
+        """
+        await self.close_engine()
+        if hasattr(self.app.ctx, self.engine_key):  # pyright: ignore[reportUnknownMemberType,reportUnknownArgumentType,reportOptionalMemberAccess]
+            delattr(self.app.ctx, self.engine_key)  # pyright: ignore[reportUnknownMemberType,reportUnknownArgumentType,reportOptionalMemberAccess]
+        if hasattr(self.app.ctx, self.session_maker_key):  # pyright: ignore[reportUnknownMemberType,reportUnknownArgumentType,reportOptionalMemberAccess]
+            delattr(self.app.ctx, self.session_maker_key)  # pyright: ignore[reportUnknownMemberType,reportUnknownArgumentType,reportOptionalMemberAccess]
+
+
+@dataclass
+class SQLAlchemySyncConfig(_SQLAlchemySyncConfig):
+    """SQLAlchemy Sync config for Starlette."""
+
+    _app: "Optional[Sanic[Any, Any]]" = None
+    """The Sanic application instance."""
+    commit_mode: Literal["manual", "autocommit", "autocommit_include_redirect"] = "manual"
+    """The commit mode to use for database sessions."""
+    engine_key: str = "db_engine"
+    """Key to use for the dependency injection of database engines."""
+    session_key: str = "db_session"
+    """Key to use for the dependency injection of database sessions."""
+    session_maker_key: str = "session_maker_class"
+    """Key under which to store the SQLAlchemy :class:`sessionmaker <sqlalchemy.orm.sessionmaker>` in the application state instance.
+    """
+
+    engine_config: EngineConfig = field(default_factory=EngineConfig)  # pyright: ignore[reportIncompatibleVariableOverride]
+    """Configuration for the SQLAlchemy engine.
+
+    The configuration options are documented in the SQLAlchemy documentation.
+    """
+
+    @property
+    def app(self) -> "Sanic[Any, Any]":
+        """The Sanic application instance."""
+        if self._app is None:
+            msg = "The Sanic application instance is not set."
+            raise ImproperConfigurationError(msg)
+        return self._app
+
+    async def create_all_metadata(self) -> None:  # pragma: no cover
+        """Create all metadata tables in the database."""
+        if self.engine_instance is None:
+            self.engine_instance = self.get_engine()
+        with self.engine_instance.begin() as conn:
+            try:
+                loop = asyncio.get_event_loop()
+                await loop.run_in_executor(
+                    None, metadata_registry.get(None if self.bind_key == "default" else self.bind_key).create_all, conn
+                )
+            except OperationalError as exc:
+                echo(f" * Could not create target metadata. Reason: {exc}")
+
+    def init_app(self, app: "Sanic[Any, Any]", bootstrap: "Extend") -> None:  # pyright: ignore[reportUnknownParameterType,reportInvalidTypeForm]
+        """Initialize the Sanic application with this configuration.
+
+        Args:
+            app: The Sanic application instance.
+            bootstrap: The Sanic extension bootstrap.
+        """
+        self._app = app
+        self.bind_key = self.bind_key or "default"
+        _ = self.create_session_maker()
+        self.session_key = _make_unique_context_key(app, f"advanced_alchemy_sync_session_{self.session_key}")
+        self.engine_key = _make_unique_context_key(app, f"advanced_alchemy_sync_engine_{self.engine_key}")
+        self.session_maker_key = _make_unique_context_key(
+            app, f"advanced_alchemy_sync_session_maker_{self.session_maker_key}"
+        )
+        self.startup(bootstrap)  # pyright: ignore[reportUnknownMemberType,reportUnknownArgumentType]
+
+    def startup(self, bootstrap: "Extend") -> None:  # pyright: ignore[reportUnknownParameterType,reportInvalidTypeForm]
+        """Initialize the Sanic application with this configuration.
+
+        Args:
+            bootstrap: The Sanic extension bootstrap.
+        """
+
+        @self.app.before_server_start  # pyright: ignore[reportUnknownMemberType]
+        async def on_startup(_: Any) -> None:  # pyright: ignore[reportUnusedFunction]
+            setattr(self.app.ctx, self.engine_key, self.get_engine())  # pyright: ignore[reportUnknownMemberType,reportUnknownArgumentType,reportOptionalMemberAccess]
+            setattr(self.app.ctx, self.session_maker_key, self.create_session_maker())  # pyright: ignore[reportUnknownMemberType,reportUnknownArgumentType,reportOptionalMemberAccess]
+            bootstrap.add_dependency(  # pyright: ignore[reportUnknownMemberType]
+                AsyncEngine,
+                self.get_engine_from_request,
+            )
+            bootstrap.add_dependency(  # pyright: ignore[reportUnknownMemberType]
+                sessionmaker[Session],
+                self.get_sessionmaker_from_request,
+            )
+            bootstrap.add_dependency(  # pyright: ignore[reportUnknownMemberType]
+                AsyncSession,
+                self.get_session_from_request,
+            )
+            await self.on_startup()
+
+        @self.app.after_server_stop  # pyright: ignore[reportUnknownMemberType]
+        async def on_shutdown(_: Any) -> None:  # pyright: ignore[reportUnusedFunction]
+            await self.on_shutdown()
+
+        @self.app.middleware("request")  # pyright: ignore[reportUnknownMemberType]
+        async def on_request(request: Request) -> None:  # pyright: ignore[reportUnusedFunction]
+            session = cast("Optional[Session]", getattr(request.ctx, self.session_key, None))
+            if session is None:
+                setattr(request.ctx, self.session_key, self.get_session())
+
+        @self.app.middleware("response")  # type: ignore[arg-type]
+        async def on_response(request: Request, response: HTTPResponse) -> None:  # pyright: ignore[reportUnusedFunction]
+            session = cast("Optional[Session]", getattr(request.ctx, self.session_key, None))
+            if session is not None:
+                await self.session_handler(session=session, request=request, response=response)
+
+    async def on_startup(self) -> None:
+        """Initialize the Sanic application with this configuration."""
+        if self.create_all:
+            await self.create_all_metadata()
+
+    def create_session_maker(self) -> Callable[[], "Session"]:
+        """Get a session maker. If none exists yet, create one.
+
+        Returns:
+            Callable[[], Session]: Session factory used by the plugin.
+        """
+        if self.session_maker:
+            return self.session_maker
+
+        session_kws = self.session_config_dict
+        if self.engine_instance is None:
+            self.engine_instance = self.get_engine()
+        if session_kws.get("bind") is None:
+            session_kws["bind"] = self.engine_instance
+        self.session_maker = self.session_maker_class(**session_kws)
+        return self.session_maker
+
+    async def session_handler(
+        self, session: "Session", request: "Request", response: "HTTPResponse"
+    ) -> None:  # pragma: no cover
+        """Handles the session after a request is processed.
+
+        Applies the commit strategy and ensures the session is closed.
+
+        Args:
+            session (sqlalchemy.orm.Session):
+                The database session.
+            request (sanic.Request):
+                The incoming HTTP request.
+            response (sanic.HTTPResponse):
+                The outgoing HTTP response.
+
+        Returns:
+            None
+        """
+        loop = asyncio.get_event_loop()
+        try:
+            if (self.commit_mode == "autocommit" and 200 <= response.status < 300) or (  # noqa: PLR2004
+                self.commit_mode == "autocommit_include_redirect" and 200 <= response.status < 400  # noqa: PLR2004
+            ):
+                await loop.run_in_executor(None, session.commit)
+            else:
+                await loop.run_in_executor(None, session.rollback)
+        finally:
+            await loop.run_in_executor(None, session.close)
+            with contextlib.suppress(AttributeError, KeyError):
+                delattr(request.ctx, self.session_key)
+
+    def get_engine_from_request(self, request: Request) -> "AsyncEngine":
+        """Retrieve the engine from the request context.
+
+        Args:
+            request (sanic.Request): The incoming request.
+
+        Returns:
+            AsyncEngine: The SQLAlchemy engine.
+        """
+        return cast("AsyncEngine", getattr(request.app.ctx, self.engine_key, self.get_engine()))  # pragma: no cover
+
+    def get_sessionmaker_from_request(self, request: Request) -> sessionmaker[Session]:
+        """Retrieve the session maker from the request context.
+
+        Args:
+            request (sanic.Request): The incoming request.
+
+        Returns:
+            SessionMakerT: The session maker.
+        """
+        return cast(sessionmaker[Session], getattr(request.app.ctx, self.session_maker_key, None))  # pragma: no cover
+
+    def get_session_from_request(self, request: Request) -> "Session":
+        """Retrieve the session from the request context.
+
+        Args:
+            request (sanic.Request): The incoming request.
+
+        Returns:
+            SessionT: The session associated with the request.
+        """
+        return cast("Session", getattr(request.ctx, self.session_key, None))  # pragma: no cover
+
+    async def close_engine(self) -> None:  # pragma: no cover
+        """Close the engine."""
+        if self.engine_instance is not None:
+            loop = asyncio.get_event_loop()
+            await loop.run_in_executor(None, self.engine_instance.dispose)
+
+    async def on_shutdown(self) -> None:  # pragma: no cover
+        """Handles the shutdown event by disposing of the SQLAlchemy engine.
+
+        Ensures that all connections are properly closed during application shutdown.
+
+        Returns:
+            None
+        """
+        await self.close_engine()
+        if hasattr(self.app.ctx, self.engine_key):  # pyright: ignore[reportUnknownMemberType,reportUnknownArgumentType,reportOptionalMemberAccess]
+            delattr(self.app.ctx, self.engine_key)  # pyright: ignore[reportUnknownMemberType,reportUnknownArgumentType,reportOptionalMemberAccess]
+        if hasattr(self.app.ctx, self.session_maker_key):  # pyright: ignore[reportUnknownMemberType,reportUnknownArgumentType,reportOptionalMemberAccess]
+            delattr(self.app.ctx, self.session_maker_key)  # pyright: ignore[reportUnknownMemberType,reportUnknownArgumentType,reportOptionalMemberAccess]

--- a/advanced_alchemy/extensions/sanic/extension.py
+++ b/advanced_alchemy/extensions/sanic/extension.py
@@ -1,15 +1,13 @@
-import asyncio
-from typing import TYPE_CHECKING, Any, Callable, Generic, Optional, Protocol, Union, cast, overload
+from collections.abc import AsyncGenerator, Generator, Sequence
+from contextlib import asynccontextmanager, contextmanager
+from typing import TYPE_CHECKING, Any, Callable, Optional, Union, cast, overload
 
-from sanic import HTTPResponse, Request, Sanic
-from sqlalchemy import Engine
-from sqlalchemy.ext.asyncio import AsyncSession
+from sanic import Request, Sanic
 
-from advanced_alchemy.config.common import EngineT, SessionMakerT, SessionT
-from advanced_alchemy.exceptions import MissingDependencyError
+from advanced_alchemy.exceptions import ImproperConfigurationError, MissingDependencyError
+from advanced_alchemy.extensions.sanic.config import SQLAlchemyAsyncConfig, SQLAlchemySyncConfig
 
 try:
-    from sanic.helpers import Default, _default  # pyright: ignore[reportPrivateUsage]
     from sanic_ext import Extend
     from sanic_ext.extensions.base import Extension
 
@@ -18,314 +16,248 @@ except ModuleNotFoundError:  # pragma: no cover
     SANIC_INSTALLED = False  # pyright: ignore[reportConstantRedefinition]
     Extension = type("Extension", (), {})  # type: ignore  # noqa: PGH003
     Extend = type("Extend", (), {})  # type: ignore  # noqa: PGH003
-    Default = type("Default", (), {})  # type: ignore  # noqa: PGH003
-    _default = Default()
 
 if TYPE_CHECKING:
-    from sqlalchemy.ext.asyncio import AsyncEngine, async_sessionmaker
-    from sqlalchemy.orm import Session, sessionmaker
-
-    from advanced_alchemy.config.asyncio import SQLAlchemyAsyncConfig
-    from advanced_alchemy.config.sync import SQLAlchemySyncConfig
-    from advanced_alchemy.config.types import CommitStrategy
-
-__all__ = ("AdvancedAlchemy", "CommitStrategyExecutor")
+    from sanic import Sanic
+    from sqlalchemy import Engine
+    from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
+    from sqlalchemy.orm import Session
 
 
-class CommitStrategyExecutor(Protocol):
-    async def __call__(self, *, session: Union["Session", "AsyncSession"], response: HTTPResponse) -> None: ...
+__all__ = ("AdvancedAlchemy",)
 
 
-class AdvancedAlchemy(Generic[EngineT, SessionT, SessionMakerT], Extension):  # type: ignore[no-untyped-call]  # pyright: ignore[reportGeneralTypeIssues,reportUntypedBaseClass]
+class AdvancedAlchemy(Extension):  # type: ignore[no-untyped-call]  # pyright: ignore[reportGeneralTypeIssues,reportUntypedBaseClass]
     """Sanic extension for integrating Advanced Alchemy with SQLAlchemy.
 
     Args:
-        sqlalchemy_config (advanced_alchemy.config.sync.SQLAlchemySyncConfig | advanced_alchemy.config.asyncio.SQLAlchemyAsyncConfig):
-            Configuration for SQLAlchemy.
-        autocommit (advanced_alchemy.config.types.CommitStrategy | None):
-            Strategy for committing transactions. Defaults to None.
-        counters (sanic.helpers.Default | bool | None):
-            Enables or disables counters. Defaults to sanic.helpers._default.
-        session_maker_key (str| None):
-            Key for the session maker in app context. Defaults to "sessionmaker".
-        engine_key (str| None):
-            Key for the engine in app context. Defaults to "engine".
-        session_key (str| None):
-            Key for the session in request context. Defaults to "session".
+        config: One or more configurations for SQLAlchemy.
+        app: The Sanic application instance.
     """
 
     name = "AdvancedAlchemy"
 
-    @overload
     def __init__(
-        self: "AdvancedAlchemy['AsyncEngine', 'AsyncSession', 'async_sessionmaker[AsyncSession]']",
+        self,
         *,
-        sqlalchemy_config: "SQLAlchemyAsyncConfig",
-        autocommit: Optional["CommitStrategy"] = None,
-        counters: Union[Default, bool] = _default,  # pyright: ignore[reportInvalidTypeForm,reportUnknownParameterType]
-        session_maker_key: str = "sessionmaker",
-        engine_key: str = "engine",
-        session_key: str = "session",
-    ) -> None: ...
-
-    @overload
-    def __init__(
-        self: "AdvancedAlchemy['Engine', 'Session', 'sessionmaker[Session]']",
-        *,
-        sqlalchemy_config: "SQLAlchemySyncConfig",
-        autocommit: Optional["CommitStrategy"] = None,
-        counters: Union[Default, bool] = _default,  # pyright: ignore[reportInvalidTypeForm,reportUnknownParameterType]
-        session_maker_key: str = "sessionmaker",
-        engine_key: str = "engine",
-        session_key: str = "session",
-    ) -> None: ...
-
-    def __init__(
-        self: (
-            Union[
-                "AdvancedAlchemy['AsyncEngine', 'AsyncSession', 'async_sessionmaker[AsyncSession]']",
-                "AdvancedAlchemy['Engine', 'Session', 'sessionmaker[Session]']",
-            ]
-        ),
-        *,
-        sqlalchemy_config: Union["SQLAlchemySyncConfig", "SQLAlchemyAsyncConfig"],
-        autocommit: Optional["CommitStrategy"] = None,
-        counters: Union[Default, bool] = _default,  # pyright: ignore[reportInvalidTypeForm,reportUnknownParameterType]
-        session_maker_key: str = "sessionmaker",
-        engine_key: str = "engine",
-        session_key: str = "session",
+        sqlalchemy_config: Union[
+            "SQLAlchemyAsyncConfig",
+            "SQLAlchemySyncConfig",
+            Sequence[Union["SQLAlchemyAsyncConfig", "SQLAlchemySyncConfig"]],
+        ],
+        sanic_app: Optional["Sanic[Any, Any]"] = None,
     ) -> None:
         if not SANIC_INSTALLED:  # pragma: no cover
             msg = "Could not locate either Sanic or Sanic Extensions. Both libraries must be installed to use Advanced Alchemy. Try: pip install sanic[ext]"
-            raise MissingDependencyError(
-                msg,
-            )
-        self.sqlalchemy_config = sqlalchemy_config
-        self.engine_key = engine_key
-        self.session_maker_key = session_maker_key
-        self.session_key = session_key
-        self.autocommit_strategy = autocommit
-        self._commit_strategies: dict[CommitStrategy, CommitStrategyExecutor] = {  # pyright: ignore[reportAttributeAccessIssue]
-            "always": self._commit_strategy_always,
-            "match_status": self._commit_strategy_match_status,
-        }
-        self.counters = counters
-        self.engine = (
-            self.sqlalchemy_config.engine_instance
-            if self.sqlalchemy_config.engine_instance is not None
-            else self.sqlalchemy_config.get_engine()
-        )
-        self.session_maker = self.sqlalchemy_config.create_session_maker()
+            raise MissingDependencyError(msg)
+        self._config = sqlalchemy_config if isinstance(sqlalchemy_config, Sequence) else [sqlalchemy_config]
+        self._mapped_configs: dict[str, Union[SQLAlchemyAsyncConfig, SQLAlchemySyncConfig]] = self.map_configs()
+        self._app = sanic_app
+        self._initialized = False
+        if self._app is not None:
+            self.register(self._app)
 
-        session_maker = cast("SessionMakerT", self.session_maker)
-        self.session_class = session_maker.class_
+    def register(self, sanic_app: "Sanic[Any, Any]") -> None:
+        """Initialize the extension with the given Sanic app."""
+        self._app = sanic_app
+        Extend.register(self)  # pyright: ignore[reportUnknownMemberType,reportAttributeAccessIssue]
+        self._initialized = True
 
-        self.app: Sanic  # pyright: ignore[reportMissingTypeArgument]
+    @property
+    def sanic_app(self) -> "Sanic[Any, Any]":
+        """The Sanic app."""
+        if self._app is None:  # pragma: no cover
+            msg = "AdvancedAlchemy has not been initialized with a Sanic app."
+            raise ImproperConfigurationError(msg)
+        return self._app
 
-    async def _do_commit(self, session: Union["Session", "AsyncSession"]) -> None:  # pragma: no cover
-        """Commit the current transaction.
+    @property
+    def sqlalchemy_config(self) -> Sequence[Union["SQLAlchemyAsyncConfig", "SQLAlchemySyncConfig"]]:
+        """Current Advanced Alchemy configuration."""
 
-        Args:
-            session (sqlalchemy.orm.Session | sqlalchemy.ext.asyncio.AsyncSession):
-                The session to commit.
-        """
-        if not isinstance(session, AsyncSession):
-            loop = asyncio.get_event_loop()
-            await loop.run_in_executor(None, session.commit)
-        else:
-            await session.commit()
+        return self._config
 
-    async def _do_rollback(self, session: Union["Session", "AsyncSession"]) -> None:  # pragma: no cover
-        """Rollback the current transaction.
-
-        Args:
-            session (sqlalchemy.orm.Session | sqlalchemy.ext.asyncio.AsyncSession):
-                The session to rollback.
-        """
-        if not isinstance(session, AsyncSession):
-            loop = asyncio.get_event_loop()
-            await loop.run_in_executor(None, session.rollback)
-        else:
-            await session.rollback()
-
-    async def _do_close(self, session: Union["Session", "AsyncSession"]) -> None:  # pragma: no cover
-        """Close the session.
-
-        Args:
-            session (sqlalchemy.orm.Session | sqlalchemy.ext.asyncio.AsyncSession):
-                The session to close.
-        """
-        if not isinstance(session, AsyncSession):
-            loop = asyncio.get_event_loop()
-            await loop.run_in_executor(None, session.close)
-        else:
-            await session.close()
-
-    async def _commit_strategy_always(
-        self, *, session: Union["Session", "AsyncSession"], response: HTTPResponse
-    ) -> None:  # pragma: no cover
-        """Commit strategy that always commits the session.
-
-        Args:
-            session (sqlalchemy.orm.Session | sqlalchemy.ext.asyncio.AsyncSession):
-                The session to commit.
-            response (sanic.HTTPResponse):
-                The HTTP response.
-        """
-        await self._do_commit(session)
-
-    async def _commit_strategy_match_status(
-        self, *, session: Union["Session", "AsyncSession"], response: HTTPResponse
-    ) -> None:  # pragma: no cover
-        """Commit strategy that commits based on the response status.
-
-        Args:
-            session (sqlalchemy.orm.Session | sqlalchemy.ext.asyncio.AsyncSession):
-                The session to commit or rollback.
-            response (sanic.HTTPResponse):
-                The HTTP response.
-        """
-        if 200 <= response.status < 300:  # noqa: PLR2004
-            await self._do_commit(session)
-        else:
-            await self._do_rollback(session)
-
-    async def session_handler(
-        self, session: Union["Session", "AsyncSession"], request: Request, response: HTTPResponse
-    ) -> None:  # pragma: no cover
-        """Handle the session lifecycle based on the commit strategy.
-
-        Args:
-            session (sqlalchemy.orm.Session | sqlalchemy.ext.asyncio.AsyncSession):
-                The current session.
-            request (sanic.Request):
-                The incoming request.
-            response (sanic.HTTPResponse):
-                The outgoing response.
-        """
-        try:
-            if self.autocommit_strategy:
-                await self._commit_strategies[self.autocommit_strategy](session=session, response=response)  # pyright: ignore[reportArgumentType]
-        finally:
-            await self._do_close(session)
-            delattr(request.ctx, self.session_key)
-
-    def get_engine(self) -> EngineT:  # pragma: no cover
-        """Retrieve the SQLAlchemy engine from the app context.
-
-        Returns:
-            EngineT: The SQLAlchemy engine.
-        """
-        engine = getattr(self.app.ctx, self.engine_key, None)  # pyright: ignore[reportUnknownMemberType,reportUnknownArgumentType]
-        if engine is not None:
-            return cast(EngineT, engine)
-        engine = cast(EngineT, self.engine)
-        setattr(self.app.ctx, self.engine_key, engine)  # pyright: ignore[reportUnknownMemberType,reportUnknownArgumentType]
-        return engine
-
-    def get_sessionmaker(self) -> Callable[[], SessionT]:
-        """Retrieve the session maker.
-
-        Returns:
-            Callable[[], SessionT]: A callable that returns a new session.
-        """
-        return cast(Callable[[], SessionT], self.session_maker)
-
-    def get_session(self, request: Request) -> SessionT:
-        """Retrieve or create a session for the current request.
-
-        Args:
-            request (sanic.Request): The incoming request.
-
-        Returns:
-            SessionT: The session associated with the request.
-        """
-        session = getattr(request.ctx, self.session_key, None)
-        if session is not None:  # pragma: no cover
-            return cast(SessionT, session)
-
-        session = cast("SessionT", self.session_maker())
-        setattr(request.ctx, self.session_key, session)
-        return session
-
-    def get_engine_from_request(self, request: Request) -> EngineT:
-        """Retrieve the engine from the request context.
-
-        Args:
-            request (sanic.Request): The incoming request.
-
-        Returns:
-            EngineT: The SQLAlchemy engine.
-        """
-        return cast("EngineT", getattr(request.app.ctx, self.engine_key, None))  # pragma: no cover
-
-    def get_sessionmaker_from_request(self, request: Request) -> SessionMakerT:
-        """Retrieve the session maker from the request context.
-
-        Args:
-            request (sanic.Request): The incoming request.
-
-        Returns:
-            SessionMakerT: The session maker.
-        """
-        return cast("SessionMakerT", getattr(request.app.ctx, self.session_maker_key, None))  # pragma: no cover
-
-    def get_session_from_request(self, request: Request) -> SessionT:
-        """Retrieve the session from the request context.
-
-        Args:
-            request (sanic.Request): The incoming request.
-
-        Returns:
-            SessionT: The session associated with the request.
-        """
-        return cast("SessionT", getattr(request.ctx, self.session_key, None))  # pragma: no cover
-
-    def startup(self, bootstrap: Extend) -> None:  # pyright: ignore[reportUnknownParameterType,reportInvalidTypeForm]
+    def startup(self, bootstrap: "Extend") -> None:  # pyright: ignore[reportUnknownParameterType,reportInvalidTypeForm]
         """Advanced Alchemy Sanic extension startup hook.
 
         Args:
             bootstrap (sanic_ext.Extend): The Sanic extension bootstrap.
         """
+        for config in self.sqlalchemy_config:
+            config.init_app(self.sanic_app, bootstrap)  # pyright: ignore[reportUnknownMemberType,reportUnknownArgumentType]
 
-        @self.app.before_server_start  # pyright: ignore[reportUnknownMemberType]
-        async def on_startup(_: Any) -> None:  # pyright: ignore[reportUnusedFunction]
-            setattr(self.app.ctx, self.engine_key, self.engine)  # pyright: ignore[reportUnknownMemberType,reportUnknownArgumentType]
-            setattr(self.app.ctx, self.session_maker_key, self.session_maker)  # pyright: ignore[reportUnknownMemberType,reportUnknownArgumentType]
-            bootstrap.add_dependency(  # pyright: ignore[reportUnknownMemberType]
-                type(self.engine),
-                self.get_engine_from_request,
-            )
-            bootstrap.add_dependency(  # pyright: ignore[reportUnknownMemberType]
-                type(self.session_maker),
-                self.get_sessionmaker_from_request,
-            )
-            bootstrap.add_dependency(  # pyright: ignore[reportUnknownMemberType]
-                self.session_class,
-                self.get_session_from_request,
-            )
+    def map_configs(self) -> dict[str, Union["SQLAlchemyAsyncConfig", "SQLAlchemySyncConfig"]]:
+        """Maps the configs to the session bind keys."""
+        mapped_configs: dict[str, Union[SQLAlchemyAsyncConfig, SQLAlchemySyncConfig]] = {}
+        for config in self.sqlalchemy_config:
+            if config.bind_key is None:
+                config.bind_key = "default"
+            mapped_configs[config.bind_key] = config
+        return mapped_configs
 
-        @self.app.after_server_stop  # pyright: ignore[reportUnknownMemberType]
-        async def on_shutdown(_: Any) -> None:  # pyright: ignore[reportUnusedFunction]
-            if isinstance(self.engine, Engine):
-                loop = asyncio.get_event_loop()
-                await loop.run_in_executor(None, self.engine.dispose)
-            else:
-                await self.engine.dispose()
-            if hasattr(self.app.ctx, self.engine_key):  # pyright: ignore[reportUnknownMemberType,reportUnknownArgumentType]
-                delattr(self.app.ctx, self.engine_key)  # pyright: ignore[reportUnknownMemberType,reportUnknownArgumentType]
-            if hasattr(self.app.ctx, self.session_maker_key):  # pyright: ignore[reportUnknownMemberType,reportUnknownArgumentType]
-                delattr(self.app.ctx, self.session_maker_key)  # pyright: ignore[reportUnknownMemberType,reportUnknownArgumentType]
+    def get_config(self, key: Optional[str] = None) -> Union["SQLAlchemyAsyncConfig", "SQLAlchemySyncConfig"]:
+        """Get the config for the given key."""
+        if key is None:
+            key = "default"
+        if key == "default" and len(self.sqlalchemy_config) == 1:
+            key = self.sqlalchemy_config[0].bind_key or "default"
+        config = self._mapped_configs.get(key)
+        if config is None:  # pragma: no cover
+            msg = f"Config with key {key} not found"
+            raise ImproperConfigurationError(msg)
+        return config
 
-        @self.app.middleware("request")  # pyright: ignore[reportUnknownMemberType]
-        async def on_request(request: Request) -> None:  # pyright: ignore[reportUnusedFunction]
-            session = cast("Optional[Union['Session', 'AsyncSession']]", getattr(request.ctx, self.session_key, None))
-            if session is None:
-                session = self.get_session(request)
-                setattr(request.ctx, self.session_key, session)
+    def get_async_config(self, key: Optional[str] = None) -> "SQLAlchemyAsyncConfig":
+        """Get the async config for the given key."""
+        config = self.get_config(key)
+        if not isinstance(config, SQLAlchemyAsyncConfig):  # pragma: no cover
+            msg = "Expected an async config, but got a sync config"
+            raise ImproperConfigurationError(msg)
+        return config
 
-        @self.app.middleware("response")  # type: ignore[arg-type]
-        async def on_response(request: Request, response: HTTPResponse) -> None:  # pyright: ignore[reportUnusedFunction]
-            session = cast("Optional[Union['Session', 'AsyncSession']]", getattr(request.ctx, self.session_key, None))
-            if session is not None:
-                await self.session_handler(session=session, request=request, response=response)
+    def get_sync_config(self, key: Optional[str] = None) -> "SQLAlchemySyncConfig":
+        """Get the sync config for the given key."""
+        config = self.get_config(key)
+        if not isinstance(config, SQLAlchemySyncConfig):  # pragma: no cover
+            msg = "Expected a sync config, but got an async config"
+            raise ImproperConfigurationError(msg)
+        return config
+
+    @asynccontextmanager
+    async def with_async_session(
+        self, key: Optional[str] = None
+    ) -> AsyncGenerator["AsyncSession", None]:  # pragma: no cover
+        """Context manager for getting an async session."""
+        config = self.get_async_config(key)
+        async with config.get_session() as session:
+            yield session
+
+    @contextmanager
+    def with_sync_session(self, key: Optional[str] = None) -> Generator["Session", None]:  # pragma: no cover
+        """Context manager for getting a sync session."""
+        config = self.get_sync_config(key)
+        with config.get_session() as session:
+            yield session
+
+    @overload
+    @staticmethod
+    def _get_session_from_request(request: "Request", config: "SQLAlchemyAsyncConfig") -> "AsyncSession": ...
+
+    @overload
+    @staticmethod
+    def _get_session_from_request(request: "Request", config: "SQLAlchemySyncConfig") -> "Session": ...
+
+    @staticmethod
+    def _get_session_from_request(
+        request: "Request",
+        config: Union["SQLAlchemyAsyncConfig", "SQLAlchemySyncConfig"],  # pragma: no cover
+    ) -> Union["Session", "AsyncSession"]:  # pragma: no cover
+        """Get the session for the given key."""
+        session = getattr(request.ctx, config.session_key, None)
+        if session is None:
+            setattr(request.ctx, config.session_key, config.get_session())
+        return cast(Union["Session", "AsyncSession"], session)
+
+    def get_session(
+        self, request: "Request", key: Optional[str] = None
+    ) -> Union["Session", "AsyncSession"]:  # pragma: no cover
+        """Get the session for the given key."""
+        config = self.get_config(key)
+        return self._get_session_from_request(request, config)
+
+    def get_async_session(self, request: "Request", key: Optional[str] = None) -> "AsyncSession":  # pragma: no cover
+        """Get the async session for the given key."""
+        config = self.get_async_config(key)
+        return self._get_session_from_request(request, config)
+
+    def get_sync_session(self, request: "Request", key: Optional[str] = None) -> "Session":  # pragma: no cover
+        """Get the sync session for the given key."""
+        config = self.get_sync_config(key)
+        return self._get_session_from_request(request, config)
+
+    def provide_session(
+        self, key: Optional[str] = None
+    ) -> Callable[["Request"], Union["Session", "AsyncSession"]]:  # pragma: no cover
+        """Get the session for the given key."""
+        config = self.get_config(key)
+
+        def _get_session(request: "Request") -> Union["Session", "AsyncSession"]:
+            return self._get_session_from_request(request, config)
+
+        return _get_session
+
+    def provide_async_session(
+        self, key: Optional[str] = None
+    ) -> Callable[["Request"], "AsyncSession"]:  # pragma: no cover
+        """Get the async session for the given key."""
+        config = self.get_async_config(key)
+
+        def _get_session(request: Request) -> "AsyncSession":
+            return self._get_session_from_request(request, config)
+
+        return _get_session
+
+    def provide_sync_session(self, key: Optional[str] = None) -> Callable[[Request], "Session"]:  # pragma: no cover
+        """Get the sync session for the given key."""
+        config = self.get_sync_config(key)
+
+        def _get_session(request: Request) -> "Session":
+            return self._get_session_from_request(request, config)
+
+        return _get_session
+
+    def get_engine(self, key: Optional[str] = None) -> Union["Engine", "AsyncEngine"]:  # pragma: no cover
+        """Get the engine for the given key."""
+        config = self.get_config(key)
+        return config.get_engine()
+
+    def get_async_engine(self, key: Optional[str] = None) -> "AsyncEngine":  # pragma: no cover
+        """Get the async engine for the given key."""
+        config = self.get_async_config(key)
+        return config.get_engine()
+
+    def get_sync_engine(self, key: Optional[str] = None) -> "Engine":  # pragma: no cover
+        """Get the sync engine for the given key."""
+        config = self.get_sync_config(key)
+        return config.get_engine()
+
+    def provide_engine(
+        self, key: Optional[str] = None
+    ) -> Callable[[], Union["Engine", "AsyncEngine"]]:  # pragma: no cover
+        """Get the engine for the given key."""
+        config = self.get_config(key)
+
+        def _get_engine() -> Union["Engine", "AsyncEngine"]:
+            return config.get_engine()
+
+        return _get_engine
+
+    def provide_async_engine(self, key: Optional[str] = None) -> Callable[[], "AsyncEngine"]:  # pragma: no cover
+        """Get the async engine for the given key."""
+        config = self.get_async_config(key)
+
+        def _get_engine() -> "AsyncEngine":
+            return config.get_engine()
+
+        return _get_engine
+
+    def provide_sync_engine(self, key: Optional[str] = None) -> Callable[[], "Engine"]:  # pragma: no cover
+        """Get the sync engine for the given key."""
+        config = self.get_sync_config(key)
+
+        def _get_engine() -> "Engine":
+            return config.get_engine()
+
+        return _get_engine
+
+    def add_session_dependency(
+        self, session_type: type[Union["Session", "AsyncSession"]], key: Optional[str] = None
+    ) -> None:
+        """Add a session dependency to the Sanic app."""
+        self.sanic_app.ext.add_dependency(session_type, self.provide_session(key))  # pyright: ignore[reportUnknownMemberType]
+
+    def add_engine_dependency(
+        self, engine_type: type[Union["Engine", "AsyncEngine"]], key: Optional[str] = None
+    ) -> None:
+        """Add an engine dependency to the Sanic app."""
+        self.sanic_app.ext.add_dependency(engine_type, self.provide_engine(key))  # pyright: ignore[reportUnknownMemberType]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -279,7 +279,6 @@ docstring-code-format = true
 docstring-code-line-length = 60
 
 [tool.ruff.lint]
-dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 extend-safe-fixes = ["TC"]
 fixable = ["ALL"]
 ignore = [

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -21,7 +21,9 @@ sonar.coverage.exclusions=\
   advanced_alchemy/service/_sync.py, \
   advanced_alchemy/service/_async.py, \
   advanced_alchemy/service/pagination.py, \
-  advanced_alchemy/extensions/litestar/plugins/init/config/*.py
+  advanced_alchemy/extensions/litestar/plugins/init/config/*.py, \
+  advanced_alchemy/extensions/sanic/config.py, \
+  advanced_alchemy/extensions/sanic/extension.py
 sonar.cpd.exclusions=\
   advanced_alchemy/repository/memory/_sync.py, \
   advanced_alchemy/repository/memory/_async.py, \
@@ -34,5 +36,7 @@ sonar.cpd.exclusions=\
   examples/*.py, \
   examples/fastapi.py, \
   tests/integration/conftest.py, \
-  advanced_alchemy/extensions/litestar/plugins/init/config/*.py
+  advanced_alchemy/extensions/litestar/plugins/init/config/*.py, \
+  advanced_alchemy/extensions/sanic/config.py, \
+  advanced_alchemy/extensions/sanic/extension.py
 sonar.projectName=Advanced Alchemy


### PR DESCRIPTION
This commit refactors the Sanic extension for Advanced Alchemy:

- Refactored configuration handling with support for multiple database configurations
- Added methods for retrieving async and sync sessions, engines, and configs
- Improved dependency injection with new provider methods
- Simplified extension initialization and registration
- Updated example and test files to reflect new extension structure
- Removed deprecated methods and simplified the extension interface

