### PR TITLE
fix: make `SentinelMixin` compatible with `MappedAsDataclass`

### DIFF
--- a/advanced_alchemy/mixins/sentinel.py
+++ b/advanced_alchemy/mixins/sentinel.py
@@ -1,4 +1,5 @@
-from sqlalchemy.orm import Mapped, declarative_mixin, declared_attr, orm_insert_sentinel
+from sqlalchemy.orm import Mapped, declarative_mixin, declared_attr, mapped_column
+from sqlalchemy.sql.schema import _InsertSentinelColumnDefault as InsertSentinelColumnDefault
 
 
 @declarative_mixin
@@ -7,4 +8,12 @@ class SentinelMixin:
 
     @declared_attr
     def _sentinel(cls) -> Mapped[int]:
-        return orm_insert_sentinel(name="sa_orm_sentinel")
+        return mapped_column(
+            name='sa_orm_sentinel',
+            init=False,
+            insert_default=InsertSentinelColumnDefault(),
+            _omit_from_statements=True,
+            insert_sentinel=True,
+            use_existing_column=True,
+            nullable=True,
+        )

--- a/advanced_alchemy/mixins/sentinel.py
+++ b/advanced_alchemy/mixins/sentinel.py
@@ -1,36 +1,31 @@
 from typing import TypedDict
 
 from sqlalchemy.orm import Mapped, MappedAsDataclass, declarative_mixin, declared_attr, mapped_column
-from sqlalchemy.sql.schema import (
-    _InsertSentinelColumnDefault as InsertSentinelColumnDefault,  # pyright: ignore [reportPrivateUsage]
-)
+from sqlalchemy.sql.schema import _InsertSentinelColumnDefault  # pyright: ignore [reportPrivateUsage]
+from typing_extensions import NotRequired
 
 
-class SentinelKwargs(TypedDict, total=False):
-    init: bool
+class SentinelKwargs(TypedDict):
+    init: NotRequired[bool]
 
 
 @declarative_mixin
 class SentinelMixin:
     """Mixin to add a sentinel column for SQLAlchemy models."""
 
-    kwargs: SentinelKwargs
-
-    def __init_subclass__(cls) -> None:
-        if issubclass(cls, MappedAsDataclass):
-            cls.kwargs = {"init": False}
-
-        else:
-            cls.kwargs = {}
+    __abstract__ = True
 
     @declared_attr
     def _sentinel(cls) -> Mapped[int]:
+        kwargs: SentinelKwargs = {}
+        if issubclass(type[cls], MappedAsDataclass):
+            kwargs["init"] = True
         return mapped_column(
             name="sa_orm_sentinel",
-            insert_default=InsertSentinelColumnDefault(),
+            insert_default=_InsertSentinelColumnDefault(),
             _omit_from_statements=True,
             insert_sentinel=True,
             use_existing_column=True,
             nullable=True,
-            **cls.kwargs,
+            **kwargs,
         )

--- a/advanced_alchemy/mixins/sentinel.py
+++ b/advanced_alchemy/mixins/sentinel.py
@@ -15,11 +15,15 @@ class SentinelMixin:
 
     __abstract__ = True
 
+    _sentinel_kwargs: SentinelKwargs = {}
+
+    def __init_subclass__(cls) -> None:
+        super().__init_subclass__()
+        if issubclass(cls, MappedAsDataclass):  # type: ignore[arg-type]
+            cls._sentinel_kwargs["init"] = False
+
     @declared_attr
     def _sentinel(cls) -> Mapped[int]:
-        kwargs: SentinelKwargs = {}
-        if issubclass(cls, MappedAsDataclass):  # pyright: ignore
-            kwargs["init"] = False
         return mapped_column(
             name="sa_orm_sentinel",
             insert_default=_InsertSentinelColumnDefault(),
@@ -27,5 +31,5 @@ class SentinelMixin:
             insert_sentinel=True,
             use_existing_column=True,
             nullable=True,
-            **kwargs,
+            **cls._sentinel_kwargs,
         )

--- a/advanced_alchemy/mixins/sentinel.py
+++ b/advanced_alchemy/mixins/sentinel.py
@@ -18,7 +18,7 @@ class SentinelMixin:
     @declared_attr
     def _sentinel(cls) -> Mapped[int]:
         kwargs: SentinelKwargs = {}
