### PR TITLE
feat: allow custom `not_found` error messages

### DIFF
--- a/advanced_alchemy/repository/_util.py
+++ b/advanced_alchemy/repository/_util.py
@@ -62,6 +62,7 @@ DEFAULT_ERROR_MESSAGE_TEMPLATES: ErrorMessages = {
     "duplicate_key": "A record matching the supplied data already exists.",
     "other": "There was an error during data processing",
     "check_constraint": "The data failed a check constraint during processing",
+    "not_found": "The requested resource was not found",
 }
 """Default error messages for repository errors."""
 

--- a/tests/unit/test_exceptions.py
+++ b/tests/unit/test_exceptions.py
@@ -18,6 +18,7 @@ from advanced_alchemy.exceptions import (
     IntegrityError,
     InvalidRequestError,
     MultipleResultsFoundError,
+    NotFoundError,
     RepositoryError,
     wrap_sqlalchemy_exception,
 )
@@ -99,6 +100,11 @@ def test_wrap_sqlalchemy_exception_attribute_error() -> None:
         raise AttributeError("original")
 
 
+def test_wrap_sqlalchemy_exception_not_found_error() -> None:
+    with pytest.raises(NotFoundError, match="No rows matched the specified data"), wrap_sqlalchemy_exception():
+        raise NotFoundError("No item found when one was expected")
+
+
 def test_wrap_sqlalchemy_exception_no_wrap() -> None:
     with pytest.raises(SQLAlchemyError), wrap_sqlalchemy_exception(wrap_exceptions=False):
         raise SQLAlchemyError("original")
@@ -110,6 +116,19 @@ def test_wrap_sqlalchemy_exception_no_wrap() -> None:
         raise SQLAlchemyInvalidRequestError()
     with pytest.raises(AttributeError), wrap_sqlalchemy_exception(wrap_exceptions=False):
         raise AttributeError()
+    with (
+        pytest.raises(NotFoundError, match="No item found when one was expected"),
+        wrap_sqlalchemy_exception(wrap_exceptions=False),
+    ):
+        raise NotFoundError("No item found when one was expected")
+
+
+def test_custom_not_found_error_message() -> None:
+    with (
+        pytest.raises(NotFoundError, match="Custom Error"),
+        wrap_sqlalchemy_exception(error_messages={"not_found": "Custom Error"}),
+    ):
+        raise NotFoundError("original")
 
 
 def test_wrap_sqlalchemy_exception_custom_error_message() -> None:


### PR DESCRIPTION
Enhance the SQLAlchemy exception wrapper to handle NotFoundError with custom error messages and improved error handling. This includes:

- Adding a 'not_found' key to ErrorMessages type
- Extending wrap_sqlalchemy_exception to catch and handle NotFoundError
- Updating default error message templates with a not_found message
- Adding unit tests for custom NotFoundError handling