### PR TITLE
feat: Add identity Mixin for Primary Keys

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ default_language_version:
   python: "3"
 repos:
   - repo: https://github.com/compilerla/conventional-pre-commit
-    rev: v4.1.0
+    rev: v4.2.0
     hooks:
       - id: conventional-pre-commit
         stages: [commit-msg]

--- a/advanced_alchemy/base.py
+++ b/advanced_alchemy/base.py
@@ -244,15 +244,17 @@ def create_registry(
     with contextlib.suppress(ImportError):
         from pydantic import AnyHttpUrl, AnyUrl, EmailStr, IPvAnyAddress, IPvAnyInterface, IPvAnyNetwork, Json
 
-        type_annotation_map.update({
-            EmailStr: String,
-            AnyUrl: String,
-            AnyHttpUrl: String,
-            Json: JsonB,
-            IPvAnyAddress: String,
-            IPvAnyInterface: String,
-            IPvAnyNetwork: String,
-        })
+        type_annotation_map.update(
+            {
+                EmailStr: String,
+                AnyUrl: String,
+                AnyHttpUrl: String,
+                Json: JsonB,
+                IPvAnyAddress: String,
+                IPvAnyInterface: String,
+                IPvAnyNetwork: String,
+            }
+        )
     with contextlib.suppress(ImportError):
         from msgspec import Struct
 

--- a/advanced_alchemy/base.py
+++ b/advanced_alchemy/base.py
@@ -27,6 +27,7 @@ from typing_extensions import Self, TypeVar
 from advanced_alchemy.mixins import (
     AuditColumns,
     BigIntPrimaryKey,
+    IdentityPrimaryKey,
     NanoIDPrimaryKey,
     UUIDPrimaryKey,
     UUIDv6PrimaryKey,
@@ -49,6 +50,9 @@ __all__ = (
     "BigIntBase",
     "BigIntBaseT",
     "CommonTableAttributes",
+    "IdentityAuditBase",
+    "IdentityBase",
+    "IdentityBaseT",
     "ModelProtocol",
     "NanoIDAuditBase",
     "NanoIDBase",
@@ -77,6 +81,8 @@ UUIDBaseT = TypeVar("UUIDBaseT", bound="UUIDBase")
 """Type variable for :class:`UUIDBase`."""
 BigIntBaseT = TypeVar("BigIntBaseT", bound="BigIntBase")
 """Type variable for :class:`BigIntBase`."""
+IdentityBaseT = TypeVar("IdentityBaseT", bound="IdentityBase")
+"""Type variable for :class:`IdentityBase`."""
 UUIDv6BaseT = TypeVar("UUIDv6BaseT", bound="UUIDv6Base")
 """Type variable for :class:`UUIDv6Base`."""
 UUIDv7BaseT = TypeVar("UUIDv7BaseT", bound="UUIDv7Base")
@@ -238,17 +244,15 @@ def create_registry(
     with contextlib.suppress(ImportError):
         from pydantic import AnyHttpUrl, AnyUrl, EmailStr, IPvAnyAddress, IPvAnyInterface, IPvAnyNetwork, Json
 
-        type_annotation_map.update(
-            {
-                EmailStr: String,
-                AnyUrl: String,
-                AnyHttpUrl: String,
-                Json: JsonB,
-                IPvAnyAddress: String,
-                IPvAnyInterface: String,
-                IPvAnyNetwork: String,
-            }
-        )
+        type_annotation_map.update({
+            EmailStr: String,
+            AnyUrl: String,
+            AnyHttpUrl: String,
+            Json: JsonB,
+            IPvAnyAddress: String,
+            IPvAnyInterface: String,
+            IPvAnyNetwork: String,
+        })
     with contextlib.suppress(ImportError):
         from msgspec import Struct
 
@@ -467,6 +471,39 @@ class BigIntAuditBase(CommonTableAttributes, BigIntPrimaryKey, AuditColumns, Adv
     .. seealso::
         :class:`CommonTableAttributes`
         :class:`advanced_alchemy.mixins.BigIntPrimaryKey`
+        :class:`advanced_alchemy.mixins.AuditColumns`
+        :class:`AdvancedDeclarativeBase`
+        :class:`AsyncAttrs`
+    """
+
+    __abstract__ = True
+
+
+class IdentityBase(IdentityPrimaryKey, CommonTableAttributes, AdvancedDeclarativeBase, AsyncAttrs):
+    """Base for all SQLAlchemy declarative models with database IDENTITY primary keys.
+
+    This model uses the database native IDENTITY feature for generating primary keys
+    instead of using database sequences.
+
+    .. seealso::
+        :class:`advanced_alchemy.mixins.IdentityPrimaryKey`
+        :class:`CommonTableAttributes`
+        :class:`AdvancedDeclarativeBase`
+        :class:`AsyncAttrs`
+    """
+
+    __abstract__ = True
+
+
+class IdentityAuditBase(CommonTableAttributes, IdentityPrimaryKey, AuditColumns, AdvancedDeclarativeBase, AsyncAttrs):
+    """Base for declarative models with database IDENTITY primary keys and audit columns.
+
+    This model uses the database native IDENTITY feature for generating primary keys
+    instead of using database sequences.
+
+    .. seealso::
+        :class:`CommonTableAttributes`
+        :class:`advanced_alchemy.mixins.IdentityPrimaryKey`
         :class:`advanced_alchemy.mixins.AuditColumns`
         :class:`AdvancedDeclarativeBase`
         :class:`AsyncAttrs`

--- a/advanced_alchemy/mixins/__init__.py
+++ b/advanced_alchemy/mixins/__init__.py
@@ -1,5 +1,5 @@
 from advanced_alchemy.mixins.audit import AuditColumns
-from advanced_alchemy.mixins.bigint import BigIntPrimaryKey
+from advanced_alchemy.mixins.bigint import BigIntPrimaryKey, IdentityPrimaryKey
 from advanced_alchemy.mixins.nanoid import NanoIDPrimaryKey
 from advanced_alchemy.mixins.sentinel import SentinelMixin
 from advanced_alchemy.mixins.slug import SlugKey
@@ -9,6 +9,7 @@ from advanced_alchemy.mixins.uuid import UUIDPrimaryKey, UUIDv6PrimaryKey, UUIDv
 __all__ = (
     "AuditColumns",
     "BigIntPrimaryKey",
+    "IdentityPrimaryKey",
     "NanoIDPrimaryKey",
     "SentinelMixin",
     "SlugKey",

--- a/advanced_alchemy/mixins/bigint.py
+++ b/advanced_alchemy/mixins/bigint.py
@@ -36,3 +36,21 @@ class BigIntPrimaryKey:
             Sequence(f"{cls.__tablename__}_id_seq", **seq_kwargs),  # type: ignore[attr-defined]
             primary_key=True,
         )
+
+
+@declarative_mixin
+class IdentityPrimaryKey:
+    """Primary Key Field Mixin using database IDENTITY feature.
+
+    This mixin uses the database's native IDENTITY feature rather than a sequence.
+    This can be more efficient for databases that support IDENTITY natively.
+    """
+
+    @declared_attr
+    def id(cls) -> Mapped[int]:
+        """Primary key column using IDENTITY."""
+        return mapped_column(
+            BigIntIdentity,
+            primary_key=True,
+            autoincrement=True,
+        )

--- a/docs/usage/modeling.rst
+++ b/docs/usage/modeling.rst
@@ -20,6 +20,10 @@ Advanced Alchemy provides several base classes optimized for different use cases
      - BIGINT primary keys for tables
    * - ``BigIntAuditBase``
      - BIGINT primary keys for tables, Automatic created_at/updated_at timestamps
+   * - ``IdentityBase``
+     - Primary keys using database IDENTITY feature instead of sequences
+   * - ``IdentityAuditBase``
+     - Primary keys using database IDENTITY feature, Automatic created_at/updated_at timestamps
    * - ``UUIDBase``
      - UUID primary keys
    * - ``UUIDv6Base``
@@ -53,6 +57,10 @@ Additionally, Advanced Alchemy provides mixins to enhance model functionality:
    * - ``AuditColumns``
      - | Automatic created_at/updated_at timestamps
        | Tracks record modifications
+   * - ``BigIntPrimaryKey``
+     - | Adds BigInt primary key with sequence
+   * - ``IdentityPrimaryKey``
+     - | Adds primary key using database IDENTITY feature
    * - ``UniqueMixin``
      - | Automatic Select or Create for many-to-many relationships
 

--- a/tests/integration/test_bigint_identity.py
+++ b/tests/integration/test_bigint_identity.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+from sqlalchemy import Column, ForeignKey, String, Table, create_engine, select
+from sqlalchemy.ext.associationproxy import AssociationProxy, association_proxy
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.orm import Mapped, Session, mapped_column, relationship, sessionmaker
+
+if TYPE_CHECKING:
+    from pytest import MonkeyPatch
+
+
+@pytest.mark.xdist_group("loader")
+def test_ap_sync(monkeypatch: MonkeyPatch, tmp_path: Path) -> None:
+    from sqlalchemy.orm import DeclarativeBase
+
+    from advanced_alchemy import base, mixins
+
+    orm_registry = base.create_registry()
+
+    class NewIdentityBase(mixins.IdentityPrimaryKey, base.CommonTableAttributes, DeclarativeBase):
+        registry = orm_registry
+
+    monkeypatch.setattr(base, "IdentityBase", NewIdentityBase)
+
+    product_tag_table = Table(
+        "product_tag",
+        orm_registry.metadata,
+        Column("product_id", ForeignKey("product.id", ondelete="CASCADE"), primary_key=True),  # pyright: ignore[reportUnknownArgumentType]
+        Column("tag_id", ForeignKey("tag.id", ondelete="CASCADE"), primary_key=True),  # pyright: ignore[reportUnknownArgumentType]
+    )
+
+    class Tag(NewIdentityBase):
+        name: Mapped[str] = mapped_column(index=True)
+        products: Mapped[list[Product]] = relationship(
+            secondary=lambda: product_tag_table,
+            back_populates="product_tags",
+            cascade="all, delete",
+            passive_deletes=True,
+            lazy="noload",
+        )
+
+    class Product(NewIdentityBase):
+        name: Mapped[str] = mapped_column(String(length=50))  # pyright: ignore
+        product_tags: Mapped[list[Tag]] = relationship(
+            secondary=lambda: product_tag_table,
+            back_populates="products",
+            cascade="all, delete",
+            passive_deletes=True,
+            lazy="joined",
+        )
+        tags: AssociationProxy[list[str]] = association_proxy(
+            "product_tags",
+            "name",
+            creator=lambda name: Tag(name=name),  # pyright: ignore[reportUnknownArgumentType,reportUnknownLambdaType]
+        )
+
+    engine = create_engine(f"sqlite:///{tmp_path}/test.sqlite1.db", echo=True)
+    session_factory: sessionmaker[Session] = sessionmaker(engine, expire_on_commit=False)
+
+    with engine.begin() as conn:
+        Product.metadata.create_all(conn)
+
+    with session_factory() as db_session:
+        product_1 = Product(name="Product 1", tags=["a new tag", "second tag"])
+        db_session.add(product_1)
+
+        tags = db_session.execute(select(Tag)).unique().fetchall()
+        assert len(tags) == 2
+
+        product_2 = Product(name="Product 2", tags=["third tag"])
+        db_session.add(product_2)
+        tags = db_session.execute(select(Tag)).unique().fetchall()
+        assert len(tags) == 3
+
+        product_2.tags = []
+        db_session.add(product_2)
+
+        product_2_validate = db_session.execute(select(Product).where(Product.name == "Product 2")).unique().fetchone()
+        assert product_2_validate
+        tags_2 = db_session.execute(select(Tag)).unique().fetchall()
+        assert len(product_2_validate[0].product_tags) == 0
+        assert len(tags_2) == 3
+        # add more assertions
+
+
+@pytest.mark.xdist_group("loader")
+async def test_ap_async(monkeypatch: MonkeyPatch, tmp_path: Path) -> None:
+    from sqlalchemy.orm import DeclarativeBase
+
+    from advanced_alchemy import base, mixins
+
+    orm_registry = base.create_registry()
+
+    class NewIdentityBase(mixins.IdentityPrimaryKey, base.CommonTableAttributes, DeclarativeBase):
+        registry = orm_registry
+
+    monkeypatch.setattr(base, "IdentityBase", NewIdentityBase)
+
+    product_tag_table = Table(
+        "product_tag",
+        orm_registry.metadata,
+        Column("product_id", ForeignKey("product.id", ondelete="CASCADE"), primary_key=True),  # pyright: ignore[reportUnknownArgumentType]
+        Column("tag_id", ForeignKey("tag.id", ondelete="CASCADE"), primary_key=True),  # pyright: ignore[reportUnknownArgumentType]
+    )
+
+    class Tag(NewIdentityBase):
+        name: Mapped[str] = mapped_column(index=True)
+        products: Mapped[list[Product]] = relationship(
+            secondary=lambda: product_tag_table,
+            back_populates="product_tags",
+            cascade="all, delete",
+            passive_deletes=True,
+            lazy="noload",
+        )
+
+    class Product(NewIdentityBase):
+        name: Mapped[str] = mapped_column(String(length=50))  # pyright: ignore
+        product_tags: Mapped[list[Tag]] = relationship(
+            secondary=lambda: product_tag_table,
+            back_populates="products",
+            cascade="all, delete",
+            passive_deletes=True,
+            lazy="joined",
+        )
+        tags: AssociationProxy[list[str]] = association_proxy(
+            "product_tags",
+            "name",
+            creator=lambda name: Tag(name=name),  # pyright: ignore[reportUnknownArgumentType,reportUnknownLambdaType]
+        )
+
+    engine = create_async_engine(f"sqlite+aiosqlite:///{tmp_path}/test.sqlite2.db", echo=True)
+    session_factory: async_sessionmaker[AsyncSession] = async_sessionmaker(engine, expire_on_commit=False)
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Tag.metadata.create_all)
+
+    async with session_factory() as db_session:
+        product_1 = Product(name="Product 1 async", tags=["a new tag", "second tag"])
+        db_session.add(product_1)
+
+        tags = await db_session.execute(select(Tag))
+        assert len(tags.unique().fetchall()) == 2
+
+        product_2 = Product(name="Product 2 async", tags=["third tag"])
+        db_session.add(product_2)
+        tags = await db_session.execute(select(Tag))
+        assert len(tags.unique().fetchall()) == 3
+
+        # add more assertions

--- a/uv.lock
+++ b/uv.lock
@@ -1873,16 +1873,16 @@ grpc = [
 
 [[package]]
 name = "google-auth"
-version = "2.39.0"
+version = "2.40.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cachetools" },
     { name = "pyasn1-modules" },
     { name = "rsa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/cb/8e/8f45c9a32f73e786e954b8f9761c61422955d23c45d1e8c347f9b4b59e8e/google_auth-2.39.0.tar.gz", hash = "sha256:73222d43cdc35a3aeacbfdcaf73142a97839f10de930550d89ebfe1d0a00cde7", size = 274834, upload-time = "2025-04-14T17:44:49.402Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/a5/38c21d0e731bb716cffcf987bd9a3555cb95877ab4b616cfb96939933f20/google_auth-2.40.1.tar.gz", hash = "sha256:58f0e8416a9814c1d86c9b7f6acf6816b51aba167b2c76821965271bac275540", size = 280975, upload-time = "2025-05-07T01:04:55.3Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ce/12/ad37a1ef86006d0a0117fc06a4a00bd461c775356b534b425f00dde208ea/google_auth-2.39.0-py2.py3-none-any.whl", hash = "sha256:0150b6711e97fb9f52fe599f55648950cc4540015565d8fbb31be2ad6e1548a2", size = 212319, upload-time = "2025-04-14T17:44:47.699Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/b1/1272c6e80847ba5349f5ccb7574596393d1e222543f5003cb810865c3575/google_auth-2.40.1-py2.py3-none-any.whl", hash = "sha256:ed4cae4f5c46b41bae1d19c036e06f6c371926e97b19e816fc854eff811974ee", size = 216101, upload-time = "2025-05-07T01:04:53.612Z" },
 ]
 
 [[package]]
@@ -2359,7 +2359,7 @@ wheels = [
 
 [[package]]
 name = "litestar"
-version = "2.15.2"
+version = "2.16.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -2377,9 +2377,9 @@ dependencies = [
     { name = "rich-click" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b5/c9/d3a431379383cb479d7122017083b9858fe92c6d3333b9d278ed7d559865/litestar-2.15.2.tar.gz", hash = "sha256:de3320e7e412bf09f420b1703cbf04295f1a5377230dad0484d7da8c7ddf5a37", size = 397217, upload-time = "2025-04-06T12:31:43.146Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0d/4e/3376d5737a4c2e26fb2991a046265c38335b134d3e04e93c6d754e962e4e/litestar-2.16.0.tar.gz", hash = "sha256:f65c0d543bfec12b7433dff624322936f30bbdfb54ad3c5b7ef22ab2d092be2d", size = 399637, upload-time = "2025-05-04T11:00:46.654Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f4/db/4ddf71ddb51c70ef4f91bb5c59a84436cecfcfed0e5733f9b31b4b360dbc/litestar-2.15.2-py3-none-any.whl", hash = "sha256:41e7670d67bac70b466008a74eeb2aa63f4f71c09ffade4f603fc00d2bbc771f", size = 571057, upload-time = "2025-04-06T12:31:41.338Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/dc/4d1018577683918cd24a58228c90833f71f792aafcfffb44905c9062f737/litestar-2.16.0-py3-none-any.whl", hash = "sha256:8a48557198556f01d3d70da3859a471aa56595a4a344362d9529ed65804e3ee4", size = 573158, upload-time = "2025-05-04T11:00:44.558Z" },
 ]
 
 [package.optional-dependencies]
@@ -4166,16 +4166,16 @@ wheels = [
 
 [[package]]
 name = "rich-toolkit"
-version = "0.14.4"
+version = "0.14.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
     { name = "rich" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e1/33/18332e1359803ae6407a1e605a6bdb253a426ffe931555f1299f9e39eece/rich_toolkit-0.14.4.tar.gz", hash = "sha256:db256cf45165cae381c9bbf3b48a0fd4d99a07c80155cc655c80212a62e28fe1", size = 104487, upload-time = "2025-04-29T19:43:36.904Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d1/24/f0678256fbe0643b4ba00a460f4b736ef07042e459f8d4087c8b7011ab81/rich_toolkit-0.14.5.tar.gz", hash = "sha256:1cb7a3fa0bdbf35793460708664f3f797e8b18cedec9cd41a7e6125e4bc6272b", size = 104799, upload-time = "2025-05-05T10:19:24.521Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/44/48/c6d43d4c56c45c0171c771b2b73deeec493efb57795b651319201e7c4638/rich_toolkit-0.14.4-py3-none-any.whl", hash = "sha256:cc71ebee83eaa122d8e42882408bc5a4bf0240bbf1e368811ee56d249b3d742a", size = 24258, upload-time = "2025-04-29T19:43:35.502Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/13/621cc551b72de51e6e5cb7cfc510a141e1858bd380ee3c8108fbda4a6be0/rich_toolkit-0.14.5-py3-none-any.whl", hash = "sha256:2fe9846ecbf5d0cdf236c7f43452b68d9da1436a81594aba6b79b3c48b05703b", size = 24791, upload-time = "2025-05-05T10:19:23.346Z" },
 ]
 
 [[package]]
@@ -4365,11 +4365,11 @@ wheels = [
 
 [[package]]
 name = "setuptools"
-version = "80.3.0"
+version = "80.3.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/51/6c/a3f892949418b5b9aced7396919c75ffb57e38f08b712b565f5eb10677ee/setuptools-80.3.0.tar.gz", hash = "sha256:ec8308eb180b2312062b1c5523204acf872cd8b0a9e6c2ae76431b22bc4065d7", size = 1314475, upload-time = "2025-05-03T09:17:32.334Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/70/dc/3976b322de9d2e87ed0007cf04cc7553969b6c7b3f48a565d0333748fbcd/setuptools-80.3.1.tar.gz", hash = "sha256:31e2c58dbb67c99c289f51c16d899afedae292b978f8051efaf6262d8212f927", size = 1315082, upload-time = "2025-05-04T18:47:04.397Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e6/61/a6239ff35d64e55def020335626894895847cc6659c0f8e1b676c58aad3b/setuptools-80.3.0-py3-none-any.whl", hash = "sha256:a65cffc4fb86167e3020b3ef58e08226baad8b29a3b34ce2c9d07e901bac481d", size = 1200273, upload-time = "2025-05-03T09:17:29.995Z" },
+    { url = "https://files.pythonhosted.org/packages/53/7e/5d8af3317ddbf9519b687bd1c39d8737fde07d97f54df65553faca5cffb1/setuptools-80.3.1-py3-none-any.whl", hash = "sha256:ea8e00d7992054c4c592aeb892f6ad51fe1b4d90cc6947cc45c45717c40ec537", size = 1201172, upload-time = "2025-05-04T18:47:02.575Z" },
 ]
 
 [[package]]
@@ -4749,7 +4749,7 @@ wheels = [
 
 [[package]]
 name = "sphinx-toolbox"
-version = "3.9.0"
+version = "3.10.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "apeye" },
@@ -4775,9 +4775,9 @@ dependencies = [
     { name = "tabulate" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/df/32/e10c272614a1f4d84b680007bd45f9b77db3262ee6c3c61a0e27932a55b7/sphinx_toolbox-3.9.0.tar.gz", hash = "sha256:9ee0603b090762d6eed4d0ec9fa91445e3ef95d40a584af125308541c1bf7b8d", size = 114497, upload-time = "2025-02-26T13:32:07.253Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f4/2d/d916dc5a70bc7b006af8a31bba1a2767e99cdb884f3dfa47aa79a60cc1e9/sphinx_toolbox-3.10.0.tar.gz", hash = "sha256:6afea9ac9afabe76bd5bd4d2b01edfdad81d653a1a34768e776e6a56d5a6f572", size = 113656, upload-time = "2025-05-06T17:36:50.926Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/7e/9811c8cf0df10c2b6c9c72667837d731dd4f0dc0d0e68980938c8eb6f7f8/sphinx_toolbox-3.9.0-py3-none-any.whl", hash = "sha256:49024961c7791ad6e9dd39c611f89b5162550afa26ccad087be38388c3dd3c1e", size = 195429, upload-time = "2025-02-26T13:32:04.4Z" },
+    { url = "https://files.pythonhosted.org/packages/12/ec/d09521ae2059fe89d8b59b2b34f5a1713b82a14e70a9a018fca8d3d514be/sphinx_toolbox-3.10.0-py3-none-any.whl", hash = "sha256:675e5978eaee31adf21701054fa75bacf820459d56e93ac30ad01eaee047a6ef", size = 195622, upload-time = "2025-05-06T17:36:48.81Z" },
 ]
 
 [[package]]
@@ -4916,16 +4916,16 @@ wheels = [
 
 [[package]]
 name = "sqlalchemy-spanner"
-version = "1.10.0"
+version = "1.11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "alembic" },
     { name = "google-cloud-spanner" },
     { name = "sqlalchemy" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b3/20/4a07595979f17babe4271f3966b80525cd073b3c4aae697014551e625403/sqlalchemy_spanner-1.10.0.tar.gz", hash = "sha256:7aad22f2df33385bd6a1951239cfa05624f3ea71bc8853e1047705e911d86c2a", size = 80561, upload-time = "2025-03-17T08:24:44.471Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/56/d5/597563c659c2a55b0f01d4b44b370ac468bafd56c2bc10b4de6b89eda97e/sqlalchemy_spanner-1.11.0.tar.gz", hash = "sha256:24f151094e8fe614255c4b208d280fad862d610d8ef6247ddde0b24bf07d625a", size = 82048, upload-time = "2025-05-07T10:44:30.366Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/7c/7a36ef4475d93ec713b225f44a0741c2b3b3b50936278d850aa52e369462/sqlalchemy_spanner-1.10.0-py3-none-any.whl", hash = "sha256:fa3c6271b5ebc62881c3467008c676c2f59895c55d47a3f1f40befee5d011caf", size = 29799, upload-time = "2025-03-17T08:24:42.922Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/85/07b7f88fa189e8651dd7b168307300256377031afc9120a718c0fad730ac/sqlalchemy_spanner-1.11.0-py3-none-any.whl", hash = "sha256:25461a57e19076a3706e6a03733771ef6acdcd3c2b4e422d77cf613ed6d485e7", size = 31593, upload-time = "2025-05-07T10:44:29.156Z" },
 ]
 
 [[package]]
@@ -5463,16 +5463,16 @@ wheels = [
 
 [[package]]
 name = "virtualenv"
-version = "20.30.0"
+version = "20.31.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "distlib" },
     { name = "filelock" },
     { name = "platformdirs" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/38/e0/633e369b91bbc664df47dcb5454b6c7cf441e8f5b9d0c250ce9f0546401e/virtualenv-20.30.0.tar.gz", hash = "sha256:800863162bcaa5450a6e4d721049730e7f2dae07720e0902b0e4040bd6f9ada8", size = 4346945, upload-time = "2025-03-31T16:33:29.185Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/07/655f4fb9592967f49197b00015bb5538d3ed1f8f96621a10bebc3bb822e2/virtualenv-20.31.1.tar.gz", hash = "sha256:65442939608aeebb9284cd30baca5865fcd9f12b58bb740a24b220030df46d26", size = 6076234, upload-time = "2025-05-05T22:45:39.829Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4c/ed/3cfeb48175f0671ec430ede81f628f9fb2b1084c9064ca67ebe8c0ed6a05/virtualenv-20.30.0-py3-none-any.whl", hash = "sha256:e34302959180fca3af42d1800df014b35019490b119eba981af27f2fa486e5d6", size = 4329461, upload-time = "2025-03-31T16:33:26.758Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/67/7d7559264a6f8ec9ce4e397ddd9157a510be1e174dc98be898b6c18eeef4/virtualenv-20.31.1-py3-none-any.whl", hash = "sha256:f448cd2f1604c831afb9ea238021060be2c0edbcad8eb0a4e8b4e14ff11a5482", size = 6057843, upload-time = "2025-05-05T22:45:37.127Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
The sequences based BigInt key offers the most compatibility, but many would prefer to use the Identity column when the database supports it.

This changes implements a basic Identity primary key mixin