### PR TITLE
feat: enable standard order by

### DIFF
--- a/advanced_alchemy/repository/_async.py
+++ b/advanced_alchemy/repository/_async.py
@@ -1600,7 +1600,7 @@ class SQLAlchemyAsyncRepository(SQLAlchemyAsyncRepositoryProtocol[ModelT], Filte
                 execution_options=execution_options,
             )
             if order_by is None:
-                order_by = self.order_by or []
+                order_by = self.order_by if self.order_by is not None else []
             statement = self._apply_order_by(statement=statement, order_by=order_by)
             statement = self._apply_filters(*filters, statement=statement)
             statement = self._filter_select_by_kwargs(statement, kwargs)
@@ -1657,7 +1657,7 @@ class SQLAlchemyAsyncRepository(SQLAlchemyAsyncRepositoryProtocol[ModelT], Filte
                 execution_options=execution_options,
             )
             if order_by is None:
-                order_by = self.order_by or []
+                order_by = self.order_by if self.order_by is not None else []
             statement = self._apply_order_by(statement=statement, order_by=order_by)
             statement = self._apply_filters(*filters, statement=statement)
             statement = self._filter_select_by_kwargs(statement, kwargs)
@@ -1945,7 +1945,7 @@ class SQLAlchemyAsyncRepository(SQLAlchemyAsyncRepositoryProtocol[ModelT], Filte
                 execution_options=execution_options,
             )
             if order_by is None:
-                order_by = self.order_by or []
+                order_by = self.order_by if self.order_by is not None else []
             statement = self._apply_order_by(statement=statement, order_by=order_by)
             statement = self._apply_filters(*filters, statement=statement)
             statement = self._filter_select_by_kwargs(statement, kwargs)

--- a/advanced_alchemy/repository/_sync.py
+++ b/advanced_alchemy/repository/_sync.py
@@ -1601,7 +1601,7 @@ class SQLAlchemySyncRepository(SQLAlchemySyncRepositoryProtocol[ModelT], Filtera
                 execution_options=execution_options,
             )
             if order_by is None:
-                order_by = self.order_by or []
+                order_by = self.order_by if self.order_by is not None else []
             statement = self._apply_order_by(statement=statement, order_by=order_by)
             statement = self._apply_filters(*filters, statement=statement)
             statement = self._filter_select_by_kwargs(statement, kwargs)
@@ -1656,7 +1656,7 @@ class SQLAlchemySyncRepository(SQLAlchemySyncRepositoryProtocol[ModelT], Filtera
                 execution_options=execution_options,
             )
             if order_by is None:
-                order_by = self.order_by or []
+                order_by = self.order_by if self.order_by is not None else []
             statement = self._apply_order_by(statement=statement, order_by=order_by)
             statement = self._apply_filters(*filters, statement=statement)
             statement = self._filter_select_by_kwargs(statement, kwargs)
@@ -1944,7 +1944,7 @@ class SQLAlchemySyncRepository(SQLAlchemySyncRepositoryProtocol[ModelT], Filtera
                 execution_options=execution_options,
             )
             if order_by is None:
-                order_by = self.order_by or []
+                order_by = self.order_by if self.order_by is not None else []
             statement = self._apply_order_by(statement=statement, order_by=order_by)
             statement = self._apply_filters(*filters, statement=statement)
             statement = self._filter_select_by_kwargs(statement, kwargs)

--- a/advanced_alchemy/repository/memory/_async.py
+++ b/advanced_alchemy/repository/memory/_async.py
@@ -85,8 +85,8 @@ class SQLAlchemyAsyncMockRepository(SQLAlchemyAsyncRepositoryProtocol[ModelT]):
         auto_expunge: bool = False,
         auto_refresh: bool = True,
         auto_commit: bool = False,
-        order_by: Union[list[OrderingPair], OrderingPair, None] = None,
-        error_messages: Union[ErrorMessages, None, EmptyType] = Empty,
+        order_by: Optional[Union[list[OrderingPair], OrderingPair]] = None,
+        error_messages: Optional[Union[ErrorMessages, EmptyType]] = Empty,
         wrap_exceptions: bool = True,
         load: Optional[LoadSpec] = None,
         execution_options: Optional[dict[str, Any]] = None,
@@ -115,8 +115,8 @@ class SQLAlchemyAsyncMockRepository(SQLAlchemyAsyncRepositoryProtocol[ModelT]):
 
     @staticmethod
     def _get_error_messages(
-        error_messages: Union[ErrorMessages, None, EmptyType] = Empty,
-        default_messages: Union[ErrorMessages, None, EmptyType] = Empty,
+        error_messages: Optional[Union[ErrorMessages, EmptyType]] = Empty,
+        default_messages: Optional[Union[ErrorMessages, EmptyType]] = Empty,
     ) -> Optional[ErrorMessages]:
         if error_messages == Empty:
             error_messages = None
