### PR TITLE
chore(ci): updated docs deployment

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,11 +10,14 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
+  build_and_deploy:
     permissions:
       contents: write
       pages: write
       id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -40,17 +43,7 @@ jobs:
         uses: actions/upload-pages-artifact@v3
         with:
           path: docs-build/
-  deploy:
-    permissions:
-      contents: write
-      pages: write
-      id-token: write
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
+
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4


### PR DESCRIPTION
Merged the build and deploy jobs into a single job named 'build_and_deploy' in the GitHub Actions workflow for documentation. This change simplifies the workflow and ensures that deployment occurs immediately after the build process, improving efficiency.