### PR TITLE
fix: correctly set `uniquify` from `new`

### DIFF
--- a/advanced_alchemy/_serialization.py
+++ b/advanced_alchemy/_serialization.py
@@ -5,7 +5,7 @@ from typing import Any
 from typing_extensions import runtime_checkable
 
 try:
-    from pydantic import BaseModel  # type: ignore # noqa: PGH003
+    from pydantic import BaseModel  # type: ignore
 
     PYDANTIC_INSTALLED = True
 except ImportError:
@@ -18,7 +18,11 @@ except ImportError:
         model_fields: ClassVar[dict[str, Any]]
 
         def model_dump_json(self, *args: Any, **kwargs: Any) -> str:
-            """Placeholder"""
+            """Placeholder for pydantic.BaseModel.model_dump_json
+
+            Returns:
+                The JSON representation of the model.
+            """
             return ""
 
     PYDANTIC_INSTALLED = False  # pyright: ignore[reportConstantRedefinition]

--- a/advanced_alchemy/alembic/templates/asyncio/env.py
+++ b/advanced_alchemy/alembic/templates/asyncio/env.py
@@ -20,7 +20,7 @@ __all__ = ("do_run_migrations", "run_migrations_offline", "run_migrations_online
 
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.
-config: "AlembicCommandConfig" = context.config  # type: ignore  # noqa: PGH003
+config: "AlembicCommandConfig" = context.config  # type: ignore
 writer = rewriter.Rewriter()
 
 
@@ -30,7 +30,16 @@ def order_columns(
     revision: tuple[str, ...],  # noqa: ARG001
     op: ops.CreateTableOp,
 ) -> ops.CreateTableOp:
-    """Orders ID first and the audit columns at the end."""
+    """Orders ID first and the audit columns at the end.
+
+    Args:
+        context: The context of the environment.
+        revision: The revision of the environment.
+        op: The operation to create the table.
+
+    Returns:
+        The operation to create the table.
+    """
     special_names = {"id": -100, "sa_orm_sentinel": 3001, "created_at": 3002, "updated_at": 3003}
     cols_by_key = [  # pyright: ignore[reportUnknownVariableType]
         (
@@ -100,6 +109,9 @@ async def run_migrations_online() -> None:
 
     In this scenario we need to create an Engine and associate a
     connection with the context.
+
+    Raises:
+        RuntimeError: If the engine cannot be created from the config.
     """
     configuration = config.get_section(config.config_ini_section) or {}
     configuration["sqlalchemy.url"] = config.db_url

--- a/advanced_alchemy/extensions/litestar/providers.py
+++ b/advanced_alchemy/extensions/litestar/providers.py
@@ -43,6 +43,7 @@ from advanced_alchemy.service import (
     SQLAlchemyAsyncRepositoryService,
     SQLAlchemySyncRepositoryService,
 )
+from advanced_alchemy.utils.singleton import SingletonMeta
 
 if TYPE_CHECKING:
     from sqlalchemy import Select
@@ -109,17 +110,6 @@ class FilterConfig(TypedDict):
     """When set, updated_at filter is enabled."""
 
 
-class SingletonMeta(type):
-    """Metaclass for singleton pattern."""
-
-    _instances: dict[type, Any] = {}
-
-    def __call__(cls, *args: Any, **kwargs: Any) -> Any:
-        if cls not in cls._instances:  # pyright: ignore[reportUnnecessaryContains]
-            cls._instances[cls] = super().__call__(*args, **kwargs)
-        return cls._instances[cls]
-
-
 class DependencyCache(metaclass=SingletonMeta):
     """Simple dependency cache for the application.  This is used to help memoize dependencies that are generated dynamically."""
 
@@ -175,7 +165,11 @@ def create_service_provider(
     uniquify: Optional[bool] = None,
     count_with_window_function: Optional[bool] = None,
 ) -> Callable[..., Union["AsyncGenerator[AsyncServiceT_co, None]", "Generator[SyncServiceT_co,None, None]"]]:
-    """Create a dependency provider for a service."""
+    """Create a dependency provider for a service.
+
+    Returns:
+        A dependency provider for the service.
+    """
     if issubclass(service_class, SQLAlchemyAsyncRepositoryService) or service_class is SQLAlchemyAsyncRepositoryService:  # type: ignore[comparison-overlap]
 
         async def provide_async_service(

--- a/advanced_alchemy/extensions/sanic/config.py
+++ b/advanced_alchemy/extensions/sanic/config.py
@@ -21,7 +21,7 @@ try:
     SANIC_INSTALLED = True
 except ModuleNotFoundError:  # pragma: no cover
     SANIC_INSTALLED = False  # pyright: ignore[reportConstantRedefinition]
-    Extend = type("Extend", (), {})  # type: ignore  # noqa: PGH003
+    Extend = type("Extend", (), {})  # type: ignore
 
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
 from sqlalchemy.orm import Session, sessionmaker

--- a/advanced_alchemy/extensions/sanic/extension.py
+++ b/advanced_alchemy/extensions/sanic/extension.py
@@ -14,8 +14,8 @@ try:
     SANIC_INSTALLED = True
 except ModuleNotFoundError:  # pragma: no cover
     SANIC_INSTALLED = False  # pyright: ignore[reportConstantRedefinition]
-    Extension = type("Extension", (), {})  # type: ignore  # noqa: PGH003
-    Extend = type("Extend", (), {})  # type: ignore  # noqa: PGH003
+    Extension = type("Extension", (), {})  # type: ignore
+    Extend = type("Extend", (), {})  # type: ignore
 
 if TYPE_CHECKING:
     from sanic import Sanic

--- a/advanced_alchemy/repository/_sync.py
+++ b/advanced_alchemy/repository/_sync.py
@@ -471,7 +471,8 @@ class SQLAlchemySyncRepository(SQLAlchemySyncRepositoryProtocol[ModelT], Filtera
             error_messages=error_messages, default_messages=self.error_messages
         )
         self.wrap_exceptions = wrap_exceptions
-        self.uniquify = self._get_uniquify(uniquify)
+        if uniquify is not None:
+            self.uniquify = uniquify
         self.count_with_window_function = (
             count_with_window_function if count_with_window_function is not None else self.count_with_window_function
         )
@@ -555,6 +556,9 @@ class SQLAlchemySyncRepository(SQLAlchemySyncRepositoryProtocol[ModelT], Filtera
         Args:
             item_or_none: Item (:class:`T <T>`) to be tested for existence.
 
+        Raises:
+            NotFoundError: If ``item_or_none`` is ``None``
+
         Returns:
             The item, if it exists.
         """
@@ -604,6 +608,7 @@ class SQLAlchemySyncRepository(SQLAlchemySyncRepositoryProtocol[ModelT], Filtera
             auto_commit: Commit objects before returning.
             error_messages: An optional dictionary of templates to use
                 for friendlier error messages to clients
+
         Returns:
             The added instance.
         """
@@ -634,6 +639,7 @@ class SQLAlchemySyncRepository(SQLAlchemySyncRepositoryProtocol[ModelT], Filtera
             auto_commit: Commit objects before returning.
             error_messages: An optional dictionary of templates to use
                 for friendlier error messages to clients
+
         Returns:
             The added instances.
         """
@@ -677,8 +683,6 @@ class SQLAlchemySyncRepository(SQLAlchemySyncRepositoryProtocol[ModelT], Filtera
         Returns:
             The deleted instance.
 
-        Raises:
-            NotFoundError: If no instance found identified by ``item_id``.
         """
         self.uniquify = self._get_uniquify(uniquify)
         error_messages = self._get_error_messages(
@@ -793,7 +797,8 @@ class SQLAlchemySyncRepository(SQLAlchemySyncRepositoryProtocol[ModelT], Filtera
                 self._expunge(instance, auto_expunge=auto_expunge)
             return instances
 
-    def _get_insertmanyvalues_max_parameters(self, chunk_size: Optional[int] = None) -> int:
+    @staticmethod
+    def _get_insertmanyvalues_max_parameters(chunk_size: Optional[int] = None) -> int:
         return chunk_size if chunk_size is not None else DEFAULT_INSERTMANYVALUES_MAX_PARAMETERS
 
     def delete_where(
@@ -821,6 +826,10 @@ class SQLAlchemySyncRepository(SQLAlchemySyncRepositoryProtocol[ModelT], Filtera
             execution_options: Set default execution options
             uniquify: Optionally apply the ``unique()`` method to results before returning.
             **kwargs: Arguments to apply to a delete
+
+        Raises:
+            RepositoryError: If the number of deleted rows does not match the number of selected instances
+
         Returns:
             The deleted instances.
 
@@ -856,7 +865,7 @@ class SQLAlchemySyncRepository(SQLAlchemySyncRepositoryProtocol[ModelT], Filtera
                 )
                 result = self.session.execute(statement)
                 row_count = getattr(result, "rowcount", -2)
-                if sanity_check and row_count >= 0 and len(instances) != row_count:  # pyright: ignore  # noqa: PGH003
+                if sanity_check and row_count >= 0 and len(instances) != row_count:  # pyright: ignore
                     # backends will return a -1 if they can't determine impacted rowcount
                     # only compare length of selected instances to results if it's >= 0
                     self.session.rollback()
@@ -904,8 +913,8 @@ class SQLAlchemySyncRepository(SQLAlchemySyncRepositoryProtocol[ModelT], Filtera
         )
         return existing > 0
 
+    @staticmethod
     def _get_base_stmt(
-        self,
         *,
         statement: StatementTypeT,
         loader_options: Optional[list[_AbstractLoad]],
@@ -980,9 +989,6 @@ class SQLAlchemySyncRepository(SQLAlchemySyncRepositoryProtocol[ModelT], Filtera
 
         Returns:
             The retrieved instance.
-
-        Raises:
-            NotFoundError: If no instance found identified by `item_id`.
         """
         self.uniquify = self._get_uniquify(uniquify)
         error_messages = self._get_error_messages(
@@ -1032,8 +1038,6 @@ class SQLAlchemySyncRepository(SQLAlchemySyncRepositoryProtocol[ModelT], Filtera
         Returns:
             The retrieved instance.
 
-        Raises:
-            NotFoundError: If no instance found identified by `item_id`.
         """
         self.uniquify = self._get_uniquify(uniquify)
         error_messages = self._get_error_messages(
@@ -1237,10 +1241,6 @@ class SQLAlchemySyncRepository(SQLAlchemySyncRepositoryProtocol[ModelT], Filtera
             a tuple that includes the instance and whether it needed to be updated.
             When using match_fields and actual model values differ from ``kwargs``, the
             model value will be updated.
-
-
-        Raises:
-            NotFoundError: If no instance found identified by `item_id`.
         """
         self.uniquify = self._get_uniquify(uniquify)
         error_messages = self._get_error_messages(
@@ -1361,9 +1361,6 @@ class SQLAlchemySyncRepository(SQLAlchemySyncRepositoryProtocol[ModelT], Filtera
 
         Returns:
             The updated instance.
-
-        Raises:
-            NotFoundError: If no instance found with same identifier as `data`.
         """
         self.uniquify = self._get_uniquify(uniquify)
         error_messages = self._get_error_messages(
@@ -1419,9 +1416,6 @@ class SQLAlchemySyncRepository(SQLAlchemySyncRepositoryProtocol[ModelT], Filtera
 
         Returns:
             The updated instances.
-
-        Raises:
-            NotFoundError: If no instance found with same identifier as `data`.
         """
         self.uniquify = self._get_uniquify(uniquify)
         error_messages = self._get_error_messages(
@@ -1736,9 +1730,6 @@ class SQLAlchemySyncRepository(SQLAlchemySyncRepositoryProtocol[ModelT], Filtera
 
         Returns:
             The updated or created instance.
-
-        Raises:
-            NotFoundError: If no instance found with same identifier as `data`.
         """
         self.uniquify = self._get_uniquify(uniquify)
         error_messages = self._get_error_messages(
@@ -1817,9 +1808,6 @@ class SQLAlchemySyncRepository(SQLAlchemySyncRepositoryProtocol[ModelT], Filtera
 
         Returns:
             The updated or created instance.
-
-        Raises:
-            NotFoundError: If no instance found with same identifier as ``data``.
         """
         self.uniquify = self._get_uniquify(uniquify)
         error_messages = self._get_error_messages(
@@ -2003,6 +1991,9 @@ class SQLAlchemySyncRepository(SQLAlchemySyncRepositoryProtocol[ModelT], Filtera
                 into the session owned by a worker thread or process
                 without re-querying the database.
 
+        Raises:
+            ValueError: If `strategy` is not one of the expected values.
+
         Returns:
             Instance attached to the session - if `"merge"` strategy, may not be same instance
             that was provided.
@@ -2041,7 +2032,11 @@ class SQLAlchemySyncSlugRepository(
         uniquify: Optional[bool] = None,
         **kwargs: Any,
     ) -> Optional[ModelT]:
-        """Select record by slug value."""
+        """Select record by slug value.
+
+        Returns:
+            The model instance or None if not found.
+        """
         return self.get_one_or_none(
             slug=slug,
             load=load,
@@ -2125,9 +2120,6 @@ class SQLAlchemySyncQueryRepository:
 
         Returns:
             The retrieved instance.
-
-        Raises:
-            NotFoundError: If no instance found identified by `item_id`.
         """
         with wrap_sqlalchemy_exception(error_messages=self.error_messages):
             statement = self._filter_statement_by_kwargs(statement, **kwargs)
@@ -2169,7 +2161,7 @@ class SQLAlchemySyncQueryRepository:
             )
             statement = self._filter_statement_by_kwargs(statement, **kwargs)
             results = self.execute(statement)
-            return results.scalar_one()  # type: ignore  # noqa: PGH003
+            return results.scalar_one()  # type: ignore
 
     def list_and_count(
         self,
@@ -2219,7 +2211,8 @@ class SQLAlchemySyncQueryRepository:
                     count = count_value
             return instances, count
 
-    def _get_count_stmt(self, statement: Select[Any]) -> Select[Any]:
+    @staticmethod
+    def _get_count_stmt(statement: Select[Any]) -> Select[Any]:
         return statement.with_only_columns(sql_func.count(text("1")), maintain_column_froms=True).order_by(None)  # pyright: ignore[reportUnknownVariable]
 
     def _list_and_count_basic(
@@ -2274,6 +2267,9 @@ class SQLAlchemySyncQueryRepository:
             statement: statement to filter
             **kwargs: key/value pairs such that objects remaining in the statement after filtering
                 have the property that their attribute named `key` has value equal to `value`.
+
+        Returns:
+            The filtered statement.
         """
 
         with wrap_sqlalchemy_exception(error_messages=self.error_messages):
@@ -2287,6 +2283,9 @@ class SQLAlchemySyncQueryRepository:
 
         Args:
             item_or_none: Item to be tested for existence.
+
+        Raises:
+            NotFoundError: If ``item_or_none`` is ``None``
 
         Returns:
             The item, if it exists.

--- a/advanced_alchemy/repository/memory/_async.py
+++ b/advanced_alchemy/repository/memory/_async.py
@@ -329,11 +329,11 @@ class SQLAlchemyAsyncMockRepository(SQLAlchemyAsyncRepositoryProtocol[ModelT]):
                 )
 
             elif isinstance(filter_, NotInCollectionFilter):
-                if filter_.values is not None:  # pyright: ignore  # noqa: PGH003
-                    result = self._filter_not_in_collection(result, filter_.field_name, filter_.values)  # pyright: ignore  # noqa: PGH003
+                if filter_.values is not None:  # pyright: ignore
+                    result = self._filter_not_in_collection(result, filter_.field_name, filter_.values)  # pyright: ignore
             elif isinstance(filter_, CollectionFilter):
-                if filter_.values is not None:  # pyright: ignore  # noqa: PGH003
-                    result = self._filter_in_collection(result, filter_.field_name, filter_.values)  # pyright: ignore  # noqa: PGH003
+                if filter_.values is not None:  # pyright: ignore
+                    result = self._filter_in_collection(result, filter_.field_name, filter_.values)  # pyright: ignore
             elif isinstance(filter_, OrderBy):
                 result = self._order_by(
                     result,
@@ -388,14 +388,15 @@ class SQLAlchemyAsyncMockRepository(SQLAlchemyAsyncRepositoryProtocol[ModelT]):
     def _find_or_raise_not_found(self, id_: Any) -> ModelT:
         return self.check_not_found(self.__collection__().get_or_none(id_))
 
-    def _find_one_or_raise_error(self, result: list[ModelT]) -> ModelT:
+    @staticmethod
+    def _find_one_or_raise_error(result: list[ModelT]) -> ModelT:
         if not result:
             msg = "No item found when one was expected"
             raise IntegrityError(msg)
         if len(result) > 1:
             msg = "Multiple objects when one was expected"
             raise IntegrityError(msg)
-        return result[0]
+        return result[0]  # pyright: ignore
 
     def _get_update_many_statement(
         self,

--- a/advanced_alchemy/repository/memory/_sync.py
+++ b/advanced_alchemy/repository/memory/_sync.py
@@ -330,11 +330,11 @@ class SQLAlchemySyncMockRepository(SQLAlchemySyncRepositoryProtocol[ModelT]):
                 )
 
             elif isinstance(filter_, NotInCollectionFilter):
-                if filter_.values is not None:  # pyright: ignore  # noqa: PGH003
-                    result = self._filter_not_in_collection(result, filter_.field_name, filter_.values)  # pyright: ignore  # noqa: PGH003
+                if filter_.values is not None:  # pyright: ignore
+                    result = self._filter_not_in_collection(result, filter_.field_name, filter_.values)  # pyright: ignore
             elif isinstance(filter_, CollectionFilter):
-                if filter_.values is not None:  # pyright: ignore  # noqa: PGH003
-                    result = self._filter_in_collection(result, filter_.field_name, filter_.values)  # pyright: ignore  # noqa: PGH003
+                if filter_.values is not None:  # pyright: ignore
+                    result = self._filter_in_collection(result, filter_.field_name, filter_.values)  # pyright: ignore
             elif isinstance(filter_, OrderBy):
                 result = self._order_by(
                     result,
@@ -389,14 +389,15 @@ class SQLAlchemySyncMockRepository(SQLAlchemySyncRepositoryProtocol[ModelT]):
     def _find_or_raise_not_found(self, id_: Any) -> ModelT:
         return self.check_not_found(self.__collection__().get_or_none(id_))
 
-    def _find_one_or_raise_error(self, result: list[ModelT]) -> ModelT:
+    @staticmethod
+    def _find_one_or_raise_error(result: list[ModelT]) -> ModelT:
         if not result:
             msg = "No item found when one was expected"
             raise IntegrityError(msg)
         if len(result) > 1:
             msg = "Multiple objects when one was expected"
             raise IntegrityError(msg)
-        return result[0]
+        return result[0]  # pyright: ignore
 
     def _get_update_many_statement(
         self,

--- a/advanced_alchemy/service/_async.py
+++ b/advanced_alchemy/service/_async.py
@@ -67,7 +67,10 @@ class SQLAlchemyAsyncQueryService(ResultConverter):
 
         Handles construction of the database session._create_select_for_model
 
-        Returns:
+        Raises:
+            AdvancedAlchemyError: If no configuration or session is provided.
+
+        Yields:
             The service object instance.
         """
         if not config and not session:
@@ -106,7 +109,7 @@ class SQLAlchemyAsyncRepositoryReadService(ResultConverter, Generic[ModelT, SQLA
         auto_refresh: bool = True,
         auto_commit: bool = False,
         order_by: Optional[Union[list[OrderingPair], OrderingPair]] = None,
-        error_messages: Union[ErrorMessages, None, EmptyType] = Empty,
+        error_messages: Optional[Union[ErrorMessages, EmptyType]] = Empty,
         wrap_exceptions: bool = True,
         load: Optional[LoadSpec] = None,
         execution_options: Optional[dict[str, Any]] = None,
@@ -157,7 +160,14 @@ class SQLAlchemyAsyncRepositoryReadService(ResultConverter, Generic[ModelT, SQLA
 
     @property
     def repository(self) -> SQLAlchemyAsyncRepositoryT:
-        """Return the repository instance."""
+        """Return the repository instance.
+
+        Raises:
+            ImproperConfigurationError: If the repository is not initialized.
+
+        Returns:
+            The repository instance.
+        """
         if not self._repository_instance:
             msg = "Repository not initialized"
             raise ImproperConfigurationError(msg)
@@ -172,7 +182,7 @@ class SQLAlchemyAsyncRepositoryReadService(ResultConverter, Generic[ModelT, SQLA
         self,
         *filters: Union[StatementFilter, ColumnElement[bool]],
         statement: Optional[Select[tuple[ModelT]]] = None,
-        error_messages: Union[ErrorMessages, None, EmptyType] = Empty,
+        error_messages: Optional[Union[ErrorMessages, EmptyType]] = Empty,
         load: Optional[LoadSpec] = None,
         execution_options: Optional[dict[str, Any]] = None,
         uniquify: Optional[bool] = None,
@@ -206,7 +216,7 @@ class SQLAlchemyAsyncRepositoryReadService(ResultConverter, Generic[ModelT, SQLA
     async def exists(
         self,
         *filters: Union[StatementFilter, ColumnElement[bool]],
-        error_messages: Union[ErrorMessages, None, EmptyType] = Empty,
+        error_messages: Optional[Union[ErrorMessages, EmptyType]] = Empty,
         load: Optional[LoadSpec] = None,
         execution_options: Optional[dict[str, Any]] = None,
         uniquify: Optional[bool] = None,
@@ -242,7 +252,7 @@ class SQLAlchemyAsyncRepositoryReadService(ResultConverter, Generic[ModelT, SQLA
         statement: Optional[Select[tuple[ModelT]]] = None,
         id_attribute: Optional[Union[str, InstrumentedAttribute[Any]]] = None,
         auto_expunge: Optional[bool] = None,
-        error_messages: Union[ErrorMessages, None, EmptyType] = Empty,
+        error_messages: Optional[Union[ErrorMessages, EmptyType]] = Empty,
         load: Optional[LoadSpec] = None,
         execution_options: Optional[dict[str, Any]] = None,
         uniquify: Optional[bool] = None,
@@ -284,7 +294,7 @@ class SQLAlchemyAsyncRepositoryReadService(ResultConverter, Generic[ModelT, SQLA
         statement: Optional[Select[tuple[ModelT]]] = None,
         auto_expunge: Optional[bool] = None,
         load: Optional[LoadSpec] = None,
-        error_messages: Union[ErrorMessages, None, EmptyType] = Empty,
+        error_messages: Optional[Union[ErrorMessages, EmptyType]] = Empty,
         execution_options: Optional[dict[str, Any]] = None,
         uniquify: Optional[bool] = None,
         **kwargs: Any,
@@ -324,7 +334,7 @@ class SQLAlchemyAsyncRepositoryReadService(ResultConverter, Generic[ModelT, SQLA
         *filters: Union[StatementFilter, ColumnElement[bool]],
         statement: Optional[Select[tuple[ModelT]]] = None,
         auto_expunge: Optional[bool] = None,
-        error_messages: Union[ErrorMessages, None, EmptyType] = Empty,
+        error_messages: Optional[Union[ErrorMessages, EmptyType]] = Empty,
         load: Optional[LoadSpec] = None,
         execution_options: Optional[dict[str, Any]] = None,
         uniquify: Optional[bool] = None,
@@ -414,6 +424,7 @@ class SQLAlchemyAsyncRepositoryReadService(ResultConverter, Generic[ModelT, SQLA
         Args:
             data: Representations to be created.
             operation: Optional operation flag so that you can provide behavior based on CRUD operation
+
         Returns:
             Representation of created instances.
         """
@@ -452,7 +463,7 @@ class SQLAlchemyAsyncRepositoryReadService(ResultConverter, Generic[ModelT, SQLA
         auto_expunge: Optional[bool] = None,
         count_with_window_function: Optional[bool] = None,
         order_by: Optional[Union[list[OrderingPair], OrderingPair]] = None,
-        error_messages: Union[ErrorMessages, None, EmptyType] = Empty,
+        error_messages: Optional[Union[ErrorMessages, EmptyType]] = Empty,
         load: Optional[LoadSpec] = None,
         execution_options: Optional[dict[str, Any]] = None,
         uniquify: Optional[bool] = None,
@@ -499,7 +510,7 @@ class SQLAlchemyAsyncRepositoryReadService(ResultConverter, Generic[ModelT, SQLA
         session: Optional[Union[AsyncSession, async_scoped_session[AsyncSession]]] = None,
         statement: Optional[Select[tuple[ModelT]]] = None,
         config: Optional[SQLAlchemyAsyncConfig] = None,
-        error_messages: Union[ErrorMessages, None, EmptyType] = Empty,
+        error_messages: Optional[Union[ErrorMessages, EmptyType]] = Empty,
         load: Optional[LoadSpec] = None,
         execution_options: Optional[dict[str, Any]] = None,
         uniquify: Optional[bool] = None,
@@ -509,7 +520,10 @@ class SQLAlchemyAsyncRepositoryReadService(ResultConverter, Generic[ModelT, SQLA
 
         Handles construction of the database session._create_select_for_model
 
-        Returns:
+        Raises:
+            AdvancedAlchemyError: If no configuration or session is provided.
+
+        Yields:
             The service object instance.
         """
         if not config and not session:
@@ -543,7 +557,7 @@ class SQLAlchemyAsyncRepositoryReadService(ResultConverter, Generic[ModelT, SQLA
         statement: Optional[Select[tuple[ModelT]]] = None,
         auto_expunge: Optional[bool] = None,
         order_by: Optional[Union[list[OrderingPair], OrderingPair]] = None,
-        error_messages: Union[ErrorMessages, None, EmptyType] = Empty,
+        error_messages: Optional[Union[ErrorMessages, EmptyType]] = Empty,
         load: Optional[LoadSpec] = None,
         execution_options: Optional[dict[str, Any]] = None,
         uniquify: Optional[bool] = None,
@@ -595,7 +609,7 @@ class SQLAlchemyAsyncRepositoryService(
         auto_commit: Optional[bool] = None,
         auto_expunge: Optional[bool] = None,
         auto_refresh: Optional[bool] = None,
-        error_messages: Union[ErrorMessages, None, EmptyType] = Empty,
+        error_messages: Optional[Union[ErrorMessages, EmptyType]] = Empty,
     ) -> "ModelT":
         """Wrap repository instance creation.
 
@@ -628,7 +642,7 @@ class SQLAlchemyAsyncRepositoryService(
         *,
         auto_commit: Optional[bool] = None,
         auto_expunge: Optional[bool] = None,
-        error_messages: Union[ErrorMessages, None, EmptyType] = Empty,
+        error_messages: Optional[Union[ErrorMessages, EmptyType]] = Empty,
     ) -> Sequence[ModelT]:
         """Wrap repository bulk instance creation.
 
@@ -667,7 +681,7 @@ class SQLAlchemyAsyncRepositoryService(
         auto_expunge: Optional[bool] = None,
         auto_refresh: Optional[bool] = None,
         id_attribute: Optional[Union[str, InstrumentedAttribute[Any]]] = None,
-        error_messages: Union[ErrorMessages, None, EmptyType] = Empty,
+        error_messages: Optional[Union[ErrorMessages, EmptyType]] = Empty,
         load: Optional[LoadSpec] = None,
         execution_options: Optional[dict[str, Any]] = None,
         uniquify: Optional[bool] = None,
@@ -692,6 +706,9 @@ class SQLAlchemyAsyncRepositoryService(
             load: Set default relationships to be loaded
             execution_options: Set default execution options
             uniquify: Optionally apply the ``unique()`` method to results before returning.
+
+        Raises:
+            RepositoryError: If no configuration or session is provided.
 
         Returns:
             Updated representation.
@@ -735,7 +752,7 @@ class SQLAlchemyAsyncRepositoryService(
         *,
         auto_commit: Optional[bool] = None,
         auto_expunge: Optional[bool] = None,
-        error_messages: Union[ErrorMessages, None, EmptyType] = Empty,
+        error_messages: Optional[Union[ErrorMessages, EmptyType]] = Empty,
         load: Optional[LoadSpec] = None,
         execution_options: Optional[dict[str, Any]] = None,
         uniquify: Optional[bool] = None,
@@ -782,7 +799,7 @@ class SQLAlchemyAsyncRepositoryService(
         auto_commit: Optional[bool] = None,
         auto_refresh: Optional[bool] = None,
         match_fields: Optional[Union[list[str], str]] = None,
-        error_messages: Union[ErrorMessages, None, EmptyType] = Empty,
+        error_messages: Optional[Union[ErrorMessages, EmptyType]] = Empty,
         load: Optional[LoadSpec] = None,
         execution_options: Optional[dict[str, Any]] = None,
         uniquify: Optional[bool] = None,
@@ -841,7 +858,7 @@ class SQLAlchemyAsyncRepositoryService(
         auto_commit: Optional[bool] = None,
         no_merge: bool = False,
         match_fields: Optional[Union[list[str], str]] = None,
-        error_messages: Union[ErrorMessages, None, EmptyType] = Empty,
+        error_messages: Optional[Union[ErrorMessages, EmptyType]] = Empty,
         load: Optional[LoadSpec] = None,
         execution_options: Optional[dict[str, Any]] = None,
         uniquify: Optional[bool] = None,
@@ -892,7 +909,7 @@ class SQLAlchemyAsyncRepositoryService(
         auto_commit: Optional[bool] = None,
         auto_expunge: Optional[bool] = None,
         auto_refresh: Optional[bool] = None,
-        error_messages: Union[ErrorMessages, None, EmptyType] = Empty,
+        error_messages: Optional[Union[ErrorMessages, EmptyType]] = Empty,
         load: Optional[LoadSpec] = None,
         execution_options: Optional[dict[str, Any]] = None,
         uniquify: Optional[bool] = None,
@@ -955,7 +972,7 @@ class SQLAlchemyAsyncRepositoryService(
         auto_commit: Optional[bool] = None,
         auto_expunge: Optional[bool] = None,
         auto_refresh: Optional[bool] = None,
-        error_messages: Union[ErrorMessages, None, EmptyType] = Empty,
+        error_messages: Optional[Union[ErrorMessages, EmptyType]] = Empty,
         load: Optional[LoadSpec] = None,
         execution_options: Optional[dict[str, Any]] = None,
         uniquify: Optional[bool] = None,
@@ -1012,7 +1029,7 @@ class SQLAlchemyAsyncRepositoryService(
         auto_commit: Optional[bool] = None,
         auto_expunge: Optional[bool] = None,
         id_attribute: Optional[Union[str, InstrumentedAttribute[Any]]] = None,
-        error_messages: Union[ErrorMessages, None, EmptyType] = Empty,
+        error_messages: Optional[Union[ErrorMessages, EmptyType]] = Empty,
         load: Optional[LoadSpec] = None,
         execution_options: Optional[dict[str, Any]] = None,
         uniquify: Optional[bool] = None,
@@ -1056,7 +1073,7 @@ class SQLAlchemyAsyncRepositoryService(
         auto_expunge: Optional[bool] = None,
         id_attribute: Optional[Union[str, InstrumentedAttribute[Any]]] = None,
         chunk_size: Optional[int] = None,
-        error_messages: Union[ErrorMessages, None, EmptyType] = Empty,
+        error_messages: Optional[Union[ErrorMessages, EmptyType]] = Empty,
         load: Optional[LoadSpec] = None,
         execution_options: Optional[dict[str, Any]] = None,
         uniquify: Optional[bool] = None,
@@ -1100,7 +1117,7 @@ class SQLAlchemyAsyncRepositoryService(
         *filters: Union[StatementFilter, ColumnElement[bool]],
         auto_commit: Optional[bool] = None,
         auto_expunge: Optional[bool] = None,
-        error_messages: Union[ErrorMessages, None, EmptyType] = Empty,
+        error_messages: Optional[Union[ErrorMessages, EmptyType]] = Empty,
         sanity_check: bool = True,
         load: Optional[LoadSpec] = None,
         execution_options: Optional[dict[str, Any]] = None,

--- a/advanced_alchemy/service/_sync.py
+++ b/advanced_alchemy/service/_sync.py
@@ -66,7 +66,10 @@ class SQLAlchemySyncQueryService(ResultConverter):
 
         Handles construction of the database session._create_select_for_model
 
-        Returns:
+        Raises:
+            AdvancedAlchemyError: If no configuration or session is provided.
+
+        Yields:
             The service object instance.
         """
         if not config and not session:
@@ -105,7 +108,7 @@ class SQLAlchemySyncRepositoryReadService(ResultConverter, Generic[ModelT, SQLAl
         auto_refresh: bool = True,
         auto_commit: bool = False,
         order_by: Optional[Union[list[OrderingPair], OrderingPair]] = None,
-        error_messages: Union[ErrorMessages, None, EmptyType] = Empty,
+        error_messages: Optional[Union[ErrorMessages, EmptyType]] = Empty,
         wrap_exceptions: bool = True,
         load: Optional[LoadSpec] = None,
         execution_options: Optional[dict[str, Any]] = None,
@@ -156,7 +159,14 @@ class SQLAlchemySyncRepositoryReadService(ResultConverter, Generic[ModelT, SQLAl
 
     @property
     def repository(self) -> SQLAlchemySyncRepositoryT:
-        """Return the repository instance."""
+        """Return the repository instance.
+
+        Raises:
+            ImproperConfigurationError: If the repository is not initialized.
+
+        Returns:
+            The repository instance.
+        """
         if not self._repository_instance:
             msg = "Repository not initialized"
             raise ImproperConfigurationError(msg)
@@ -171,7 +181,7 @@ class SQLAlchemySyncRepositoryReadService(ResultConverter, Generic[ModelT, SQLAl
         self,
         *filters: Union[StatementFilter, ColumnElement[bool]],
         statement: Optional[Select[tuple[ModelT]]] = None,
-        error_messages: Union[ErrorMessages, None, EmptyType] = Empty,
+        error_messages: Optional[Union[ErrorMessages, EmptyType]] = Empty,
         load: Optional[LoadSpec] = None,
         execution_options: Optional[dict[str, Any]] = None,
         uniquify: Optional[bool] = None,
@@ -205,7 +215,7 @@ class SQLAlchemySyncRepositoryReadService(ResultConverter, Generic[ModelT, SQLAl
     def exists(
         self,
         *filters: Union[StatementFilter, ColumnElement[bool]],
-        error_messages: Union[ErrorMessages, None, EmptyType] = Empty,
+        error_messages: Optional[Union[ErrorMessages, EmptyType]] = Empty,
         load: Optional[LoadSpec] = None,
         execution_options: Optional[dict[str, Any]] = None,
         uniquify: Optional[bool] = None,
@@ -241,7 +251,7 @@ class SQLAlchemySyncRepositoryReadService(ResultConverter, Generic[ModelT, SQLAl
         statement: Optional[Select[tuple[ModelT]]] = None,
         id_attribute: Optional[Union[str, InstrumentedAttribute[Any]]] = None,
         auto_expunge: Optional[bool] = None,
-        error_messages: Union[ErrorMessages, None, EmptyType] = Empty,
+        error_messages: Optional[Union[ErrorMessages, EmptyType]] = Empty,
         load: Optional[LoadSpec] = None,
         execution_options: Optional[dict[str, Any]] = None,
         uniquify: Optional[bool] = None,
@@ -283,7 +293,7 @@ class SQLAlchemySyncRepositoryReadService(ResultConverter, Generic[ModelT, SQLAl
         statement: Optional[Select[tuple[ModelT]]] = None,
         auto_expunge: Optional[bool] = None,
         load: Optional[LoadSpec] = None,
-        error_messages: Union[ErrorMessages, None, EmptyType] = Empty,
+        error_messages: Optional[Union[ErrorMessages, EmptyType]] = Empty,
         execution_options: Optional[dict[str, Any]] = None,
         uniquify: Optional[bool] = None,
         **kwargs: Any,
@@ -323,7 +333,7 @@ class SQLAlchemySyncRepositoryReadService(ResultConverter, Generic[ModelT, SQLAl
         *filters: Union[StatementFilter, ColumnElement[bool]],
         statement: Optional[Select[tuple[ModelT]]] = None,
         auto_expunge: Optional[bool] = None,
-        error_messages: Union[ErrorMessages, None, EmptyType] = Empty,
+        error_messages: Optional[Union[ErrorMessages, EmptyType]] = Empty,
         load: Optional[LoadSpec] = None,
         execution_options: Optional[dict[str, Any]] = None,
         uniquify: Optional[bool] = None,
@@ -413,6 +423,7 @@ class SQLAlchemySyncRepositoryReadService(ResultConverter, Generic[ModelT, SQLAl
         Args:
             data: Representations to be created.
             operation: Optional operation flag so that you can provide behavior based on CRUD operation
+
         Returns:
             Representation of created instances.
         """
@@ -451,7 +462,7 @@ class SQLAlchemySyncRepositoryReadService(ResultConverter, Generic[ModelT, SQLAl
         auto_expunge: Optional[bool] = None,
         count_with_window_function: Optional[bool] = None,
         order_by: Optional[Union[list[OrderingPair], OrderingPair]] = None,
-        error_messages: Union[ErrorMessages, None, EmptyType] = Empty,
+        error_messages: Optional[Union[ErrorMessages, EmptyType]] = Empty,
         load: Optional[LoadSpec] = None,
         execution_options: Optional[dict[str, Any]] = None,
         uniquify: Optional[bool] = None,
@@ -498,7 +509,7 @@ class SQLAlchemySyncRepositoryReadService(ResultConverter, Generic[ModelT, SQLAl
         session: Optional[Union[Session, scoped_session[Session]]] = None,
         statement: Optional[Select[tuple[ModelT]]] = None,
         config: Optional[SQLAlchemySyncConfig] = None,
-        error_messages: Union[ErrorMessages, None, EmptyType] = Empty,
+        error_messages: Optional[Union[ErrorMessages, EmptyType]] = Empty,
         load: Optional[LoadSpec] = None,
         execution_options: Optional[dict[str, Any]] = None,
         uniquify: Optional[bool] = None,
@@ -508,7 +519,10 @@ class SQLAlchemySyncRepositoryReadService(ResultConverter, Generic[ModelT, SQLAl
 
         Handles construction of the database session._create_select_for_model
 
-        Returns:
+        Raises:
+            AdvancedAlchemyError: If no configuration or session is provided.
+
+        Yields:
             The service object instance.
         """
         if not config and not session:
@@ -542,7 +556,7 @@ class SQLAlchemySyncRepositoryReadService(ResultConverter, Generic[ModelT, SQLAl
         statement: Optional[Select[tuple[ModelT]]] = None,
         auto_expunge: Optional[bool] = None,
         order_by: Optional[Union[list[OrderingPair], OrderingPair]] = None,
-        error_messages: Union[ErrorMessages, None, EmptyType] = Empty,
+        error_messages: Optional[Union[ErrorMessages, EmptyType]] = Empty,
         load: Optional[LoadSpec] = None,
         execution_options: Optional[dict[str, Any]] = None,
         uniquify: Optional[bool] = None,
@@ -594,7 +608,7 @@ class SQLAlchemySyncRepositoryService(
         auto_commit: Optional[bool] = None,
         auto_expunge: Optional[bool] = None,
         auto_refresh: Optional[bool] = None,
-        error_messages: Union[ErrorMessages, None, EmptyType] = Empty,
+        error_messages: Optional[Union[ErrorMessages, EmptyType]] = Empty,
     ) -> "ModelT":
         """Wrap repository instance creation.
 
@@ -627,7 +641,7 @@ class SQLAlchemySyncRepositoryService(
         *,
         auto_commit: Optional[bool] = None,
         auto_expunge: Optional[bool] = None,
-        error_messages: Union[ErrorMessages, None, EmptyType] = Empty,
+        error_messages: Optional[Union[ErrorMessages, EmptyType]] = Empty,
     ) -> Sequence[ModelT]:
         """Wrap repository bulk instance creation.
 
@@ -666,7 +680,7 @@ class SQLAlchemySyncRepositoryService(
         auto_expunge: Optional[bool] = None,
         auto_refresh: Optional[bool] = None,
         id_attribute: Optional[Union[str, InstrumentedAttribute[Any]]] = None,
-        error_messages: Union[ErrorMessages, None, EmptyType] = Empty,
+        error_messages: Optional[Union[ErrorMessages, EmptyType]] = Empty,
         load: Optional[LoadSpec] = None,
         execution_options: Optional[dict[str, Any]] = None,
         uniquify: Optional[bool] = None,
@@ -691,6 +705,9 @@ class SQLAlchemySyncRepositoryService(
             load: Set default relationships to be loaded
             execution_options: Set default execution options
             uniquify: Optionally apply the ``unique()`` method to results before returning.
+
+        Raises:
+            RepositoryError: If no configuration or session is provided.
 
         Returns:
             Updated representation.
@@ -734,7 +751,7 @@ class SQLAlchemySyncRepositoryService(
         *,
         auto_commit: Optional[bool] = None,
         auto_expunge: Optional[bool] = None,
-        error_messages: Union[ErrorMessages, None, EmptyType] = Empty,
+        error_messages: Optional[Union[ErrorMessages, EmptyType]] = Empty,
         load: Optional[LoadSpec] = None,
         execution_options: Optional[dict[str, Any]] = None,
         uniquify: Optional[bool] = None,
@@ -781,7 +798,7 @@ class SQLAlchemySyncRepositoryService(
         auto_commit: Optional[bool] = None,
         auto_refresh: Optional[bool] = None,
         match_fields: Optional[Union[list[str], str]] = None,
-        error_messages: Union[ErrorMessages, None, EmptyType] = Empty,
+        error_messages: Optional[Union[ErrorMessages, EmptyType]] = Empty,
         load: Optional[LoadSpec] = None,
         execution_options: Optional[dict[str, Any]] = None,
         uniquify: Optional[bool] = None,
@@ -840,7 +857,7 @@ class SQLAlchemySyncRepositoryService(
         auto_commit: Optional[bool] = None,
         no_merge: bool = False,
         match_fields: Optional[Union[list[str], str]] = None,
-        error_messages: Union[ErrorMessages, None, EmptyType] = Empty,
+        error_messages: Optional[Union[ErrorMessages, EmptyType]] = Empty,
         load: Optional[LoadSpec] = None,
         execution_options: Optional[dict[str, Any]] = None,
         uniquify: Optional[bool] = None,
@@ -891,7 +908,7 @@ class SQLAlchemySyncRepositoryService(
         auto_commit: Optional[bool] = None,
         auto_expunge: Optional[bool] = None,
         auto_refresh: Optional[bool] = None,
-        error_messages: Union[ErrorMessages, None, EmptyType] = Empty,
+        error_messages: Optional[Union[ErrorMessages, EmptyType]] = Empty,
         load: Optional[LoadSpec] = None,
         execution_options: Optional[dict[str, Any]] = None,
         uniquify: Optional[bool] = None,
@@ -954,7 +971,7 @@ class SQLAlchemySyncRepositoryService(
         auto_commit: Optional[bool] = None,
         auto_expunge: Optional[bool] = None,
         auto_refresh: Optional[bool] = None,
-        error_messages: Union[ErrorMessages, None, EmptyType] = Empty,
+        error_messages: Optional[Union[ErrorMessages, EmptyType]] = Empty,
         load: Optional[LoadSpec] = None,
         execution_options: Optional[dict[str, Any]] = None,
         uniquify: Optional[bool] = None,
@@ -1011,7 +1028,7 @@ class SQLAlchemySyncRepositoryService(
         auto_commit: Optional[bool] = None,
         auto_expunge: Optional[bool] = None,
         id_attribute: Optional[Union[str, InstrumentedAttribute[Any]]] = None,
-        error_messages: Union[ErrorMessages, None, EmptyType] = Empty,
+        error_messages: Optional[Union[ErrorMessages, EmptyType]] = Empty,
         load: Optional[LoadSpec] = None,
         execution_options: Optional[dict[str, Any]] = None,
         uniquify: Optional[bool] = None,
@@ -1055,7 +1072,7 @@ class SQLAlchemySyncRepositoryService(
         auto_expunge: Optional[bool] = None,
         id_attribute: Optional[Union[str, InstrumentedAttribute[Any]]] = None,
         chunk_size: Optional[int] = None,
-        error_messages: Union[ErrorMessages, None, EmptyType] = Empty,
+        error_messages: Optional[Union[ErrorMessages, EmptyType]] = Empty,
         load: Optional[LoadSpec] = None,
         execution_options: Optional[dict[str, Any]] = None,
         uniquify: Optional[bool] = None,
@@ -1099,7 +1116,7 @@ class SQLAlchemySyncRepositoryService(
         *filters: Union[StatementFilter, ColumnElement[bool]],
         auto_commit: Optional[bool] = None,
         auto_expunge: Optional[bool] = None,
-        error_messages: Union[ErrorMessages, None, EmptyType] = Empty,
+        error_messages: Optional[Union[ErrorMessages, EmptyType]] = Empty,
         sanity_check: bool = True,
         load: Optional[LoadSpec] = None,
         execution_options: Optional[dict[str, Any]] = None,

--- a/advanced_alchemy/utils/singleton.py
+++ b/advanced_alchemy/utils/singleton.py
@@ -1,0 +1,12 @@
+from typing import Any
+
+
+class SingletonMeta(type):
+    """Metaclass for singleton pattern."""
+
+    _instances: dict[type, Any] = {}
+
+    def __call__(cls, *args: Any, **kwargs: Any) -> Any:
+        if cls not in cls._instances:  # pyright: ignore[reportUnnecessaryContains]
+            cls._instances[cls] = super().__call__(*args, **kwargs)
+        return cls._instances[cls]

--- a/advanced_alchemy/utils/sync_tools.py
+++ b/advanced_alchemy/utils/sync_tools.py
@@ -1,0 +1,360 @@
+import asyncio
+import functools
+import inspect
+import sys
+from contextlib import AbstractAsyncContextManager, AbstractContextManager
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Generic,
+    Optional,
+    TypeVar,
+    Union,
+    cast,
+)
+
+from typing_extensions import ParamSpec
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable, Coroutine
+    from types import TracebackType
+
+try:
+    import uvloop  # pyright: ignore[reportMissingImports]
+except ImportError:
+    uvloop = None  # type: ignore[assignment]
+
+
+ReturnT = TypeVar("ReturnT")
+ParamSpecT = ParamSpec("ParamSpecT")
+T = TypeVar("T")
+
+
+class PendingType:
+    def __repr__(self) -> str:
+        return "AsyncPending"
+
+
+Pending = PendingType()
+
+
+class PendingValueError(Exception):
+    """Exception raised when a value is accessed before it is ready."""
+
+
+class SoonValue(Generic[T]):
+    """Holds a value that will be available soon after an async operation."""
+
+    def __init__(self) -> None:
+        self._stored_value: Union[T, PendingType] = Pending
+
+    @property
+    def value(self) -> "T":
+        if isinstance(self._stored_value, PendingType):
+            msg = "The return value of this task is still pending."
+            raise PendingValueError(msg)
+        return self._stored_value
+
+    @property
+    def ready(self) -> bool:
+        return not isinstance(self._stored_value, PendingType)
+
+
+class TaskGroup:
+    """Manages a group of asyncio tasks, allowing them to be run concurrently."""
+
+    def __init__(self) -> None:
+        self._tasks: set[asyncio.Task[Any]] = set()
+        self._exceptions: list[BaseException] = []
+        self._closed = False
+
+    async def __aenter__(self) -> "TaskGroup":
+        if self._closed:
+            msg = "Cannot enter a task group that has already been closed."
+            raise RuntimeError(msg)
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: "Optional[type[BaseException]]",  # noqa: PYI036
+        exc_val: "Optional[BaseException]",  # noqa: PYI036
+        exc_tb: "Optional[TracebackType]",  # noqa: PYI036
+    ) -> None:
+        self._closed = True
+        if exc_val:
+            self._exceptions.append(exc_val)
+
+        if self._tasks:
+            await asyncio.wait(self._tasks)
+
+        if self._exceptions:
+            # Re-raise the first exception encountered.
+            raise self._exceptions[0]
+
+    def create_task(self, coro: "Coroutine[Any, Any, Any]") -> "asyncio.Task[Any]":
+        """Create and add a coroutine as a task to the task group.
+
+        Args:
+            coro (Coroutine): The coroutine to be added as a task.
+
+        Returns:
+            asyncio.Task: The created asyncio task.
+
+        Raises:
+            RuntimeError: If the task group has already been closed.
+        """
+        if self._closed:
+            msg = "Cannot create a task in a task group that has already been closed."
+            raise RuntimeError(msg)
+        task = asyncio.create_task(coro)
+        self._tasks.add(task)
+        task.add_done_callback(self._tasks.discard)
+        task.add_done_callback(self._check_result)
+        return task
+
+    def _check_result(self, task: "asyncio.Task[Any]") -> None:
+        """Check and store exceptions from a completed task.
+
+        Args:
+            task (asyncio.Task): The task to check for exceptions.
+        """
+        try:
+            task.result()  # This will raise the exception if one occurred.
+        except Exception as e:  # noqa: BLE001
+            self._exceptions.append(e)
+
+    def start_soon_(
+        self,
+        async_function: "Callable[ParamSpecT, Awaitable[T]]",
+        name: object = None,
+    ) -> "Callable[ParamSpecT, SoonValue[T]]":
+        """Create a function to start a new task in this task group.
+
+        Args:
+            async_function (Callable): An async function to call soon.
+            name (object, optional): Name of the task for introspection and debugging.
+
+        Returns:
+            Callable: A function that starts the task and returns a SoonValue object.
+        """
+
+        @functools.wraps(async_function)
+        def wrapper(*args: "ParamSpecT.args", **kwargs: "ParamSpecT.kwargs") -> "SoonValue[T]":
+            partial_f = functools.partial(async_function, *args, **kwargs)
+            soon_value: SoonValue[T] = SoonValue()
+
+            @functools.wraps(partial_f)
+            async def value_wrapper(*_args: "Any") -> None:
+                value = await partial_f()
+                soon_value._stored_value = value  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+
+            self.create_task(value_wrapper)  # type: ignore[arg-type]
+            return soon_value
+
+        return wrapper
+
+
+def create_task_group() -> "TaskGroup":
+    """Create a TaskGroup for managing multiple concurrent async tasks.
+
+    Returns:
+        TaskGroup: A new TaskGroup instance.
+    """
+    return TaskGroup()
+
+
+class CapacityLimiter:
+    """Limits the number of concurrent operations using a semaphore."""
+
+    def __init__(self, total_tokens: int) -> None:
+        self._semaphore = asyncio.Semaphore(total_tokens)
+
+    async def acquire(self) -> None:
+        await self._semaphore.acquire()
+
+    def release(self) -> None:
+        self._semaphore.release()
+
+    @property
+    def total_tokens(self) -> int:
+        return self._semaphore._value  # noqa: SLF001
+
+    @total_tokens.setter
+    def total_tokens(self, value: int) -> None:
+        self._semaphore = asyncio.Semaphore(value)
+
+    async def __aenter__(self) -> None:
+        await self.acquire()
+
+    async def __aexit__(
+        self,
+        exc_type: "Optional[type[BaseException]]",  # noqa: PYI036
+        exc_val: "Optional[BaseException]",  # noqa: PYI036
+        exc_tb: "Optional[TracebackType]",  # noqa: PYI036
+    ) -> None:
+        self.release()
+
+
+_default_limiter = CapacityLimiter(40)
+
+
+def run_(async_function: "Callable[ParamSpecT, Coroutine[Any, Any, ReturnT]]") -> "Callable[ParamSpecT, ReturnT]":
+    """Convert an async function to a blocking function using asyncio.run().
+
+    Args:
+        async_function (Callable): The async function to convert.
+
+    Returns:
+        Callable: A blocking function that runs the async function.
+
+    """
+
+    @functools.wraps(async_function)
+    def wrapper(*args: "ParamSpecT.args", **kwargs: "ParamSpecT.kwargs") -> "ReturnT":
+        partial_f = functools.partial(async_function, *args, **kwargs)
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            loop = None
+
+        if loop is not None:
+            # Running in an existing event loop
+            return asyncio.run(partial_f())
+        # Create a new event loop and run the function
+        if uvloop and sys.platform != "win32":
+            uvloop.install()  # pyright: ignore[reportUnknownMemberType]
+        return asyncio.run(partial_f())
+
+    return wrapper
+
+
+def await_(
+    async_function: "Callable[ParamSpecT, Coroutine[Any, Any, ReturnT]]",
+    raise_sync_error: bool = True,
+) -> "Callable[ParamSpecT, ReturnT]":
+    """Convert an async function to a blocking one, running in the main async loop.
+
+    Args:
+        async_function (Callable): The async function to convert.
+        raise_sync_error (bool, optional): If False, runs in a new event loop if no loop is present.
+
+    Returns:
+        Callable: A blocking function that runs the async function.
+    """
+
+    @functools.wraps(async_function)
+    def wrapper(*args: "ParamSpecT.args", **kwargs: "ParamSpecT.kwargs") -> "ReturnT":
+        partial_f = functools.partial(async_function, *args, **kwargs)
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            loop = None
+
+        if loop is None and raise_sync_error is False:
+            return asyncio.run(partial_f())
+        # Running in an existing event loop
+        return asyncio.run(partial_f())
+
+    return wrapper
+
+
+def async_(
+    function: "Callable[ParamSpecT, ReturnT]",
+    *,
+    limiter: "Optional[CapacityLimiter]" = None,
+) -> "Callable[ParamSpecT, Awaitable[ReturnT]]":
+    """Convert a blocking function to an async one using asyncio.to_thread().
+
+    Args:
+        function (Callable): The blocking function to convert.
+        cancellable (bool, optional): Allow cancellation of the operation.
+        limiter (CapacityLimiter, optional): Limit the total number of threads.
+
+    Returns:
+        Callable: An async function that runs the original function in a thread.
+    """
+
+    async def wrapper(
+        *args: "ParamSpecT.args",
+        **kwargs: "ParamSpecT.kwargs",
+    ) -> "ReturnT":
+        partial_f = functools.partial(function, *args, **kwargs)
+        used_limiter = limiter or _default_limiter
+        async with used_limiter:
+            return await asyncio.to_thread(partial_f)
+
+    return wrapper
+
+
+def maybe_async_(
+    function: "Callable[ParamSpecT, Union[Awaitable[ReturnT], ReturnT]]",
+) -> "Callable[ParamSpecT, Awaitable[ReturnT]]":
+    """Convert a function to an async one if it is not already.
+
+    Args:
+        function (Callable): The function to convert.
+
+    Returns:
+        Callable: An async function that runs the original function.
+    """
+    if inspect.iscoroutinefunction(function):
+        return function
+
+    async def wrapper(*args: "ParamSpecT.args", **kwargs: "ParamSpecT.kwargs") -> "ReturnT":
+        result = function(*args, **kwargs)
+        if inspect.isawaitable(result):
+            return await result
+        return await async_(lambda: result)()
+
+    return wrapper
+
+
+def wrap_sync(fn: "Callable[ParamSpecT, ReturnT]") -> "Callable[ParamSpecT, Awaitable[ReturnT]]":
+    """Convert a sync function to an async one.
+
+    Args:
+        fn (Callable): The function to convert.
+
+    Returns:
+        Callable: An async function that runs the original function.
+    """
+    if inspect.iscoroutinefunction(fn):
+        return fn
+
+    async def wrapped(*args: "ParamSpecT.args", **kwargs: "ParamSpecT.kwargs") -> ReturnT:
+        return await async_(functools.partial(fn, *args, **kwargs))()
+
+    return wrapped
+
+
+class _ContextManagerWrapper(Generic[T]):
+    def __init__(self, cm: AbstractContextManager[T]) -> None:
+        self._cm = cm
+
+    async def __aenter__(self) -> T:
+        return self._cm.__enter__()
+
+    async def __aexit__(
+        self,
+        exc_type: "Optional[type[BaseException]]",  # noqa: PYI036
+        exc_val: "Optional[BaseException]",  # noqa: PYI036
+        exc_tb: "Optional[TracebackType]",  # noqa: PYI036
+    ) -> "Optional[bool]":
+        return self._cm.__exit__(exc_type, exc_val, exc_tb)
+
+
+def maybe_async_context(
+    obj: "Union[AbstractContextManager[T], AbstractAsyncContextManager[T]]",
+) -> "AbstractAsyncContextManager[T]":
+    """Convert a context manager to an async one if it is not already.
+
+    Args:
+        obj (AbstractContextManager[T] or AbstractAsyncContextManager[T]): The context manager to convert.
+
+    Returns:
+        AbstractAsyncContextManager[T]: An async context manager that runs the original context manager.
+    """
+
+    if isinstance(obj, AbstractContextManager):
+        return cast("AbstractAsyncContextManager[T]", _ContextManagerWrapper(obj))
+    return obj

--- a/examples/litestar/litestar_repo_only.py
+++ b/examples/litestar/litestar_repo_only.py
@@ -150,7 +150,7 @@ class AuthorController(Controller):
     async def get_author(
         self,
         authors_repo: AuthorRepository,
-        author_id: UUID = Parameter(  # noqa: B008
+        author_id: UUID = Parameter(
             title="Author ID",
             description="The author to retrieve.",
         ),
@@ -167,7 +167,7 @@ class AuthorController(Controller):
         self,
         authors_repo: AuthorRepository,
         data: AuthorUpdate,
-        author_id: UUID = Parameter(  # noqa: B008
+        author_id: UUID = Parameter(
             title="Author ID",
             description="The author to update.",
         ),
@@ -183,7 +183,7 @@ class AuthorController(Controller):
     async def delete_author(
         self,
         authors_repo: AuthorRepository,
-        author_id: UUID = Parameter(  # noqa: B008
+        author_id: UUID = Parameter(
             title="Author ID",
             description="The author to delete.",
         ),

--- a/examples/litestar/litestar_service.py
+++ b/examples/litestar/litestar_service.py
@@ -1,54 +1,39 @@
-from __future__ import annotations
+import datetime
+from typing import Annotated, Optional
+from uuid import UUID
 
-import datetime  # noqa: TC003
-from typing import TYPE_CHECKING, Optional
-from uuid import UUID  # noqa: TC003
-
-from litestar import Litestar
-from litestar.controller import Controller
-from litestar.di import Provide
-from litestar.handlers.http_handlers.decorators import delete, get, patch, post
-from litestar.params import Parameter
-from pydantic import BaseModel as _BaseModel
+from litestar import Controller, Litestar, delete, get, patch, post
+from litestar.params import Dependency, Parameter
+from pydantic import BaseModel
 from sqlalchemy import ForeignKey
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
-from advanced_alchemy.base import UUIDAuditBase, UUIDBase
 from advanced_alchemy.extensions.litestar import (
     AsyncSessionConfig,
     SQLAlchemyAsyncConfig,
     SQLAlchemyPlugin,
+    base,
+    filters,
+    providers,
+    repository,
+    service,
 )
-from advanced_alchemy.filters import FilterTypes, LimitOffset
-from advanced_alchemy.repository import SQLAlchemyAsyncRepository
-from advanced_alchemy.service import OffsetPagination, SQLAlchemyAsyncRepositoryService
-
-if TYPE_CHECKING:
-    from collections.abc import AsyncGenerator
-
-    from sqlalchemy.ext.asyncio import AsyncSession
-
-
-class BaseModel(_BaseModel):
-    """Extend Pydantic's BaseModel to enable ORM mode"""
-
-    model_config = {"from_attributes": True}
 
 
 # the SQLAlchemy base includes a declarative model for you to use in your models.
 # The `Base` class includes a `UUID` based primary key (`id`)
-class AuthorModel(UUIDBase):
+class AuthorModel(base.UUIDBase):
     # we can optionally provide the table name instead of auto-generating it
     __tablename__ = "author"
     name: Mapped[str]
-    dob: Mapped[Optional[datetime.date]]  # noqa: UP007
-    books: Mapped[list[BookModel]] = relationship(back_populates="author", lazy="noload")
+    dob: Mapped[Optional[datetime.date]]
+    books: Mapped["list[BookModel]"] = relationship(back_populates="author", lazy="noload")
 
 
 # The `AuditBase` class includes the same UUID` based primary key (`id`) and 2
 # additional columns: `created` and `updated`. `created` is a timestamp of when the
 # record created, and `updated` is the last time the record was modified.
-class BookModel(UUIDAuditBase):
+class BookModel(base.UUIDAuditBase):
     __tablename__ = "book"
     title: Mapped[str]
     author_id: Mapped[UUID] = mapped_column(ForeignKey("author.id"))
@@ -59,83 +44,51 @@ class BookModel(UUIDAuditBase):
 
 
 class Author(BaseModel):
-    id: UUID | None
+    id: Optional[UUID] = None
     name: str
-    dob: datetime.date | None = None
+    dob: Optional[datetime.date] = None
 
 
 class AuthorCreate(BaseModel):
     name: str
-    dob: datetime.date | None = None
+    dob: Optional[datetime.date] = None
 
 
 class AuthorUpdate(BaseModel):
-    name: str | None = None
-    dob: datetime.date | None = None
+    name: Optional[str] = None
+    dob: Optional[datetime.date] = None
 
 
-class AuthorRepository(SQLAlchemyAsyncRepository[AuthorModel]):
+class AuthorService(service.SQLAlchemyAsyncRepositoryService[AuthorModel]):
     """Author repository."""
 
-    model_type = AuthorModel
+    class Repo(repository.SQLAlchemyAsyncRepository[AuthorModel]):
+        """Author repository."""
 
+        model_type = AuthorModel
 
-class AuthorService(SQLAlchemyAsyncRepositoryService[AuthorModel, AuthorRepository]):
-    """Author repository."""
-
-    repository_type = AuthorRepository
-
-
-async def provide_authors_service(db_session: AsyncSession) -> AsyncGenerator[AuthorService, None]:
-    """This provides the default Authors repository."""
-    async with AuthorService.new(
-        session=db_session,
-    ) as service:
-        yield service
-
-
-# we can optionally override the default `select` used for the repository to pass in
-# specific SQL options such as join details
-async def provide_author_details_service(db_session: AsyncSession) -> AsyncGenerator[AuthorService, None]:
-    """This provides a simple example demonstrating how to override the join options for the repository."""
-    async with AuthorService.new(
-        session=db_session,
-        load=[AuthorModel.books],
-    ) as service:
-        yield service
-
-
-def provide_limit_offset_pagination(
-    current_page: int = Parameter(ge=1, query="currentPage", default=1, required=False),
-    page_size: int = Parameter(
-        query="pageSize",
-        ge=1,
-        default=10,
-        required=False,
-    ),
-) -> FilterTypes:
-    """Add offset/limit pagination.
-
-    Parameters
-    ----------
-    current_page : int
-        LIMIT to apply to select.
-    page_size : int
-        OFFSET to apply to select.
-    """
-    return LimitOffset(page_size, page_size * (current_page - 1))
+    repository_type = Repo
 
 
 class AuthorController(Controller):
     """Author CRUD"""
 
-    dependencies = {"authors_service": Provide(provide_authors_service)}
+    dependencies = providers.create_service_dependencies(
+        AuthorService,
+        "authors_service",
+        load=[AuthorModel.books],
+        filters={"pagination_type": "limit_offset", "id_filter": UUID, "search": "name", "search_ignore_case": True},
+    )
 
     @get(path="/authors")
-    async def list_authors(self, authors_service: AuthorService, limit_offset: LimitOffset) -> OffsetPagination[Author]:
+    async def list_authors(
+        self,
+        authors_service: AuthorService,
+        filters: Annotated[list[filters.FilterTypes], Dependency(skip_validation=True)],
+    ) -> service.OffsetPagination[Author]:
         """List authors."""
-        results, total = await authors_service.list_and_count(limit_offset)
-        return authors_service.to_schema(results, total, filters=[limit_offset], schema_type=Author)
+        results, total = await authors_service.list_and_count(*filters)
+        return authors_service.to_schema(results, total, filters=filters, schema_type=Author)
 
     @post(path="/authors")
     async def create_author(self, authors_service: AuthorService, data: AuthorCreate) -> Author:
@@ -144,11 +97,11 @@ class AuthorController(Controller):
         return authors_service.to_schema(obj, schema_type=Author)
 
     # we override the authors_repo to use the version that joins the Books in
-    @get(path="/authors/{author_id:uuid}", dependencies={"authors_service": Provide(provide_author_details_service)})
+    @get(path="/authors/{author_id:uuid}")
     async def get_author(
         self,
         authors_service: AuthorService,
-        author_id: UUID = Parameter(  # noqa: B008
+        author_id: UUID = Parameter(
             title="Author ID",
             description="The author to retrieve.",
         ),
@@ -157,15 +110,12 @@ class AuthorController(Controller):
         obj = await authors_service.get(author_id)
         return authors_service.to_schema(obj, schema_type=Author)
 
-    @patch(
-        path="/authors/{author_id:uuid}",
-        dependencies={"authors_service": Provide(provide_author_details_service)},
-    )
+    @patch(path="/authors/{author_id:uuid}")
     async def update_author(
         self,
         authors_service: AuthorService,
         data: AuthorUpdate,
-        author_id: UUID = Parameter(  # noqa: B008
+        author_id: UUID = Parameter(
             title="Author ID",
             description="The author to update.",
         ),
@@ -178,7 +128,7 @@ class AuthorController(Controller):
     async def delete_author(
         self,
         authors_service: AuthorService,
-        author_id: UUID = Parameter(  # noqa: B008
+        author_id: UUID = Parameter(
             title="Author ID",
             description="The author to delete.",
         ),
@@ -187,18 +137,14 @@ class AuthorController(Controller):
         _ = await authors_service.delete(author_id)
 
 
-session_config = AsyncSessionConfig(expire_on_commit=False)
-sqlalchemy_config = SQLAlchemyAsyncConfig(
+alchemy = SQLAlchemyAsyncConfig(
     connection_string="sqlite+aiosqlite:///test.sqlite",
     before_send_handler="autocommit",
-    session_config=session_config,
+    session_config=AsyncSessionConfig(expire_on_commit=False),
     create_all=True,
 )
-alchemy = SQLAlchemyPlugin(config=sqlalchemy_config)
-
 
 app = Litestar(
     route_handlers=[AuthorController],
-    plugins=[alchemy],
-    dependencies={"limit_offset": Provide(provide_limit_offset_pagination, sync_to_thread=False)},
+    plugins=[SQLAlchemyPlugin(config=alchemy)],
 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -302,6 +302,10 @@ ignore = [
   "COM812",
   "CPY001",
   "FA100",
+  "PLC0415",
+  "PLR0917",
+  "PLR0904",
+  "PGH003",
 ]
 select = ["ALL"]
 
@@ -326,6 +330,7 @@ classmethod-decorators = [
 "advanced_alchemy/repository/*.py" = ['C901']
 "examples/flask.py" = ["ANN"]
 "examples/flask/*.py" = ["ANN"]
+"examples/litestar/*.py" = ["B008"]
 "tests/**/*.*" = [
   "A",
   "ARG",

--- a/tests/unit/test_utils/test_sync_tools.py
+++ b/tests/unit/test_utils/test_sync_tools.py
@@ -1,0 +1,109 @@
+import asyncio
+from collections.abc import AsyncIterator, Iterator
+from contextlib import asynccontextmanager, contextmanager
+from typing import TypeVar
+
+import pytest
+
+from advanced_alchemy.utils.sync_tools import (
+    CapacityLimiter,
+    PendingValueError,
+    SoonValue,
+    TaskGroup,
+    async_,
+    await_,
+    maybe_async_,
+    maybe_async_context,
+    run_,
+)
+
+T = TypeVar("T")
+
+
+@pytest.mark.asyncio
+async def test_maybe_async() -> None:
+    @maybe_async_
+    def sync_func(x: int) -> int:
+        return x * 2
+
+    @maybe_async_  # type: ignore[arg-type]
+    async def async_func(x: int) -> int:
+        return x * 2
+
+    assert await sync_func(21) == 42
+    assert await async_func(21) == 42
+
+
+@pytest.mark.asyncio
+async def test_maybe_async_context() -> None:
+    @contextmanager
+    def sync_cm() -> Iterator[int]:
+        yield 42
+
+    @asynccontextmanager
+    async def async_cm() -> AsyncIterator[int]:
+        yield 42
+
+    async with maybe_async_context(sync_cm()) as value:
+        assert value == 42
+
+    async with maybe_async_context(async_cm()) as value:
+        assert value == 42
+
+
+@pytest.mark.asyncio
+async def test_soon_value() -> None:
+    soon_value = SoonValue[int]()
+    assert not soon_value.ready
+    with pytest.raises(PendingValueError):
+        _ = soon_value.value
+
+    setattr(soon_value, "_stored_value", 42)
+    assert soon_value.ready
+    assert soon_value.value == 42  # type: ignore[unreachable]
+
+
+@pytest.mark.asyncio
+async def test_task_group() -> None:
+    async def sample_task(x: int) -> int:
+        return x * 2
+
+    async with TaskGroup() as tg:
+        task = tg.create_task(sample_task(21))
+        await asyncio.wait([task])
+        assert task.result() == 42
+
+
+@pytest.mark.asyncio
+async def test_capacity_limiter() -> None:
+    limiter = CapacityLimiter(1)
+
+    async with limiter:
+        assert limiter.total_tokens == 0
+
+    assert limiter.total_tokens == 1
+
+
+def test_run_() -> None:
+    async def async_func(x: int) -> int:
+        return x * 2
+
+    sync_func = run_(async_func)
+    assert sync_func(21) == 42
+
+
+def test_await_() -> None:
+    async def async_func(x: int) -> int:
+        return x * 2
+
+    sync_func = await_(async_func, raise_sync_error=False)
+    assert sync_func(21) == 42
+
+
+@pytest.mark.asyncio
+async def test_async_() -> None:
+    def sync_func(x: int) -> int:
+        return x * 2
+
+    async_func = async_(sync_func)
+    assert await async_func(21) == 42


### PR DESCRIPTION
Unquify is now correctly set when passed into the `new`/`init` methods.

Introduced tests for `sync_tools` utilities, including `maybe_async_`, `maybe_async_context`, `SoonValue`, `TaskGroup`, and others.

Improves coverage for async and sync function handling, context managers, and value management.

 