-        if issubclass(type[cls], MappedAsDataclass):
+        if issubclass(cls, MappedAsDataclass):  # pyright: ignore
             kwargs["init"] = False
         return mapped_column(
             name="sa_orm_sentinel",

--- a/advanced_alchemy/mixins/sentinel.py
+++ b/advanced_alchemy/mixins/sentinel.py
@@ -4,11 +4,10 @@ from sqlalchemy.orm import Mapped, MappedAsDataclass, declarative_mixin, declare
 from sqlalchemy.sql.schema import (
     _InsertSentinelColumnDefault as InsertSentinelColumnDefault,  # pyright: ignore [reportPrivateUsage]
 )
-from typing_extensions import NotRequired
 
 
-class SentinelKwargs(TypedDict):
-    init: NotRequired[bool]
+class SentinelKwargs(TypedDict, total=False):
+    init: bool
 
 
 @declarative_mixin
@@ -18,7 +17,11 @@ class SentinelMixin:
     kwargs: SentinelKwargs
 
     def __init_subclass__(cls) -> None:
-        cls.kwargs = SentinelKwargs(init=False) if issubclass(cls, MappedAsDataclass) else SentinelKwargs()
+        if issubclass(cls, MappedAsDataclass):
+            cls.kwargs = {"init": False}
+
+        else:
+            cls.kwargs = {}
 
     @declared_attr
     def _sentinel(cls) -> Mapped[int]:

--- a/advanced_alchemy/mixins/sentinel.py
+++ b/advanced_alchemy/mixins/sentinel.py
@@ -1,19 +1,31 @@
-from sqlalchemy.orm import Mapped, declarative_mixin, declared_attr, mapped_column
-from sqlalchemy.sql.schema import _InsertSentinelColumnDefault as InsertSentinelColumnDefault  # pyright: ignore [reportPrivateUsage]
+from typing import TypedDict
+
+from sqlalchemy.orm import Mapped, MappedAsDataclass, declarative_mixin, declared_attr, mapped_column
+from sqlalchemy.sql.schema import (
+    _InsertSentinelColumnDefault as InsertSentinelColumnDefault,  # pyright: ignore [reportPrivateUsage]
+)
+from typing_extensions import NotRequired
+
+
+class SentinelKwargs(TypedDict):
+    init: NotRequired[bool]
 
 
 @declarative_mixin
 class SentinelMixin:
     """Mixin to add a sentinel column for SQLAlchemy models."""
 
+    def __init_subclass__(cls) -> None:
+        cls.kwargs = SentinelKwargs(init=False) if issubclass(cls, MappedAsDataclass) else SentinelKwargs()
+
     @declared_attr
     def _sentinel(cls) -> Mapped[int]:
         return mapped_column(
-            name='sa_orm_sentinel',
-            init=False,
+            name="sa_orm_sentinel",
             insert_default=InsertSentinelColumnDefault(),
             _omit_from_statements=True,
             insert_sentinel=True,
             use_existing_column=True,
             nullable=True,
+            **cls.kwargs,
         )

--- a/advanced_alchemy/mixins/sentinel.py
+++ b/advanced_alchemy/mixins/sentinel.py
@@ -19,7 +19,7 @@ class SentinelMixin:
     def _sentinel(cls) -> Mapped[int]:
         kwargs: SentinelKwargs = {}
         if issubclass(type[cls], MappedAsDataclass):
-            kwargs["init"] = True
+            kwargs["init"] = False
         return mapped_column(
             name="sa_orm_sentinel",
             insert_default=_InsertSentinelColumnDefault(),

--- a/advanced_alchemy/mixins/sentinel.py
+++ b/advanced_alchemy/mixins/sentinel.py
@@ -15,6 +15,8 @@ class SentinelKwargs(TypedDict):
 class SentinelMixin:
     """Mixin to add a sentinel column for SQLAlchemy models."""
 
+    kwargs: SentinelKwargs
+
     def __init_subclass__(cls) -> None:
         cls.kwargs = SentinelKwargs(init=False) if issubclass(cls, MappedAsDataclass) else SentinelKwargs()
 

--- a/advanced_alchemy/mixins/sentinel.py
+++ b/advanced_alchemy/mixins/sentinel.py
@@ -1,5 +1,5 @@
 from sqlalchemy.orm import Mapped, declarative_mixin, declared_attr, mapped_column
-from sqlalchemy.sql.schema import _InsertSentinelColumnDefault as InsertSentinelColumnDefault
+from sqlalchemy.sql.schema import _InsertSentinelColumnDefault as InsertSentinelColumnDefault  # pyright: ignore [reportPrivateUsage]
 
 
 @declarative_mixin

--- a/advanced_alchemy/mixins/sentinel.py
+++ b/advanced_alchemy/mixins/sentinel.py
@@ -19,7 +19,7 @@ class SentinelMixin:
 
     def __init_subclass__(cls) -> None:
         super().__init_subclass__()
-        if issubclass(cls, MappedAsDataclass):  # type: ignore[arg-type]
+        if issubclass(cls, MappedAsDataclass):
             cls._sentinel_kwargs["init"] = False
 
     @declared_attr


### PR DESCRIPTION
`MappedAsDataclass` is a mixin introduced in SQLAlchemy 2.0. It introduces massive DX improvements to SQLAlchemy by introducing dataclass type validation to SQLAlchemy models. However, this mixin is incompatible with SQLAlchemy's recommended method of implementing a sentinel column as written in their [documentation](https://docs.sqlalchemy.org/en/20/core/connections.html#configuring-sentinel-columns).

This PR fixes this incompatibility as suggested by the SQLAlchemy maintainer in this [discussion](https://github.com/sqlalchemy/sqlalchemy/discussions/12519#discussioncomment-12804658).