@@ -204,19 +204,20 @@ class SQLAlchemyAsyncMockRepository(SQLAlchemyAsyncRepositoryProtocol[ModelT]):
     def _exclude_unused_kwargs(self, kwargs: dict[str, Any]) -> dict[str, Any]:
         return {key: value for key, value in kwargs.items() if key not in self._exclude_kwargs}
 
-    def _apply_limit_offset_pagination(self, result: list[ModelT], limit: int, offset: int) -> list[ModelT]:
+    @staticmethod
+    def _apply_limit_offset_pagination(result: list[ModelT], limit: int, offset: int) -> list[ModelT]:
         return result[offset:limit]
 
+    @staticmethod
     def _filter_in_collection(
-        self,
         result: list[ModelT],
         field_name: str,
         values: abc.Collection[Any],
     ) -> list[ModelT]:
         return [item for item in result if getattr(item, field_name) in values]
 
+    @staticmethod
     def _filter_not_in_collection(
-        self,
         result: list[ModelT],
         field_name: str,
         values: abc.Collection[Any],
@@ -225,8 +226,8 @@ class SQLAlchemyAsyncMockRepository(SQLAlchemyAsyncRepositoryProtocol[ModelT]):
             return result
         return [item for item in result if getattr(item, field_name) not in values]
 
+    @staticmethod
     def _filter_on_datetime_field(
-        self,
         result: list[ModelT],
         field_name: str,
         before: Optional[datetime.datetime] = None,
@@ -247,8 +248,8 @@ class SQLAlchemyAsyncMockRepository(SQLAlchemyAsyncRepositoryProtocol[ModelT]):
                 result_.append(item)
         return result_
 
+    @staticmethod
     def _filter_by_like(
-        self,
         result: list[ModelT],
         field_name: Union[str, set[str]],
         value: str,
@@ -267,8 +268,8 @@ class SQLAlchemyAsyncMockRepository(SQLAlchemyAsyncRepositoryProtocol[ModelT]):
             )
         return list(set(items))
 
+    @staticmethod
     def _filter_by_not_like(
-        self,
         result: list[ModelT],
         field_name: Union[str, set[str]],
         value: str,
@@ -294,13 +295,14 @@ class SQLAlchemyAsyncMockRepository(SQLAlchemyAsyncRepositoryProtocol[ModelT]):
         kwargs: Union[dict[Any, Any], Iterable[tuple[Any, Any]]],
     ) -> list[ModelT]:
         kwargs_: dict[Any, Any] = kwargs if isinstance(kwargs, dict) else dict(*kwargs)
-        kwargs_ = self._exclude_unused_kwargs(kwargs_)
+        kwargs_ = self._exclude_unused_kwargs(kwargs_)  # pyright: ignore
         try:
-            return [item for item in result if all(getattr(item, field) == value for field, value in kwargs_.items())]
+            return [item for item in result if all(getattr(item, field) == value for field, value in kwargs_.items())]  # pyright: ignore
         except AttributeError as error:
             raise RepositoryError from error
 
-    def _order_by(self, result: list[ModelT], field_name: str, sort_desc: bool = False) -> list[ModelT]:
+    @staticmethod
+    def _order_by(result: list[ModelT], field_name: str, sort_desc: bool = False) -> list[ModelT]:
         return sorted(result, key=lambda item: getattr(item, field_name), reverse=sort_desc)
 
     def _apply_filters(
@@ -418,7 +420,7 @@ class SQLAlchemyAsyncMockRepository(SQLAlchemyAsyncRepositoryProtocol[ModelT]):
         auto_expunge: Optional[bool] = None,
         statement: Union[Select[tuple[ModelT]], StatementLambdaElement, None] = None,
         id_attribute: Union[str, InstrumentedAttribute[Any], None] = None,
-        error_messages: Union[ErrorMessages, None, EmptyType] = Empty,
+        error_messages: Optional[Union[ErrorMessages, EmptyType]] = Empty,
         load: Optional[LoadSpec] = None,
         execution_options: Optional[dict[str, Any]] = None,
         uniquify: Optional[bool] = None,
@@ -430,7 +432,7 @@ class SQLAlchemyAsyncMockRepository(SQLAlchemyAsyncRepositoryProtocol[ModelT]):
         *filters: Union[StatementFilter, ColumnElement[bool]],
         auto_expunge: Optional[bool] = None,
         statement: Union[Select[tuple[ModelT]], StatementLambdaElement, None] = None,
-        error_messages: Union[ErrorMessages, None, EmptyType] = Empty,
+        error_messages: Optional[Union[ErrorMessages, EmptyType]] = Empty,
         load: Optional[LoadSpec] = None,
         execution_options: Optional[dict[str, Any]] = None,
         uniquify: Optional[bool] = None,
@@ -443,7 +445,7 @@ class SQLAlchemyAsyncMockRepository(SQLAlchemyAsyncRepositoryProtocol[ModelT]):
         *filters: Union[StatementFilter, ColumnElement[bool]],
         auto_expunge: Optional[bool] = None,
         statement: Union[Select[tuple[ModelT]], StatementLambdaElement, None] = None,
-        error_messages: Union[ErrorMessages, None, EmptyType] = Empty,
+        error_messages: Optional[Union[ErrorMessages, EmptyType]] = Empty,
         load: Optional[LoadSpec] = None,
         execution_options: Optional[dict[str, Any]] = None,
         uniquify: Optional[bool] = None,
@@ -465,7 +467,7 @@ class SQLAlchemyAsyncMockRepository(SQLAlchemyAsyncRepositoryProtocol[ModelT]):
         auto_commit: Optional[bool] = None,
         auto_expunge: Optional[bool] = None,
         auto_refresh: Optional[bool] = None,
-        error_messages: Union[ErrorMessages, None, EmptyType] = Empty,
+        error_messages: Optional[Union[ErrorMessages, EmptyType]] = Empty,
         load: Optional[LoadSpec] = None,
         execution_options: Optional[dict[str, Any]] = None,
         uniquify: Optional[bool] = None,
@@ -501,7 +503,7 @@ class SQLAlchemyAsyncMockRepository(SQLAlchemyAsyncRepositoryProtocol[ModelT]):
         auto_commit: Optional[bool] = None,
         auto_expunge: Optional[bool] = None,
         auto_refresh: Optional[bool] = None,
-        error_messages: Union[ErrorMessages, None, EmptyType] = Empty,
+        error_messages: Optional[Union[ErrorMessages, EmptyType]] = Empty,
         load: Optional[LoadSpec] = None,
         execution_options: Optional[dict[str, Any]] = None,
         uniquify: Optional[bool] = None,
@@ -552,7 +554,7 @@ class SQLAlchemyAsyncMockRepository(SQLAlchemyAsyncRepositoryProtocol[ModelT]):
         auto_commit: Optional[bool] = None,
         auto_expunge: Optional[bool] = None,
         auto_refresh: Optional[bool] = None,
-        error_messages: Union[ErrorMessages, None, EmptyType] = Empty,
+        error_messages: Optional[Union[ErrorMessages, EmptyType]] = Empty,
     ) -> ModelT:
         try:
             self.__database__.add(self.model_type, data)
@@ -567,7 +569,7 @@ class SQLAlchemyAsyncMockRepository(SQLAlchemyAsyncRepositoryProtocol[ModelT]):
         *,
         auto_commit: Optional[bool] = None,
         auto_expunge: Optional[bool] = None,
-        error_messages: Union[ErrorMessages, None, EmptyType] = Empty,
+        error_messages: Optional[Union[ErrorMessages, EmptyType]] = Empty,
     ) -> list[ModelT]:
         for obj in data:
             await self.add(obj)  # pyright: ignore[reportCallIssue]
@@ -582,8 +584,8 @@ class SQLAlchemyAsyncMockRepository(SQLAlchemyAsyncRepositoryProtocol[ModelT]):
         auto_commit: Optional[bool] = None,
         auto_expunge: Optional[bool] = None,
         auto_refresh: Optional[bool] = None,
-        id_attribute: Union[str, InstrumentedAttribute[Any], None] = None,
-        error_messages: Union[ErrorMessages, None, EmptyType] = Empty,
+        id_attribute: Optional[Union[str, InstrumentedAttribute[Any]]] = None,
+        error_messages: Optional[Union[ErrorMessages, EmptyType]] = Empty,
         load: Optional[LoadSpec] = None,
         execution_options: Optional[dict[str, Any]] = None,
         uniquify: Optional[bool] = None,
@@ -597,7 +599,7 @@ class SQLAlchemyAsyncMockRepository(SQLAlchemyAsyncRepositoryProtocol[ModelT]):
         *,
         auto_commit: Optional[bool] = None,
         auto_expunge: Optional[bool] = None,
-        error_messages: Union[ErrorMessages, None, EmptyType] = Empty,
+        error_messages: Optional[Union[ErrorMessages, EmptyType]] = Empty,
         load: Optional[LoadSpec] = None,
         execution_options: Optional[dict[str, Any]] = None,
         uniquify: Optional[bool] = None,
@@ -610,8 +612,8 @@ class SQLAlchemyAsyncMockRepository(SQLAlchemyAsyncRepositoryProtocol[ModelT]):
         *,
         auto_commit: Optional[bool] = None,
         auto_expunge: Optional[bool] = None,
-        id_attribute: Union[str, InstrumentedAttribute[Any], None] = None,
-        error_messages: Union[ErrorMessages, None, EmptyType] = Empty,
+        id_attribute: Optional[Union[str, InstrumentedAttribute[Any]]] = None,
+        error_messages: Optional[Union[ErrorMessages, EmptyType]] = Empty,
         load: Optional[LoadSpec] = None,
         execution_options: Optional[dict[str, Any]] = None,
         uniquify: Optional[bool] = None,
@@ -627,9 +629,9 @@ class SQLAlchemyAsyncMockRepository(SQLAlchemyAsyncRepositoryProtocol[ModelT]):
         *,
         auto_commit: Optional[bool] = None,
         auto_expunge: Optional[bool] = None,
-        id_attribute: Union[str, InstrumentedAttribute[Any], None] = None,
+        id_attribute: Optional[Union[str, InstrumentedAttribute[Any]]] = None,
         chunk_size: Optional[int] = None,
-        error_messages: Union[ErrorMessages, None, EmptyType] = Empty,
+        error_messages: Optional[Union[ErrorMessages, EmptyType]] = Empty,
         load: Optional[LoadSpec] = None,
         execution_options: Optional[dict[str, Any]] = None,
         uniquify: Optional[bool] = None,
@@ -646,7 +648,7 @@ class SQLAlchemyAsyncMockRepository(SQLAlchemyAsyncRepositoryProtocol[ModelT]):
         *filters: Union[StatementFilter, ColumnElement[bool]],
         auto_commit: Optional[bool] = None,
         auto_expunge: Optional[bool] = None,
-        error_messages: Union[ErrorMessages, None, EmptyType] = Empty,
+        error_messages: Optional[Union[ErrorMessages, EmptyType]] = Empty,
         sanity_check: bool = True,
         load: Optional[LoadSpec] = None,
         execution_options: Optional[dict[str, Any]] = None,
@@ -668,8 +670,8 @@ class SQLAlchemyAsyncMockRepository(SQLAlchemyAsyncRepositoryProtocol[ModelT]):
         auto_expunge: Optional[bool] = None,
         auto_commit: Optional[bool] = None,
         auto_refresh: Optional[bool] = None,
-        match_fields: Union[list[str], str, None] = None,
-        error_messages: Union[ErrorMessages, None, EmptyType] = Empty,
+        match_fields: Optional[Union[list[str], str]] = None,
+        error_messages: Optional[Union[ErrorMessages, EmptyType]] = Empty,
         load: Optional[LoadSpec] = None,
         execution_options: Optional[dict[str, Any]] = None,
         uniquify: Optional[bool] = None,
@@ -686,8 +688,8 @@ class SQLAlchemyAsyncMockRepository(SQLAlchemyAsyncRepositoryProtocol[ModelT]):
         auto_expunge: Optional[bool] = None,
         auto_commit: Optional[bool] = None,
         no_merge: bool = False,
-        match_fields: Union[list[str], str, None] = None,
-        error_messages: Union[ErrorMessages, None, EmptyType] = Empty,
+        match_fields: Optional[Union[list[str], str]] = None,
+        error_messages: Optional[Union[ErrorMessages, EmptyType]] = Empty,
         load: Optional[LoadSpec] = None,
         execution_options: Optional[dict[str, Any]] = None,
         uniquify: Optional[bool] = None,
@@ -700,8 +702,8 @@ class SQLAlchemyAsyncMockRepository(SQLAlchemyAsyncRepositoryProtocol[ModelT]):
         statement: Union[Select[tuple[ModelT]], StatementLambdaElement, None] = None,
         auto_expunge: Optional[bool] = None,
         count_with_window_function: Optional[bool] = None,
-        order_by: Union[list[OrderingPair], OrderingPair, None] = None,
-        error_messages: Union[ErrorMessages, None, EmptyType] = Empty,
+        order_by: Optional[Union[list[OrderingPair], OrderingPair]] = None,
+        error_messages: Optional[Union[ErrorMessages, EmptyType]] = Empty,
         load: Optional[LoadSpec] = None,
         execution_options: Optional[dict[str, Any]] = None,
         uniquify: Optional[bool] = None,
@@ -727,13 +729,12 @@ class SQLAlchemyAsyncMockSlugRepository(
     async def get_by_slug(
         self,
         slug: str,
-        error_messages: Union[ErrorMessages, None, EmptyType] = Empty,
+        error_messages: Optional[Union[ErrorMessages, EmptyType]] = Empty,
         load: Optional[LoadSpec] = None,
         execution_options: Optional[dict[str, Any]] = None,
         uniquify: Optional[bool] = None,
         **kwargs: Any,
     ) -> Union[ModelT, None]:
-        """Select record by slug value."""
         return await self.get_one_or_none(slug=slug)
 
     async def get_available_slug(

--- a/advanced_alchemy/repository/memory/_sync.py
+++ b/advanced_alchemy/repository/memory/_sync.py
@@ -86,8 +86,8 @@ class SQLAlchemySyncMockRepository(SQLAlchemySyncRepositoryProtocol[ModelT]):
         auto_expunge: bool = False,
         auto_refresh: bool = True,
         auto_commit: bool = False,
-        order_by: Union[list[OrderingPair], OrderingPair, None] = None,
-        error_messages: Union[ErrorMessages, None, EmptyType] = Empty,
+        order_by: Optional[Union[list[OrderingPair], OrderingPair]] = None,
+        error_messages: Optional[Union[ErrorMessages, EmptyType]] = Empty,
         wrap_exceptions: bool = True,
         load: Optional[LoadSpec] = None,
         execution_options: Optional[dict[str, Any]] = None,
@@ -116,8 +116,8 @@ class SQLAlchemySyncMockRepository(SQLAlchemySyncRepositoryProtocol[ModelT]):
 
     @staticmethod
     def _get_error_messages(
-        error_messages: Union[ErrorMessages, None, EmptyType] = Empty,
-        default_messages: Union[ErrorMessages, None, EmptyType] = Empty,
+        error_messages: Optional[Union[ErrorMessages, EmptyType]] = Empty,
+        default_messages: Optional[Union[ErrorMessages, EmptyType]] = Empty,
     ) -> Optional[ErrorMessages]:
         if error_messages == Empty:
             error_messages = None
@@ -205,19 +205,20 @@ class SQLAlchemySyncMockRepository(SQLAlchemySyncRepositoryProtocol[ModelT]):
     def _exclude_unused_kwargs(self, kwargs: dict[str, Any]) -> dict[str, Any]:
         return {key: value for key, value in kwargs.items() if key not in self._exclude_kwargs}
 
-    def _apply_limit_offset_pagination(self, result: list[ModelT], limit: int, offset: int) -> list[ModelT]:
+    @staticmethod
+    def _apply_limit_offset_pagination(result: list[ModelT], limit: int, offset: int) -> list[ModelT]:
         return result[offset:limit]
 
+    @staticmethod
     def _filter_in_collection(
-        self,
         result: list[ModelT],
         field_name: str,
         values: abc.Collection[Any],
     ) -> list[ModelT]:
         return [item for item in result if getattr(item, field_name) in values]
 
+    @staticmethod
     def _filter_not_in_collection(
-        self,
         result: list[ModelT],
         field_name: str,
         values: abc.Collection[Any],
@@ -226,8 +227,8 @@ class SQLAlchemySyncMockRepository(SQLAlchemySyncRepositoryProtocol[ModelT]):
             return result
         return [item for item in result if getattr(item, field_name) not in values]
 
+    @staticmethod
     def _filter_on_datetime_field(
-        self,
         result: list[ModelT],
         field_name: str,
         before: Optional[datetime.datetime] = None,
@@ -248,8 +249,8 @@ class SQLAlchemySyncMockRepository(SQLAlchemySyncRepositoryProtocol[ModelT]):
                 result_.append(item)
         return result_
 
+    @staticmethod
     def _filter_by_like(
-        self,
         result: list[ModelT],
         field_name: Union[str, set[str]],
         value: str,
@@ -268,8 +269,8 @@ class SQLAlchemySyncMockRepository(SQLAlchemySyncRepositoryProtocol[ModelT]):
             )
         return list(set(items))
 
+    @staticmethod
     def _filter_by_not_like(
-        self,
         result: list[ModelT],
         field_name: Union[str, set[str]],
         value: str,
@@ -295,13 +296,14 @@ class SQLAlchemySyncMockRepository(SQLAlchemySyncRepositoryProtocol[ModelT]):
         kwargs: Union[dict[Any, Any], Iterable[tuple[Any, Any]]],
     ) -> list[ModelT]:
         kwargs_: dict[Any, Any] = kwargs if isinstance(kwargs, dict) else dict(*kwargs)
-        kwargs_ = self._exclude_unused_kwargs(kwargs_)
+        kwargs_ = self._exclude_unused_kwargs(kwargs_)  # pyright: ignore
         try:
-            return [item for item in result if all(getattr(item, field) == value for field, value in kwargs_.items())]
+            return [item for item in result if all(getattr(item, field) == value for field, value in kwargs_.items())]  # pyright: ignore
         except AttributeError as error:
             raise RepositoryError from error
 
-    def _order_by(self, result: list[ModelT], field_name: str, sort_desc: bool = False) -> list[ModelT]:
+    @staticmethod
+    def _order_by(result: list[ModelT], field_name: str, sort_desc: bool = False) -> list[ModelT]:
         return sorted(result, key=lambda item: getattr(item, field_name), reverse=sort_desc)
 
     def _apply_filters(
@@ -419,7 +421,7 @@ class SQLAlchemySyncMockRepository(SQLAlchemySyncRepositoryProtocol[ModelT]):
         auto_expunge: Optional[bool] = None,
         statement: Union[Select[tuple[ModelT]], StatementLambdaElement, None] = None,
         id_attribute: Union[str, InstrumentedAttribute[Any], None] = None,
-        error_messages: Union[ErrorMessages, None, EmptyType] = Empty,
+        error_messages: Optional[Union[ErrorMessages, EmptyType]] = Empty,
         load: Optional[LoadSpec] = None,
         execution_options: Optional[dict[str, Any]] = None,
         uniquify: Optional[bool] = None,
@@ -431,7 +433,7 @@ class SQLAlchemySyncMockRepository(SQLAlchemySyncRepositoryProtocol[ModelT]):
         *filters: Union[StatementFilter, ColumnElement[bool]],
         auto_expunge: Optional[bool] = None,
         statement: Union[Select[tuple[ModelT]], StatementLambdaElement, None] = None,
-        error_messages: Union[ErrorMessages, None, EmptyType] = Empty,
+        error_messages: Optional[Union[ErrorMessages, EmptyType]] = Empty,
         load: Optional[LoadSpec] = None,
         execution_options: Optional[dict[str, Any]] = None,
         uniquify: Optional[bool] = None,
@@ -444,7 +446,7 @@ class SQLAlchemySyncMockRepository(SQLAlchemySyncRepositoryProtocol[ModelT]):
         *filters: Union[StatementFilter, ColumnElement[bool]],
         auto_expunge: Optional[bool] = None,
         statement: Union[Select[tuple[ModelT]], StatementLambdaElement, None] = None,
-        error_messages: Union[ErrorMessages, None, EmptyType] = Empty,
+        error_messages: Optional[Union[ErrorMessages, EmptyType]] = Empty,
         load: Optional[LoadSpec] = None,
         execution_options: Optional[dict[str, Any]] = None,
         uniquify: Optional[bool] = None,
@@ -466,7 +468,7 @@ class SQLAlchemySyncMockRepository(SQLAlchemySyncRepositoryProtocol[ModelT]):
         auto_commit: Optional[bool] = None,
         auto_expunge: Optional[bool] = None,
         auto_refresh: Optional[bool] = None,
-        error_messages: Union[ErrorMessages, None, EmptyType] = Empty,
+        error_messages: Optional[Union[ErrorMessages, EmptyType]] = Empty,
         load: Optional[LoadSpec] = None,
         execution_options: Optional[dict[str, Any]] = None,
         uniquify: Optional[bool] = None,
@@ -502,7 +504,7 @@ class SQLAlchemySyncMockRepository(SQLAlchemySyncRepositoryProtocol[ModelT]):
         auto_commit: Optional[bool] = None,
         auto_expunge: Optional[bool] = None,
         auto_refresh: Optional[bool] = None,
-        error_messages: Union[ErrorMessages, None, EmptyType] = Empty,
+        error_messages: Optional[Union[ErrorMessages, EmptyType]] = Empty,
         load: Optional[LoadSpec] = None,
         execution_options: Optional[dict[str, Any]] = None,
         uniquify: Optional[bool] = None,
@@ -553,7 +555,7 @@ class SQLAlchemySyncMockRepository(SQLAlchemySyncRepositoryProtocol[ModelT]):
         auto_commit: Optional[bool] = None,
         auto_expunge: Optional[bool] = None,
         auto_refresh: Optional[bool] = None,
-        error_messages: Union[ErrorMessages, None, EmptyType] = Empty,
+        error_messages: Optional[Union[ErrorMessages, EmptyType]] = Empty,
     ) -> ModelT:
         try:
             self.__database__.add(self.model_type, data)
@@ -568,7 +570,7 @@ class SQLAlchemySyncMockRepository(SQLAlchemySyncRepositoryProtocol[ModelT]):
         *,
         auto_commit: Optional[bool] = None,
         auto_expunge: Optional[bool] = None,
-        error_messages: Union[ErrorMessages, None, EmptyType] = Empty,
+        error_messages: Optional[Union[ErrorMessages, EmptyType]] = Empty,
     ) -> list[ModelT]:
         for obj in data:
             self.add(obj)  # pyright: ignore[reportCallIssue]
@@ -583,8 +585,8 @@ class SQLAlchemySyncMockRepository(SQLAlchemySyncRepositoryProtocol[ModelT]):
         auto_commit: Optional[bool] = None,
         auto_expunge: Optional[bool] = None,
         auto_refresh: Optional[bool] = None,
-        id_attribute: Union[str, InstrumentedAttribute[Any], None] = None,
-        error_messages: Union[ErrorMessages, None, EmptyType] = Empty,
+        id_attribute: Optional[Union[str, InstrumentedAttribute[Any]]] = None,
+        error_messages: Optional[Union[ErrorMessages, EmptyType]] = Empty,
         load: Optional[LoadSpec] = None,
         execution_options: Optional[dict[str, Any]] = None,
         uniquify: Optional[bool] = None,
@@ -598,7 +600,7 @@ class SQLAlchemySyncMockRepository(SQLAlchemySyncRepositoryProtocol[ModelT]):
         *,
         auto_commit: Optional[bool] = None,
         auto_expunge: Optional[bool] = None,
-        error_messages: Union[ErrorMessages, None, EmptyType] = Empty,
+        error_messages: Optional[Union[ErrorMessages, EmptyType]] = Empty,
         load: Optional[LoadSpec] = None,
         execution_options: Optional[dict[str, Any]] = None,
         uniquify: Optional[bool] = None,
@@ -611,8 +613,8 @@ class SQLAlchemySyncMockRepository(SQLAlchemySyncRepositoryProtocol[ModelT]):
         *,
         auto_commit: Optional[bool] = None,
         auto_expunge: Optional[bool] = None,
-        id_attribute: Union[str, InstrumentedAttribute[Any], None] = None,
-        error_messages: Union[ErrorMessages, None, EmptyType] = Empty,
+        id_attribute: Optional[Union[str, InstrumentedAttribute[Any]]] = None,
+        error_messages: Optional[Union[ErrorMessages, EmptyType]] = Empty,
         load: Optional[LoadSpec] = None,
         execution_options: Optional[dict[str, Any]] = None,
         uniquify: Optional[bool] = None,
@@ -628,9 +630,9 @@ class SQLAlchemySyncMockRepository(SQLAlchemySyncRepositoryProtocol[ModelT]):
         *,
         auto_commit: Optional[bool] = None,
         auto_expunge: Optional[bool] = None,
-        id_attribute: Union[str, InstrumentedAttribute[Any], None] = None,
+        id_attribute: Optional[Union[str, InstrumentedAttribute[Any]]] = None,
         chunk_size: Optional[int] = None,
-        error_messages: Union[ErrorMessages, None, EmptyType] = Empty,
+        error_messages: Optional[Union[ErrorMessages, EmptyType]] = Empty,
         load: Optional[LoadSpec] = None,
         execution_options: Optional[dict[str, Any]] = None,
         uniquify: Optional[bool] = None,
@@ -647,7 +649,7 @@ class SQLAlchemySyncMockRepository(SQLAlchemySyncRepositoryProtocol[ModelT]):
         *filters: Union[StatementFilter, ColumnElement[bool]],
         auto_commit: Optional[bool] = None,
         auto_expunge: Optional[bool] = None,
-        error_messages: Union[ErrorMessages, None, EmptyType] = Empty,
+        error_messages: Optional[Union[ErrorMessages, EmptyType]] = Empty,
         sanity_check: bool = True,
         load: Optional[LoadSpec] = None,
         execution_options: Optional[dict[str, Any]] = None,
@@ -669,8 +671,8 @@ class SQLAlchemySyncMockRepository(SQLAlchemySyncRepositoryProtocol[ModelT]):
         auto_expunge: Optional[bool] = None,
         auto_commit: Optional[bool] = None,
         auto_refresh: Optional[bool] = None,
-        match_fields: Union[list[str], str, None] = None,
-        error_messages: Union[ErrorMessages, None, EmptyType] = Empty,
+        match_fields: Optional[Union[list[str], str]] = None,
+        error_messages: Optional[Union[ErrorMessages, EmptyType]] = Empty,
         load: Optional[LoadSpec] = None,
         execution_options: Optional[dict[str, Any]] = None,
         uniquify: Optional[bool] = None,
@@ -687,8 +689,8 @@ class SQLAlchemySyncMockRepository(SQLAlchemySyncRepositoryProtocol[ModelT]):
         auto_expunge: Optional[bool] = None,
         auto_commit: Optional[bool] = None,
         no_merge: bool = False,
-        match_fields: Union[list[str], str, None] = None,
-        error_messages: Union[ErrorMessages, None, EmptyType] = Empty,
+        match_fields: Optional[Union[list[str], str]] = None,
+        error_messages: Optional[Union[ErrorMessages, EmptyType]] = Empty,
         load: Optional[LoadSpec] = None,
         execution_options: Optional[dict[str, Any]] = None,
         uniquify: Optional[bool] = None,
@@ -701,8 +703,8 @@ class SQLAlchemySyncMockRepository(SQLAlchemySyncRepositoryProtocol[ModelT]):
         statement: Union[Select[tuple[ModelT]], StatementLambdaElement, None] = None,
         auto_expunge: Optional[bool] = None,
         count_with_window_function: Optional[bool] = None,
-        order_by: Union[list[OrderingPair], OrderingPair, None] = None,
-        error_messages: Union[ErrorMessages, None, EmptyType] = Empty,
+        order_by: Optional[Union[list[OrderingPair], OrderingPair]] = None,
+        error_messages: Optional[Union[ErrorMessages, EmptyType]] = Empty,
         load: Optional[LoadSpec] = None,
         execution_options: Optional[dict[str, Any]] = None,
         uniquify: Optional[bool] = None,
@@ -728,13 +730,12 @@ class SQLAlchemySyncMockSlugRepository(
     def get_by_slug(
         self,
         slug: str,
-        error_messages: Union[ErrorMessages, None, EmptyType] = Empty,
+        error_messages: Optional[Union[ErrorMessages, EmptyType]] = Empty,
         load: Optional[LoadSpec] = None,
         execution_options: Optional[dict[str, Any]] = None,
         uniquify: Optional[bool] = None,
         **kwargs: Any,
     ) -> Union[ModelT, None]:
-        """Select record by slug value."""
         return self.get_one_or_none(slug=slug)
 
     def get_available_slug(

--- a/advanced_alchemy/repository/typing.py
+++ b/advanced_alchemy/repository/typing.py
@@ -1,5 +1,6 @@
 from typing import TYPE_CHECKING, Any, Union
 
+from sqlalchemy import UnaryExpression
 from sqlalchemy.orm import InstrumentedAttribute
 from typing_extensions import TypeAlias, TypeVar
 
@@ -69,12 +70,13 @@ SQLAlchemyAsyncRepositoryT = TypeVar(
 
 :class:`~advanced_alchemy.repository.SQLAlchemyAsyncRepository`
 """
-OrderingPair: TypeAlias = tuple[Union[str, InstrumentedAttribute[Any]], bool]
+OrderingPair: TypeAlias = Union[tuple[Union[str, InstrumentedAttribute[Any]], bool], UnaryExpression[Any]]
 """Type alias for ordering pairs.
 
 A tuple of (column, ascending) where:
 - column: Union[str, :class:`sqlalchemy.orm.InstrumentedAttribute`]
 - ascending: bool
+- or a :class:`sqlalchemy.sql.elements.UnaryExpression` which is the standard way to express an ordering in SQLAlchemy
 
 This type is used to specify ordering criteria for repository queries.
 """

--- a/tests/integration/test_repository.py
+++ b/tests/integration/test_repository.py
@@ -1887,6 +1887,13 @@ async def test_repo_filter_order_by(author_repo: AnyAuthorRepository) -> None:
     assert existing_obj[0].name == "Leo Tolstoy"
 
 
+async def test_repo_filter_order_by_unary_expression(author_repo: AnyAuthorRepository) -> None:
+    existing_obj = await maybe_async(author_repo.list(order_by=author_repo.model_type.created_at.desc()))
+    assert existing_obj[0].name == "Agatha Christie"
+    existing_obj = await maybe_async(author_repo.list(order_by=author_repo.model_type.created_at.asc()))
+    assert existing_obj[0].name == "Leo Tolstoy"
+
+
 async def test_repo_filter_collection(
     author_repo: AnyAuthorRepository,
     existing_author_ids: Generator[Any, None, None],

--- a/tests/integration/test_repository.py
+++ b/tests/integration/test_repository.py
@@ -1890,8 +1890,6 @@ async def test_repo_filter_order_by(author_repo: AnyAuthorRepository) -> None:
 async def test_repo_filter_order_by_unary_expression(author_repo: AnyAuthorRepository) -> None:
     existing_obj = await maybe_async(author_repo.list(order_by=author_repo.model_type.created_at.desc()))
     assert existing_obj[0].name == "Agatha Christie"
-    existing_obj = await maybe_async(author_repo.list(order_by=author_repo.model_type.created_at.asc()))
-    assert existing_obj[0].name == "Leo Tolstoy"
 
 
 async def test_repo_filter_collection(


### PR DESCRIPTION
Enables the standard `UnaryOperator` order by support in addition to the existing `OrderingPair`