### PR TITLE
chore(docs): Fix the broken links for pwdlib and argon2-cffi in docs

### DIFF
--- a/docs/usage/types.rst
+++ b/docs/usage/types.rst
@@ -157,8 +157,8 @@ Password Hash
 
 A type for storing password hashes with configurable backends.  Currently supports:
 
-- :class:`~advanced_alchemy.types.password_hash.pwdlib.PwdlibHasher`: Uses `pwdlib <https://github.com/pwdlib/pwdlib>`_
-- :class:`~advanced_alchemy.types.password_hash.argon2.Argon2Hasher`: Uses `argon2-cffi <https://argon2.readthedocs.io/en/stable/>`_
+- :class:`~advanced_alchemy.types.password_hash.pwdlib.PwdlibHasher`: Uses `pwdlib <https://frankie567.github.io/pwdlib/>`_
+- :class:`~advanced_alchemy.types.password_hash.argon2.Argon2Hasher`: Uses `argon2-cffi <https://argon2-cffi.readthedocs.io/en/stable/>`_
 - :class:`~advanced_alchemy.types.password_hash.passlib.PasslibHasher`: Uses `passlib <https://passlib.readthedocs.io/en/stable/>`_
 
 .. code-block:: python


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description
- Fixes the 2 broken links in the docs for pwdlib and argon2

