### PR TITLE
feat: `attrs` integration

### DIFF
--- a/advanced_alchemy/service/__init__.py
+++ b/advanced_alchemy/service/__init__.py
@@ -22,11 +22,18 @@ from advanced_alchemy.service._sync import (
 from advanced_alchemy.service._util import ResultConverter, find_filter
 from advanced_alchemy.service.pagination import OffsetPagination
 from advanced_alchemy.service.typing import (
+    ATTRS_INSTALLED,
+    AttrsClass,
     FilterTypeT,
     ModelDictListT,
     ModelDictT,
     ModelDTOT,
     SupportedSchemaModel,
+    fields,
+    is_attrs_instance,
+    is_attrs_instance_with_field,
+    is_attrs_instance_without_field,
+    is_attrs_schema,
     is_dict,
     is_dict_with_field,
     is_dict_without_field,
@@ -47,7 +54,9 @@ from advanced_alchemy.service.typing import (
 )
 
 __all__ = (
+    "ATTRS_INSTALLED",
     "DEFAULT_ERROR_MESSAGE_TEMPLATES",
+    "AttrsClass",
     "Empty",
     "EmptyType",
     "ErrorMessages",
@@ -68,7 +77,12 @@ __all__ = (
     "SQLAlchemySyncRepositoryReadService",
     "SQLAlchemySyncRepositoryService",
     "SupportedSchemaModel",
+    "fields",
     "find_filter",
+    "is_attrs_instance",
+    "is_attrs_instance_with_field",
+    "is_attrs_instance_without_field",
+    "is_attrs_schema",
     "is_dict",
     "is_dict_with_field",
     "is_dict_without_field",

--- a/advanced_alchemy/service/__init__.py
+++ b/advanced_alchemy/service/__init__.py
@@ -23,7 +23,7 @@ from advanced_alchemy.service._util import ResultConverter, find_filter
 from advanced_alchemy.service.pagination import OffsetPagination
 from advanced_alchemy.service.typing import (
     ATTRS_INSTALLED,
-    AttrsClass,
+    AttrsInstance,
     FilterTypeT,
     ModelDictListT,
     ModelDictT,
@@ -56,7 +56,7 @@ from advanced_alchemy.service.typing import (
 __all__ = (
     "ATTRS_INSTALLED",
     "DEFAULT_ERROR_MESSAGE_TEMPLATES",
-    "AttrsClass",
+    "AttrsInstance",
     "Empty",
     "EmptyType",
     "ErrorMessages",

--- a/advanced_alchemy/service/_async.py
+++ b/advanced_alchemy/service/_async.py
@@ -30,6 +30,8 @@ from advanced_alchemy.service.typing import (
     BulkModelDictT,
     ModelDictListT,
     ModelDictT,
+    asdict,
+    is_attrs_instance,
     is_dict,
     is_dto_data,
     is_msgspec_struct,
@@ -455,6 +457,20 @@ class SQLAlchemyAsyncRepositoryReadService(ResultConverter, Generic[ModelT, SQLA
 
         if is_dto_data(data):
             return cast("ModelT", data.create_instance())
+
+        if is_attrs_instance(data):
+            return model_from_dict(
+                model=self.model_type,
+                **asdict(data),
+            )
+
+        # Fallback for objects with __dict__ (e.g., regular classes)
+        if hasattr(data, "__dict__"):
+            return model_from_dict(
+                model=self.model_type,
+                **data.__dict__,
+            )
+
         return cast("ModelT", data)
 
     async def list_and_count(

--- a/advanced_alchemy/service/_sync.py
+++ b/advanced_alchemy/service/_sync.py
@@ -29,6 +29,8 @@ from advanced_alchemy.service.typing import (
     BulkModelDictT,
     ModelDictListT,
     ModelDictT,
+    asdict,
+    is_attrs_instance,
     is_dict,
     is_dto_data,
     is_msgspec_struct,
@@ -454,6 +456,20 @@ class SQLAlchemySyncRepositoryReadService(ResultConverter, Generic[ModelT, SQLAl
 
         if is_dto_data(data):
             return cast("ModelT", data.create_instance())
+
+        if is_attrs_instance(data):
+            return model_from_dict(
+                model=self.model_type,
+                **asdict(data),
+            )
+
+        # Fallback for objects with __dict__ (e.g., regular classes)
+        if hasattr(data, "__dict__"):
+            return model_from_dict(
+                model=self.model_type,
+                **data.__dict__,
+            )
+
         return cast("ModelT", data)
 
     def list_and_count(

--- a/advanced_alchemy/service/_typing.py
+++ b/advanced_alchemy/service/_typing.py
@@ -130,7 +130,7 @@ try:
     from attrs import asdict, define, field, fields, has  # pyright: ignore
 
     @runtime_checkable
-    class AttrsClass(Protocol):  # type: ignore[no-redef]
+    class AttrsClass(Protocol):  # pyright: ignore
         """Protocol for attrs classes when attrs is installed"""
 
         __attrs_attrs__: "ClassVar[tuple[Any, ...]]"
@@ -166,8 +166,25 @@ except ImportError:
 
     ATTRS_INSTALLED = False  # pyright: ignore[reportConstantRedefinition]
 
+try:
+    from cattrs import structure, unstructure  # pyright: ignore # type: ignore[import-not-found]
+
+    CATTRS_INSTALLED = True
+except ImportError:
+
+    def unstructure(*args: Any, **kwargs: Any) -> Any:  # noqa: ARG001
+        """Placeholder implementation"""
+        return {}
+
+    def structure(*args: Any, **kwargs: Any) -> Any:  # noqa: ARG001
+        """Placeholder implementation"""
+        return {}
+
+    CATTRS_INSTALLED = False  # pyright: ignore[reportConstantRedefinition]
+
 __all__ = (
     "ATTRS_INSTALLED",
+    "CATTRS_INSTALLED",
     "LITESTAR_INSTALLED",
     "MSGSPEC_INSTALLED",
     "PYDANTIC_INSTALLED",
@@ -185,4 +202,6 @@ __all__ = (
     "field",
     "fields",
     "has",
+    "structure",
+    "unstructure",
 )

--- a/advanced_alchemy/service/_typing.py
+++ b/advanced_alchemy/service/_typing.py
@@ -126,16 +126,63 @@ except ImportError:
 
     LITESTAR_INSTALLED = False  # pyright: ignore[reportConstantRedefinition]
 
+try:
+    from attrs import asdict, define, field, fields, has  # pyright: ignore
+
+    @runtime_checkable
+    class AttrsClass(Protocol):  # type: ignore[no-redef]
+        """Protocol for attrs classes when attrs is installed"""
+
+        __attrs_attrs__: "ClassVar[tuple[Any, ...]]"
+
+    ATTRS_INSTALLED = True
+except ImportError:
+
+    @runtime_checkable
+    class AttrsClass(Protocol):  # type: ignore[no-redef]
+        """Placeholder Implementation for attrs classes"""
+
+        __attrs_attrs__: "ClassVar[tuple[Any, ...]]"
+
+    def asdict(*args: Any, **kwargs: Any) -> "dict[str, Any]":  # type: ignore[misc] # noqa: ARG001
+        """Placeholder implementation"""
+        return {}
+
+    def define(*args: Any, **kwargs: Any) -> Any:  # type: ignore[no-redef] # noqa: ARG001
+        """Placeholder implementation"""
+        return lambda cls: cls  # pyright: ignore[reportUnknownVariableType,reportUnknownLambdaType]
+
+    def field(*args: Any, **kwargs: Any) -> Any:  # type: ignore[no-redef] # noqa: ARG001
+        """Placeholder implementation"""
+        return None
+
+    def fields(*args: Any, **kwargs: Any) -> "tuple[Any, ...]":  # type: ignore[misc] # noqa: ARG001
+        """Placeholder implementation"""
+        return ()
+
+    def has(*args: Any, **kwargs: Any) -> bool:  # type: ignore[misc] # noqa: ARG001
+        """Placeholder implementation"""
+        return False
+
+    ATTRS_INSTALLED = False  # pyright: ignore[reportConstantRedefinition]
+
 __all__ = (
+    "ATTRS_INSTALLED",
     "LITESTAR_INSTALLED",
     "MSGSPEC_INSTALLED",
     "PYDANTIC_INSTALLED",
     "UNSET",
+    "AttrsClass",
     "BaseModel",
     "DTOData",
     "FailFast",
     "Struct",
     "TypeAdapter",
     "UnsetType",
+    "asdict",
     "convert",
+    "define",
+    "field",
+    "fields",
+    "has",
 )

--- a/advanced_alchemy/service/_typing.py
+++ b/advanced_alchemy/service/_typing.py
@@ -127,22 +127,14 @@ except ImportError:
     LITESTAR_INSTALLED = False  # pyright: ignore[reportConstantRedefinition]
 
 try:
-    from attrs import asdict, define, field, fields, has  # pyright: ignore
-
-    @runtime_checkable
-    class AttrsClass(Protocol):  # pyright: ignore
-        """Protocol for attrs classes when attrs is installed"""
-
-        __attrs_attrs__: "ClassVar[tuple[Any, ...]]"
+    from attrs import AttrsInstance, asdict, define, field, fields, has  # pyright: ignore
 
     ATTRS_INSTALLED = True
 except ImportError:
 
     @runtime_checkable
-    class AttrsClass(Protocol):  # type: ignore[no-redef]
+    class AttrsInstance(Protocol):  # type: ignore[no-redef]
         """Placeholder Implementation for attrs classes"""
-
-        __attrs_attrs__: "ClassVar[tuple[Any, ...]]"
 
     def asdict(*args: Any, **kwargs: Any) -> "dict[str, Any]":  # type: ignore[misc] # noqa: ARG001
         """Placeholder implementation"""
@@ -189,7 +181,7 @@ __all__ = (
     "MSGSPEC_INSTALLED",
     "PYDANTIC_INSTALLED",
     "UNSET",
-    "AttrsClass",
+    "AttrsInstance",
     "BaseModel",
     "DTOData",
     "FailFast",

--- a/advanced_alchemy/service/_util.py
+++ b/advanced_alchemy/service/_util.py
@@ -7,17 +7,17 @@ should be a SQLAlchemy model.
 import datetime
 from collections.abc import Sequence
 from enum import Enum
-from functools import partial
+from functools import lru_cache, partial
 from pathlib import Path, PurePath
 from typing import TYPE_CHECKING, Any, Callable, Optional, Union, cast, overload
 from uuid import UUID
 
 from advanced_alchemy.exceptions import AdvancedAlchemyError
 from advanced_alchemy.filters import LimitOffset, StatementFilter
-from advanced_alchemy.repository.typing import ModelOrRowMappingT
 from advanced_alchemy.service.pagination import OffsetPagination
 from advanced_alchemy.service.typing import (
     ATTRS_INSTALLED,
+    CATTRS_INSTALLED,
     MSGSPEC_INSTALLED,
     PYDANTIC_INSTALLED,
     BaseModel,
@@ -29,12 +29,15 @@ from advanced_alchemy.service.typing import (
     get_type_adapter,
     is_attrs_schema,
     schema_dump,
+    structure,
 )
 
 if TYPE_CHECKING:
     from sqlalchemy import ColumnElement, RowMapping
+    from sqlalchemy.engine.row import Row
 
     from advanced_alchemy.base import ModelProtocol
+    from advanced_alchemy.repository.typing import ModelOrRowMappingT
 
 __all__ = ("ResultConverter", "find_filter")
 
@@ -45,43 +48,6 @@ DEFAULT_TYPE_DECODERS = [  # pyright: ignore[reportUnknownVariableType]
     (lambda x: x is datetime.time, lambda t, v: t(v.isoformat())),  # pyright: ignore[reportUnknownLambdaType,reportUnknownMemberType]
     (lambda x: x is Enum, lambda t, v: t(v.value)),  # pyright: ignore[reportUnknownLambdaType,reportUnknownMemberType]
 ]
-
-
-def _default_msgspec_deserializer(
-    target_type: Any,
-    value: Any,
-    type_decoders: "Union[Sequence[tuple[Callable[[Any], bool], Callable[[Any, Any], Any]]], None]" = None,
-) -> Any:  # pragma: no cover
-    """Transform values non-natively supported by ``msgspec``
-
-    Args:
-        target_type: Encountered type
-        value: Value to coerce
-        type_decoders: Optional sequence of type decoders
-
-    Raises:
-        TypeError: If the value cannot be coerced to the target type
-
-    Returns:
-        A ``msgspec``-supported type
-    """
-
-    if isinstance(value, target_type):
-        return value
-
-    if type_decoders:
-        for predicate, decoder in type_decoders:
-            if predicate(target_type):
-                return decoder(target_type, value)
-
-    if issubclass(target_type, (Path, PurePath, UUID)):
-        return target_type(value)
-
-    try:
-        return target_type(value)
-    except Exception as e:
-        msg = f"Unsupported type: {type(value)!r}"
-        raise TypeError(msg) from e
 
 
 def find_filter(
@@ -127,7 +93,7 @@ class ResultConverter:
     @overload
     def to_schema(
         self,
-        data: "Union[ModelProtocol, RowMapping]",
+        data: "Union[ModelProtocol, RowMapping, Row[Any], dict[str, Any]]",
         *,
         schema_type: "type[ModelDTOT]",
     ) -> "ModelDTOT": ...
@@ -144,7 +110,7 @@ class ResultConverter:
     @overload
     def to_schema(
         self,
-        data: "Union[ModelProtocol, RowMapping]",
+        data: "Union[ModelProtocol, RowMapping, Row[Any], dict[str, Any]]",
         total: "Optional[int]" = None,
         *,
         schema_type: "type[ModelDTOT]",
@@ -163,7 +129,7 @@ class ResultConverter:
     @overload
     def to_schema(
         self,
-        data: "Union[ModelProtocol, RowMapping]",
+        data: "Union[ModelProtocol, RowMapping, Row[Any], dict[str, Any]]",
         total: "Optional[int]" = None,
         filters: "Union[Sequence[Union[StatementFilter, ColumnElement[bool]]], Sequence[StatementFilter], None]" = None,
         *,
@@ -181,7 +147,7 @@ class ResultConverter:
     @overload
     def to_schema(
         self,
-        data: "Union[Sequence[ModelProtocol], Sequence[RowMapping]]",
+        data: "Union[Sequence[ModelProtocol], Sequence[RowMapping], Sequence[Row[Any]], Sequence[dict[str, Any]]]",
         *,
         schema_type: "type[ModelDTOT]",
     ) -> "OffsetPagination[ModelDTOT]": ...
@@ -199,7 +165,7 @@ class ResultConverter:
     @overload
     def to_schema(
         self,
-        data: "Union[Sequence[ModelProtocol], Sequence[RowMapping]]",
+        data: "Union[Sequence[ModelProtocol], Sequence[RowMapping], Sequence[Row[Any]], Sequence[dict[str, Any]]]",
         total: "Optional[int]" = None,
         filters: "Union[Sequence[Union[StatementFilter, ColumnElement[bool]]], Sequence[StatementFilter], None]" = None,
         *,
@@ -208,7 +174,7 @@ class ResultConverter:
 
     def to_schema(
         self,
-        data: "Union[ModelOrRowMappingT, Sequence[ModelOrRowMappingT], ModelProtocol, Sequence[ModelProtocol], RowMapping, Sequence[RowMapping]]",
+        data: "Union[ModelOrRowMappingT, Sequence[ModelOrRowMappingT], ModelProtocol, Sequence[ModelProtocol], RowMapping, Sequence[RowMapping], Row[Any], Sequence[Row[Any]], dict[str, Any], Sequence[dict[str, Any]]]",
         total: "Optional[int]" = None,
         filters: "Union[Sequence[Union[StatementFilter, ColumnElement[bool]]], Sequence[StatementFilter], None]" = None,
         *,
@@ -236,14 +202,9 @@ class ResultConverter:
         if schema_type is None:
             if not isinstance(data, Sequence):
                 return cast("ModelOrRowMappingT", data)  # type: ignore[unreachable,unused-ignore]
-            limit_offset = find_filter(LimitOffset, filters=filters)
-            total = total or len(data)
-            limit_offset = limit_offset if limit_offset is not None else LimitOffset(limit=len(data), offset=0)
-            return OffsetPagination[ModelOrRowMappingT](
-                items=cast("Sequence[ModelOrRowMappingT]", data),
-                limit=limit_offset.limit,
-                offset=limit_offset.offset,
-                total=total,
+            return cast(
+                "OffsetPagination[ModelOrRowMappingT]",
+                _create_pagination(cast("Sequence[ModelOrRowMappingT]", data), filters, total),
             )
         if MSGSPEC_INSTALLED and issubclass(schema_type, Struct):
             if not isinstance(data, Sequence):
@@ -256,23 +217,16 @@ class ResultConverter:
                         type_decoders=DEFAULT_TYPE_DECODERS,
                     ),
                 )
-            limit_offset = find_filter(LimitOffset, filters=filters)
-            total = total or len(data)
-            limit_offset = limit_offset if limit_offset is not None else LimitOffset(limit=len(data), offset=0)
-            return OffsetPagination[ModelDTOT](
-                items=convert(
-                    obj=data,
-                    type=list[schema_type],  # type: ignore[valid-type]
-                    from_attributes=True,
-                    dec_hook=partial(
-                        _default_msgspec_deserializer,
-                        type_decoders=DEFAULT_TYPE_DECODERS,
-                    ),
+            converted_items = convert(
+                obj=data,
+                type=list[schema_type],  # type: ignore[valid-type]
+                from_attributes=True,
+                dec_hook=partial(
+                    _default_msgspec_deserializer,
+                    type_decoders=DEFAULT_TYPE_DECODERS,
                 ),
-                limit=limit_offset.limit,
-                offset=limit_offset.offset,
-                total=total,
             )
+            return cast("OffsetPagination[ModelDTOT]", _create_pagination(converted_items, filters, total))
 
         if PYDANTIC_INSTALLED and issubclass(schema_type, BaseModel):
             if not isinstance(data, Sequence):
@@ -280,47 +234,23 @@ class ResultConverter:
                     "ModelDTOT",
                     get_type_adapter(schema_type).validate_python(data, from_attributes=True),
                 )
-            limit_offset = find_filter(LimitOffset, filters=filters)
-            total = total or len(data)
-            limit_offset = limit_offset if limit_offset is not None else LimitOffset(limit=len(data), offset=0)
-            return OffsetPagination[ModelDTOT](
-                items=get_type_adapter(list[schema_type]).validate_python(data, from_attributes=True),  # type: ignore[valid-type] # pyright: ignore[reportUnknownArgumentType]
-                limit=limit_offset.limit,
-                offset=limit_offset.offset,
-                total=total,
-            )
-
-        if is_attrs_schema(schema_type):
+            validated_items = get_type_adapter(list[schema_type]).validate_python(data, from_attributes=True)  # type: ignore[valid-type] # pyright: ignore[reportUnknownArgumentType]
+            return cast("OffsetPagination[ModelDTOT]", _create_pagination(validated_items, filters, total))
+        if CATTRS_INSTALLED and is_attrs_schema(schema_type):
             if not isinstance(data, Sequence):
-                # Get the attrs field names for the target schema
-                attrs_field_names = {field.name for field in fields(schema_type)}
+                return cast("ModelDTOT", structure(schema_dump(data), schema_type))
+            structured_items = [cast("ModelDTOT", structure(schema_dump(item), schema_type)) for item in data]
+            return cast("OffsetPagination[ModelDTOT]", _create_pagination(structured_items, filters, total))
 
-                # Convert data to dict using schema_dump
-                data_dict = cast("dict[str, Any]", schema_dump(data))
+        if ATTRS_INSTALLED and is_attrs_schema(schema_type):
+            # Cache field names for performance
+            field_names = _get_attrs_field_names(schema_type)
 
-                # Filter to only include fields that exist in the attrs class
-                filtered_dict = {k: v for k, v in data_dict.items() if k in attrs_field_names}
-                return cast("ModelDTOT", schema_type(**filtered_dict))
-            limit_offset = find_filter(LimitOffset, filters=filters)
-            total = total or len(data)
-            limit_offset = limit_offset if limit_offset is not None else LimitOffset(limit=len(data), offset=0)
-            # Get the attrs field names for the target schema
-            attrs_field_names = {field.name for field in fields(schema_type)}
+            if not isinstance(data, Sequence):
+                return cast("ModelDTOT", _convert_attrs_item(data, schema_type, field_names))
 
-            items = []
-            for item in data:
-                # Convert item to dict using schema_dump
-                item_dict = cast("dict[str, Any]", schema_dump(item))
-
-                # Filter to only include fields that exist in the attrs class
-                filtered_dict = {k: v for k, v in item_dict.items() if k in attrs_field_names}
-                items.append(schema_type(**filtered_dict))
-            return OffsetPagination[ModelDTOT](
-                items=items,  # type: ignore[arg-type]
-                limit=limit_offset.limit,
-                offset=limit_offset.offset,
-                total=total,
-            )
+            converted_items = [_convert_attrs_item(item, schema_type, field_names) for item in data]
+            return cast("OffsetPagination[ModelDTOT]", _create_pagination(converted_items, filters, total))
 
         if not MSGSPEC_INSTALLED and not PYDANTIC_INSTALLED and not ATTRS_INSTALLED:
             msg = "Either Msgspec, Pydantic, or attrs must be installed to use schema conversion"
@@ -328,3 +258,94 @@ class ResultConverter:
 
         msg = "`schema_type` should be a valid Pydantic, Msgspec, or attrs schema"
         raise AdvancedAlchemyError(msg)
+
+
+# Private helper functions
+
+
+def _default_msgspec_deserializer(
+    target_type: Any,
+    value: Any,
+    type_decoders: "Union[Sequence[tuple[Callable[[Any], bool], Callable[[Any, Any], Any]]], None]" = None,
+) -> Any:  # pragma: no cover
+    """Transform values non-natively supported by ``msgspec``
+
+    Args:
+        target_type: Encountered type
+        value: Value to coerce
+        type_decoders: Optional sequence of type decoders
+
+    Raises:
+        TypeError: If the value cannot be coerced to the target type
+
+    Returns:
+        A ``msgspec``-supported type
+    """
+
+    if isinstance(value, target_type):
+        return value
+
+    if type_decoders:
+        for predicate, decoder in type_decoders:
+            if predicate(target_type):
+                return decoder(target_type, value)
+
+    if issubclass(target_type, (Path, PurePath, UUID)):
+        return target_type(value)
+
+    try:
+        return target_type(value)
+    except Exception as e:
+        msg = f"Unsupported type: {type(value)!r}"
+        raise TypeError(msg) from e
+
+
+@lru_cache(maxsize=128)
+def _get_attrs_field_names(schema_type: "type[Any]") -> "set[str]":
+    """Get and cache the field names for a given attrs class.
+
+    Args:
+        schema_type: attrs class to get field names for.
+
+    Returns:
+        Set of field names for the attrs class.
+    """
+    if ATTRS_INSTALLED and is_attrs_schema(schema_type):
+        return {field.name for field in fields(schema_type)}
+    return set()
+
+
+def _convert_attrs_item(item: Any, schema_type: "type[ModelDTOT]", field_names: "set[str]") -> "ModelDTOT":
+    """Convert a single item to attrs schema using cached field names.
+
+    Args:
+        item: Item to convert.
+        schema_type: Target attrs schema type.
+        field_names: Cached set of field names.
+
+    Returns:
+        Converted attrs instance.
+    """
+    item_dict = schema_dump(item)
+    filtered_dict = {k: v for k, v in item_dict.items() if k in field_names}
+    return schema_type(**filtered_dict)  # type: ignore[return-value]
+
+
+def _create_pagination(items: Any, filters: Any, total: "Optional[int]") -> "OffsetPagination[Any]":
+    """Create OffsetPagination with consistent limit_offset logic.
+
+    Args:
+        items: Items to paginate.
+        filters: Filters to extract LimitOffset from.
+        total: Total count or None.
+
+    Returns:
+        OffsetPagination instance.
+    """
+    limit_offset = find_filter(LimitOffset, filters=filters) or LimitOffset(limit=len(items), offset=0)
+    return OffsetPagination(
+        items=items,
+        limit=limit_offset.limit,
+        offset=limit_offset.offset,
+        total=total or len(items),
+    )

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -11,31 +11,13 @@
         :pr: 482
         :issue: 481
 
-        <!--
-        By submitting this pull request, you agree to:
-        - follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
-        - follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
-        - follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-        -->
-        ## Description
-
         Adds [`DefaultBase`](https://github.com/litestar-org/advanced-alchemy/blob/6cc26ef8d53bc04f89a070337f8b0ab07a1bac46/advanced_alchemy/base.py#L517) class to `__all__` to match other public classes in the module.
-
-        <!--
-        Please add in issue numbers this pull request will close, if applicable
-        Examples: Fixes #4321 or Closes #1234
-
-        Ensure you are using a supported keyword to properly link an issue:
-        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-        -->
-        ## Fixes
-
-        #481
 
     .. change:: Update list and count
         :type: bugfix
         :pr: 487
 
+        Minor adjustment to the list and count method
 
 
 .. changelog:: 1.4.4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -347,6 +347,7 @@ classmethod-decorators = [
 
 [tool.ruff.lint.per-file-ignores]
 "advanced_alchemy/repository/*.py" = ['C901']
+"advanced_alchemy/service/*.py" = ["PLR0911"]
 "examples/flask.py" = ["ANN"]
 "examples/flask/*.py" = ["ANN"]
 "examples/litestar/*.py" = ["PLR6301", "DOC", "B008"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -145,6 +145,7 @@ sanic = ["sanic", "sanic-testing>=24.6.0", "sanic[ext]>=24.6.0"]
 spanner = ["sqlalchemy-spanner>=1.7.0"]
 sqlite = ["aiosqlite>=0.20.0"]
 test = [
+  "attrs",
   "dishka ; python_version >= \"3.10\"",
   "pydantic-extra-types",
   "rich-click",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -146,6 +146,7 @@ spanner = ["sqlalchemy-spanner>=1.7.0"]
 sqlite = ["aiosqlite>=0.20.0"]
 test = [
   "attrs",
+  "cattrs",
   "dishka ; python_version >= \"3.10\"",
   "pydantic-extra-types",
   "rich-click",
@@ -221,6 +222,7 @@ filterwarnings = [
 ]
 markers = [
   "integration: SQLAlchemy integration tests",
+  "unit: Unit tests",
   "asyncmy: SQLAlchemy MySQL (asyncmy) Tests",
   "asyncpg: SQLAlchemy Postgres (asyncpg) Tests",
   "psycopg_async: SQLAlchemy Postgres (psycopg async) Tests",

--- a/tests/integration/test_attrs_service.py
+++ b/tests/integration/test_attrs_service.py
@@ -1,0 +1,400 @@
+"""Integration tests for attrs support in Advanced Alchemy services."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+import pytest
+from sqlalchemy import create_engine, select
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import DeclarativeBase, Mapped, Session
+
+from advanced_alchemy import base, mixins
+from advanced_alchemy.repository import (
+    SQLAlchemyAsyncRepository,
+    SQLAlchemySyncRepository,
+)
+from advanced_alchemy.service import SQLAlchemyAsyncQueryService, SQLAlchemySyncQueryService
+from advanced_alchemy.service._async import SQLAlchemyAsyncRepositoryService
+from advanced_alchemy.service._sync import SQLAlchemySyncRepositoryService
+from advanced_alchemy.service.typing import (
+    ATTRS_INSTALLED,
+    is_attrs_instance,
+    is_attrs_instance_with_field,
+    is_attrs_instance_without_field,
+)
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(not ATTRS_INSTALLED, reason="attrs not installed"),
+]
+
+here = Path(__file__).parent
+fixture_path = here.parent.parent / "examples"
+attrs_registry = base.create_registry()
+
+if ATTRS_INSTALLED:
+    from attrs import define, field
+
+    @define
+    class PersonAttrs:
+        """attrs class for testing."""
+
+        name: str
+        age: int
+        email: Optional[str] = None
+
+    @define
+    class PersonWithDefaults:
+        """attrs class with field defaults."""
+
+        name: str
+        age: int = field(default=18)
+        is_active: bool = field(default=True)
+        tags: list[str] = field(factory=list)
+
+    @define
+    class StateAttrs:
+        """attrs class matching US State structure."""
+
+        abbreviation: str
+        name: str
+
+    @define
+    class StateQueryAttrs:
+        """attrs class for query results."""
+
+        state_abbreviation: str
+        state_name: str
+
+
+class UUIDBase(mixins.UUIDPrimaryKey, base.CommonTableAttributes, DeclarativeBase):
+    """Base for all SQLAlchemy declarative models with UUID primary keys."""
+
+    registry = attrs_registry
+
+
+class Person(UUIDBase):
+    """Person model for testing attrs integration."""
+
+    __tablename__ = "person"
+    name: Mapped[str]
+    age: Mapped[int]
+    email: Mapped[Optional[str]]
+
+
+class USState(UUIDBase):
+    """US State model for testing."""
+
+    __tablename__ = "us_state_lookup"
+    abbreviation: Mapped[str]
+    name: Mapped[str]
+
+
+class PersonSyncRepository(SQLAlchemySyncRepository[Person]):
+    """Person repository."""
+
+    model_type = Person
+
+
+class PersonSyncService(SQLAlchemySyncRepositoryService[Person, PersonSyncRepository]):
+    """Person service."""
+
+    repository_type = PersonSyncRepository
+
+
+class PersonAsyncRepository(SQLAlchemyAsyncRepository[Person]):
+    """Person async repository."""
+
+    model_type = Person
+
+
+class PersonAsyncService(SQLAlchemyAsyncRepositoryService[Person, PersonAsyncRepository]):
+    """Person async service."""
+
+    repository_type = PersonAsyncRepository
+
+
+class USStateSyncRepository(SQLAlchemySyncRepository[USState]):
+    """US State repository."""
+
+    model_type = USState
+
+
+class USStateSyncService(SQLAlchemySyncRepositoryService[USState, USStateSyncRepository]):
+    """US State service."""
+
+    repository_type = USStateSyncRepository
+
+
+class USStateAsyncRepository(SQLAlchemyAsyncRepository[USState]):
+    """US State async repository."""
+
+    model_type = USState
+
+
+class USStateAsyncService(SQLAlchemyAsyncRepositoryService[USState, USStateAsyncRepository]):
+    """US State async service."""
+
+    repository_type = USStateAsyncRepository
+
+
+class StateQuery(base.SQLQuery):
+    """Custom query for testing attrs conversion."""
+
+    __table__ = select(  # type: ignore[misc]
+        USState.abbreviation.label("state_abbreviation"),
+        USState.name.label("state_name"),
+    ).alias("state_lookup")
+    __mapper_args__ = {
+        "primary_key": [USState.abbreviation],
+    }
+    state_abbreviation: str  # type: ignore[misc]
+    state_name: str  # type: ignore[misc]
+
+
+@pytest.mark.skipif(not ATTRS_INSTALLED, reason="attrs not installed")
+def test_sync_attrs_service_basic_operations() -> None:
+    """Test basic service operations with attrs classes."""
+    engine = create_engine("sqlite://")
+    attrs_registry.metadata.create_all(engine)
+
+    with Session(engine) as session:
+        service = PersonSyncService(session=session)
+
+        # Test create with dict data first (which works with existing services)
+        person_data = {"name": "John Doe", "age": 30, "email": "john@example.com"}
+        created_person = service.create(person_data)
+
+        assert created_person.name == "John Doe"
+        assert created_person.age == 30
+        assert created_person.email == "john@example.com"
+
+        # Test create many with dict data
+        people_data = [
+            {"name": "Jane Smith", "age": 25, "email": "jane@example.com"},
+            {"name": "Bob Wilson", "age": 35, "email": "bob@example.com"},
+        ]
+        created_people = service.create_many(people_data)
+        assert len(created_people) == 2
+
+        # Test to_schema conversion to attrs - this is the main integration point
+        person_attrs = service.to_schema(created_person, schema_type=PersonAttrs)
+        assert isinstance(person_attrs, PersonAttrs)
+        assert is_attrs_instance(person_attrs)
+        assert is_attrs_instance_with_field(person_attrs, "name")
+        assert is_attrs_instance_with_field(person_attrs, "age")
+        assert is_attrs_instance_with_field(person_attrs, "email")
+        assert not is_attrs_instance_without_field(person_attrs, "name")
+
+        # Test list conversion to attrs
+        all_people = service.list()
+        people_paginated = service.to_schema(all_people, schema_type=PersonAttrs)
+        assert len(people_paginated.items) == 3
+        assert all(isinstance(person, PersonAttrs) for person in people_paginated.items)
+
+
+@pytest.mark.skipif(not ATTRS_INSTALLED, reason="attrs not installed")
+def test_sync_attrs_with_defaults() -> None:
+    """Test attrs classes with default values."""
+    engine = create_engine("sqlite://")
+    attrs_registry.metadata.create_all(engine)
+
+    with Session(engine) as session:
+        service = PersonSyncService(session=session)
+
+        # Create with dict data and default values
+        person_data = {"name": "Default Person", "age": 18}
+        created_person = service.create(person_data)
+
+        assert created_person.name == "Default Person"
+        assert created_person.age == 18
+
+        # Convert to attrs with defaults - this tests the attrs schema conversion
+        person_attrs = service.to_schema(created_person, schema_type=PersonWithDefaults)
+        assert isinstance(person_attrs, PersonWithDefaults)
+        assert person_attrs.name == "Default Person"
+        assert person_attrs.age == 18
+        assert person_attrs.is_active is True  # default value from attrs class
+        assert person_attrs.tags == []  # default factory from attrs class
+
+
+@pytest.mark.skipif(not ATTRS_INSTALLED, reason="attrs not installed")
+def test_sync_query_service_with_attrs() -> None:
+    """Test query service with attrs schema conversion."""
+    engine = create_engine("sqlite://")
+    attrs_registry.metadata.create_all(engine)
+
+    with Session(engine) as session:
+        state_service = USStateSyncService(session=session)
+        query_service = SQLAlchemySyncQueryService(session=session)
+
+        # Create test data with dict data
+        states_data = [
+            {"abbreviation": "CA", "name": "California"},
+            {"abbreviation": "TX", "name": "Texas"},
+            {"abbreviation": "NY", "name": "New York"},
+        ]
+        state_service.create_many(states_data)
+
+        # Query and convert to attrs
+        query_results, count = query_service.repository.list_and_count(statement=select(StateQuery))
+        assert count >= 3
+
+        # Test single item conversion
+        single_result = query_service.to_schema(
+            data=query_results[0],
+            schema_type=StateQueryAttrs,
+        )
+        assert isinstance(single_result, StateQueryAttrs)
+        assert is_attrs_instance(single_result)
+        assert hasattr(single_result, "state_abbreviation")
+        assert hasattr(single_result, "state_name")
+
+        # Test paginated conversion
+        paginated_results = query_service.to_schema(
+            data=query_results,
+            total=count,
+            schema_type=StateQueryAttrs,
+        )
+        assert len(paginated_results.items) >= 3
+        assert all(isinstance(item, StateQueryAttrs) for item in paginated_results.items)
+        assert all(is_attrs_instance(item) for item in paginated_results.items)
+
+
+@pytest.mark.skipif(not ATTRS_INSTALLED, reason="attrs not installed")
+async def test_async_attrs_service_basic_operations() -> None:
+    """Test async service operations with attrs classes."""
+    engine = create_async_engine("sqlite+aiosqlite://")
+
+    async with engine.begin() as conn:
+        await conn.run_sync(attrs_registry.metadata.create_all)
+
+    async with AsyncSession(engine) as session:
+        service = PersonAsyncService(session=session)
+
+        # Test create with dict data
+        person_data = {"name": "Async John", "age": 28, "email": "async.john@example.com"}
+        created_person = await service.create(person_data)
+
+        assert created_person.name == "Async John"
+        assert created_person.age == 28
+        assert created_person.email == "async.john@example.com"
+
+        # Test create many with dict data
+        people_data = [
+            {"name": "Async Jane", "age": 26, "email": "async.jane@example.com"},
+            {"name": "Async Bob", "age": 32, "email": "async.bob@example.com"},
+        ]
+        created_people = await service.create_many(people_data)
+        assert len(created_people) == 2
+
+        # Test to_schema conversion to attrs
+        person_attrs = service.to_schema(created_person, schema_type=PersonAttrs)
+        assert isinstance(person_attrs, PersonAttrs)
+        assert is_attrs_instance(person_attrs)
+        assert person_attrs.name == "Async John"
+        assert person_attrs.age == 28
+
+        # Test list conversion to attrs
+        all_people = await service.list()
+        people_paginated = service.to_schema(all_people, schema_type=PersonAttrs)
+        assert len(people_paginated.items) == 3
+        assert all(isinstance(person, PersonAttrs) for person in people_paginated.items)
+
+
+@pytest.mark.skipif(not ATTRS_INSTALLED, reason="attrs not installed")
+async def test_async_query_service_with_attrs() -> None:
+    """Test async query service with attrs schema conversion."""
+    engine = create_async_engine("sqlite+aiosqlite://")
+
+    async with engine.begin() as conn:
+        await conn.run_sync(attrs_registry.metadata.create_all)
+
+    async with AsyncSession(engine) as session:
+        state_service = USStateAsyncService(session=session)
+        query_service = SQLAlchemyAsyncQueryService(session=session)
+
+        # Create test data with dict data
+        states_data = [
+            {"abbreviation": "FL", "name": "Florida"},
+            {"abbreviation": "WA", "name": "Washington"},
+            {"abbreviation": "OR", "name": "Oregon"},
+        ]
+        await state_service.create_many(states_data)
+
+        # Query and convert to attrs
+        query_results, count = await query_service.repository.list_and_count(statement=select(StateQuery))
+        assert count >= 3
+
+        # Test single item conversion
+        single_result = query_service.to_schema(
+            data=query_results[0],
+            schema_type=StateQueryAttrs,
+        )
+        assert isinstance(single_result, StateQueryAttrs)
+        assert is_attrs_instance(single_result)
+
+        # Test paginated conversion
+        paginated_results = query_service.to_schema(
+            data=query_results,
+            total=count,
+            schema_type=StateQueryAttrs,
+        )
+        assert len(paginated_results.items) >= 3
+        assert all(isinstance(item, StateQueryAttrs) for item in paginated_results.items)
+
+
+@pytest.mark.skipif(not ATTRS_INSTALLED, reason="attrs not installed")
+def test_attrs_error_handling() -> None:
+    """Test error handling with attrs integration."""
+    engine = create_engine("sqlite://")
+    attrs_registry.metadata.create_all(engine)
+
+    with Session(engine) as session:
+        service = PersonSyncService(session=session)
+
+        # Test with invalid attrs-like class (should work with duck typing)
+        class FakeAttrsClass:
+            def __init__(self, name: str, age: int) -> None:
+                self.name = name
+                self.age = age
+
+        fake_data = FakeAttrsClass(name="Fake", age=25)
+
+        # This should still work because the service will use __dict__ fallback
+        created_person = service.create(fake_data)  # type: ignore[arg-type]
+        assert created_person.name == "Fake"
+        assert created_person.age == 25
+
+
+@pytest.mark.skipif(not ATTRS_INSTALLED, reason="attrs not installed")
+def test_attrs_mixed_with_other_schemas() -> None:
+    """Test attrs alongside other schema types."""
+    engine = create_engine("sqlite://")
+    attrs_registry.metadata.create_all(engine)
+
+    with Session(engine) as session:
+        service = PersonSyncService(session=session)
+
+        # Create with attrs
+        attrs_person = PersonAttrs(name="Attrs Person", age=30)
+        created_attrs = service.create(attrs_person)  # type: ignore[arg-type]
+
+        # Create with dict
+        dict_person = {"name": "Dict Person", "age": 25, "email": "dict@example.com"}
+        created_dict = service.create(dict_person)
+
+        # Both should work
+        assert created_attrs.name == "Attrs Person"
+        assert created_dict.name == "Dict Person"
+
+        # Convert both to attrs
+        attrs_result = service.to_schema(created_attrs, schema_type=PersonAttrs)
+        dict_to_attrs_result = service.to_schema(created_dict, schema_type=PersonAttrs)
+
+        assert isinstance(attrs_result, PersonAttrs)
+        assert isinstance(dict_to_attrs_result, PersonAttrs)
+        assert is_attrs_instance(attrs_result)
+        assert is_attrs_instance(dict_to_attrs_result)

--- a/tests/integration/test_attrs_service.py
+++ b/tests/integration/test_attrs_service.py
@@ -1,9 +1,10 @@
+# ruff: noqa: UP045
 """Integration tests for attrs support in Advanced Alchemy services."""
 
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Optional
+from typing import Optional, cast
 
 import pytest
 from sqlalchemy import create_engine, select
@@ -294,6 +295,8 @@ async def test_async_attrs_service_basic_operations() -> None:
         person_attrs = service.to_schema(created_person, schema_type=PersonAttrs)
         assert isinstance(person_attrs, PersonAttrs)
         assert is_attrs_instance(person_attrs)
+        # Type cast to help pyright understand the specific attrs type
+        person_attrs = cast(PersonAttrs, person_attrs)
         assert person_attrs.name == "Async John"
         assert person_attrs.age == 28
 

--- a/tests/unit/test_attrs_integration.py
+++ b/tests/unit/test_attrs_integration.py
@@ -2,13 +2,14 @@
 
 from __future__ import annotations
 
-from typing import Any, Optional
+from typing import Any
 
 import pytest
+from attrs import define, field
 
 from advanced_alchemy.service.typing import (
     ATTRS_INSTALLED,
-    AttrsClass,
+    AttrsInstance,
     is_attrs_instance,
     is_attrs_instance_with_field,
     is_attrs_instance_without_field,
@@ -24,11 +25,10 @@ pytestmark = [
 ]
 
 # attrs test classes and fixtures
-from attrs import define, field
 
 
 @define
-class SimpleAttrsClass(AttrsClass):
+class SimpleAttrsInstance:
     """Simple attrs class for testing."""
 
     name: str
@@ -36,16 +36,16 @@ class SimpleAttrsClass(AttrsClass):
 
 
 @define
-class AttrsWithOptional(AttrsClass):
+class AttrsWithOptional:
     """attrs class with optional fields."""
 
     name: str
-    email: Optional[str] = None
+    email: str | None = None
     active: bool = True
 
 
 @define
-class AttrsWithDefaults(AttrsClass):
+class AttrsWithDefaults:
     """attrs class with field defaults."""
 
     title: str
@@ -54,10 +54,10 @@ class AttrsWithDefaults(AttrsClass):
 
 
 @define
-class NestedAttrsClass(AttrsClass):
+class NestedAttrsInstance:
     """attrs class with nested attrs."""
 
-    user: SimpleAttrsClass
+    user: SimpleAttrsInstance
     metadata: dict[str, Any] = field(factory=dict)
 
 
@@ -71,14 +71,14 @@ class TestAttrsDetection:
     @pytest.mark.skipif(not ATTRS_INSTALLED, reason="attrs not installed")
     def test_is_attrs_instance_with_attrs_instance(self) -> None:
         """Test is_attrs_instance with actual attrs class instance."""
-        instance = SimpleAttrsClass(name="test", age=30)
+        instance = SimpleAttrsInstance(name="test", age=30)
         assert is_attrs_instance(instance)
 
     @pytest.mark.skipif(not ATTRS_INSTALLED, reason="attrs not installed")
     def test_is_attrs_instance_with_complex_attrs(self) -> None:
         """Test is_attrs_instance with complex attrs instances."""
-        simple_instance = SimpleAttrsClass(name="John", age=25)
-        nested_instance = NestedAttrsClass(user=simple_instance, metadata={"role": "admin"})
+        simple_instance = SimpleAttrsInstance(name="John", age=25)
+        nested_instance = NestedAttrsInstance(user=simple_instance, metadata={"role": "admin"})
 
         assert is_attrs_instance(simple_instance)
         assert is_attrs_instance(nested_instance)
@@ -86,10 +86,10 @@ class TestAttrsDetection:
     @pytest.mark.skipif(not ATTRS_INSTALLED, reason="attrs not installed")
     def test_is_attrs_schema_with_attrs_classes(self) -> None:
         """Test is_attrs_schema with attrs class types."""
-        assert is_attrs_schema(SimpleAttrsClass)
+        assert is_attrs_schema(SimpleAttrsInstance)
         assert is_attrs_schema(AttrsWithOptional)
         assert is_attrs_schema(AttrsWithDefaults)
-        assert is_attrs_schema(NestedAttrsClass)
+        assert is_attrs_schema(NestedAttrsInstance)
 
     def test_is_attrs_schema_with_non_attrs_classes(self) -> None:
         """Test is_attrs_schema with non-attrs class types."""
@@ -123,7 +123,7 @@ class TestAttrsDetection:
     @pytest.mark.skipif(not ATTRS_INSTALLED, reason="attrs not installed")
     def test_is_attrs_instance_with_field(self) -> None:
         """Test is_attrs_class_with_field function."""
-        instance = SimpleAttrsClass(name="test", age=30)
+        instance = SimpleAttrsInstance(name="test", age=30)
 
         assert is_attrs_instance_with_field(instance, "name")
         assert is_attrs_instance_with_field(instance, "age")
@@ -132,7 +132,7 @@ class TestAttrsDetection:
     @pytest.mark.skipif(not ATTRS_INSTALLED, reason="attrs not installed")
     def test_is_attrs_instance_without_field(self) -> None:
         """Test is_attrs_class_without_field function."""
-        instance = SimpleAttrsClass(name="test", age=30)
+        instance = SimpleAttrsInstance(name="test", age=30)
 
         assert not is_attrs_instance_without_field(instance, "name")
         assert not is_attrs_instance_without_field(instance, "age")
@@ -152,13 +152,13 @@ class TestSchemaIntegration:
     @pytest.mark.skipif(not ATTRS_INSTALLED, reason="attrs not installed")
     def test_is_schema_with_attrs_class(self) -> None:
         """Test is_schema function includes attrs classes."""
-        instance = SimpleAttrsClass(name="test", age=30)
+        instance = SimpleAttrsInstance(name="test", age=30)
         assert is_schema(instance)
 
     @pytest.mark.skipif(not ATTRS_INSTALLED, reason="attrs not installed")
     def test_is_schema_with_field_attrs(self) -> None:
         """Test is_schema_with_field with attrs classes."""
-        instance = SimpleAttrsClass(name="test", age=30)
+        instance = SimpleAttrsInstance(name="test", age=30)
 
         assert is_schema_with_field(instance, "name")
         assert is_schema_with_field(instance, "age")
@@ -167,7 +167,7 @@ class TestSchemaIntegration:
     @pytest.mark.skipif(not ATTRS_INSTALLED, reason="attrs not installed")
     def test_is_schema_without_field_attrs(self) -> None:
         """Test is_schema_without_field with attrs classes."""
-        instance = SimpleAttrsClass(name="test", age=30)
+        instance = SimpleAttrsInstance(name="test", age=30)
 
         assert not is_schema_without_field(instance, "name")
         assert not is_schema_without_field(instance, "age")
@@ -180,7 +180,7 @@ class TestSchemaDump:
     @pytest.mark.skipif(not ATTRS_INSTALLED, reason="attrs not installed")
     def test_schema_dump_simple_attrs(self) -> None:
         """Test schema_dump with simple attrs class."""
-        instance = SimpleAttrsClass(name="John", age=30)
+        instance = SimpleAttrsInstance(name="John", age=30)
         result = schema_dump(instance)
 
         expected = {"name": "John", "age": 30}
@@ -208,8 +208,8 @@ class TestSchemaDump:
     @pytest.mark.skipif(not ATTRS_INSTALLED, reason="attrs not installed")
     def test_schema_dump_nested_attrs(self) -> None:
         """Test schema_dump with nested attrs classes."""
-        user = SimpleAttrsClass(name="John", age=25)
-        instance = NestedAttrsClass(user=user, metadata={"role": "admin"})
+        user = SimpleAttrsInstance(name="John", age=25)
+        instance = NestedAttrsInstance(user=user, metadata={"role": "admin"})
         result = schema_dump(instance)
 
         expected = {"user": {"name": "John", "age": 25}, "metadata": {"role": "admin"}}
@@ -233,7 +233,7 @@ class TestSchemaDump:
     @pytest.mark.skipif(not ATTRS_INSTALLED, reason="attrs not installed")
     def test_schema_dump_exclude_unset_parameter(self) -> None:
         """Test schema_dump exclude_unset parameter (attrs always includes all fields)."""
-        instance = SimpleAttrsClass(name="test", age=30)
+        instance = SimpleAttrsInstance(name="test", age=30)
 
         # attrs.asdict doesn't have exclude_unset concept, should return all fields
         result_with_unset = schema_dump(instance, exclude_unset=True)
@@ -244,26 +244,26 @@ class TestSchemaDump:
         assert result_without_unset == expected
 
 
-class TestAttrsClassProtocol:
-    """Test AttrsClass protocol."""
+class TestAttrsInstanceProtocol:
+    """Test AttrsInstance protocol."""
 
     def test_attrs_class_protocol_exists(self) -> None:
-        """Test that AttrsClass protocol is available."""
-        assert AttrsClass is not None
+        """Test that AttrsInstance protocol is available."""
+        assert AttrsInstance is not None
 
     @pytest.mark.skipif(not ATTRS_INSTALLED, reason="attrs not installed")
     def test_attrs_class_protocol_with_real_attrs(self) -> None:
-        """Test AttrsClass protocol with real attrs class."""
-        instance = SimpleAttrsClass(name="test", age=30)
+        """Test AttrsInstance protocol with real attrs class."""
+        instance = SimpleAttrsInstance(name="test", age=30)
 
         # Should have __attrs_attrs__ attribute when attrs is installed
         assert hasattr(instance.__class__, "__attrs_attrs__")
 
     def test_attrs_class_protocol_type_annotation(self) -> None:
-        """Test AttrsClass can be used in type annotations."""
+        """Test AttrsInstance can be used in type annotations."""
 
         # This test ensures the protocol is properly defined for type checking
-        def process_attrs(obj: AttrsClass) -> dict[str, Any]:
+        def process_attrs(obj: AttrsInstance) -> dict[str, Any]:
             return {"processed": True}
 
         # Should not raise type errors
@@ -277,7 +277,7 @@ class TestErrorHandling:
     def test_attrs_functions_when_not_installed(self) -> None:
         """Test attrs functions behave correctly when attrs not installed."""
         # When attrs not installed, detection should return False
-        dummy_obj = SimpleAttrsClass(name="test", age=30)
+        dummy_obj = SimpleAttrsInstance(name="test", age=30)
 
         assert not is_attrs_instance(dummy_obj)
         assert not is_attrs_instance_with_field(dummy_obj, "name")
@@ -286,7 +286,7 @@ class TestErrorHandling:
     @pytest.mark.skipif(ATTRS_INSTALLED, reason="attrs is installed")
     def test_schema_dump_fallback_when_attrs_not_installed(self) -> None:
         """Test schema_dump falls back to __dict__ when attrs not installed."""
-        dummy_obj = SimpleAttrsClass(name="test", age=30)
+        dummy_obj = SimpleAttrsInstance(name="test", age=30)
         result = schema_dump(dummy_obj)
 
         # Should fall back to __dict__ access

--- a/tests/unit/test_attrs_integration.py
+++ b/tests/unit/test_attrs_integration.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Optional
 
 import pytest
 from attrs import define, field
@@ -40,7 +40,7 @@ class AttrsWithOptional:
     """attrs class with optional fields."""
 
     name: str
-    email: str | None = None
+    email: Optional[str] = None  # noqa: UP045
     active: bool = True
 
 

--- a/tests/unit/test_attrs_integration.py
+++ b/tests/unit/test_attrs_integration.py
@@ -1,0 +1,294 @@
+"""Tests for attrs integration in Advanced Alchemy services."""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+import pytest
+
+from advanced_alchemy.service.typing import (
+    ATTRS_INSTALLED,
+    AttrsClass,
+    is_attrs_instance,
+    is_attrs_instance_with_field,
+    is_attrs_instance_without_field,
+    is_attrs_schema,
+    is_schema,
+    is_schema_with_field,
+    is_schema_without_field,
+    schema_dump,
+)
+
+pytestmark = [
+    pytest.mark.unit,
+]
+
+# attrs test classes and fixtures
+from attrs import define, field
+
+
+@define
+class SimpleAttrsClass(AttrsClass):
+    """Simple attrs class for testing."""
+
+    name: str
+    age: int
+
+
+@define
+class AttrsWithOptional(AttrsClass):
+    """attrs class with optional fields."""
+
+    name: str
+    email: Optional[str] = None
+    active: bool = True
+
+
+@define
+class AttrsWithDefaults(AttrsClass):
+    """attrs class with field defaults."""
+
+    title: str
+    count: int = field(default=0)
+    tags: list[str] = field(factory=list)
+
+
+@define
+class NestedAttrsClass(AttrsClass):
+    """attrs class with nested attrs."""
+
+    user: SimpleAttrsClass
+    metadata: dict[str, Any] = field(factory=dict)
+
+
+class TestAttrsDetection:
+    """Test attrs class detection functions."""
+
+    def test_attrs_installed_flag(self) -> None:
+        """Test that ATTRS_INSTALLED flag is a boolean."""
+        assert isinstance(ATTRS_INSTALLED, bool)
+
+    @pytest.mark.skipif(not ATTRS_INSTALLED, reason="attrs not installed")
+    def test_is_attrs_instance_with_attrs_instance(self) -> None:
+        """Test is_attrs_instance with actual attrs class instance."""
+        instance = SimpleAttrsClass(name="test", age=30)
+        assert is_attrs_instance(instance)
+
+    @pytest.mark.skipif(not ATTRS_INSTALLED, reason="attrs not installed")
+    def test_is_attrs_instance_with_complex_attrs(self) -> None:
+        """Test is_attrs_instance with complex attrs instances."""
+        simple_instance = SimpleAttrsClass(name="John", age=25)
+        nested_instance = NestedAttrsClass(user=simple_instance, metadata={"role": "admin"})
+
+        assert is_attrs_instance(simple_instance)
+        assert is_attrs_instance(nested_instance)
+
+    @pytest.mark.skipif(not ATTRS_INSTALLED, reason="attrs not installed")
+    def test_is_attrs_schema_with_attrs_classes(self) -> None:
+        """Test is_attrs_schema with attrs class types."""
+        assert is_attrs_schema(SimpleAttrsClass)
+        assert is_attrs_schema(AttrsWithOptional)
+        assert is_attrs_schema(AttrsWithDefaults)
+        assert is_attrs_schema(NestedAttrsClass)
+
+    def test_is_attrs_schema_with_non_attrs_classes(self) -> None:
+        """Test is_attrs_schema with non-attrs class types."""
+        assert not is_attrs_schema(dict)
+        assert not is_attrs_schema(list)
+        assert not is_attrs_schema(str)
+        assert not is_attrs_schema(int)
+
+        class RegularClass:
+            pass
+
+        assert not is_attrs_schema(RegularClass)
+
+    def test_is_attrs_class_with_non_attrs_instance(self) -> None:
+        """Test is_attrs_class with non-attrs objects."""
+        assert not is_attrs_instance({})
+        assert not is_attrs_instance([])
+        assert not is_attrs_instance("string")
+        assert not is_attrs_instance(42)
+
+    def test_is_attrs_class_with_regular_class(self) -> None:
+        """Test is_attrs_class with regular Python class."""
+
+        class RegularClass:
+            def __init__(self, name: str) -> None:
+                self.name = name
+
+        instance = RegularClass("test")
+        assert not is_attrs_instance(instance)
+
+    @pytest.mark.skipif(not ATTRS_INSTALLED, reason="attrs not installed")
+    def test_is_attrs_instance_with_field(self) -> None:
+        """Test is_attrs_class_with_field function."""
+        instance = SimpleAttrsClass(name="test", age=30)
+
+        assert is_attrs_instance_with_field(instance, "name")
+        assert is_attrs_instance_with_field(instance, "age")
+        assert not is_attrs_instance_with_field(instance, "nonexistent")
+
+    @pytest.mark.skipif(not ATTRS_INSTALLED, reason="attrs not installed")
+    def test_is_attrs_instance_without_field(self) -> None:
+        """Test is_attrs_class_without_field function."""
+        instance = SimpleAttrsClass(name="test", age=30)
+
+        assert not is_attrs_instance_without_field(instance, "name")
+        assert not is_attrs_instance_without_field(instance, "age")
+        assert is_attrs_instance_without_field(instance, "nonexistent")
+
+    def test_is_attrs_class_field_checks_with_non_attrs(self) -> None:
+        """Test field checking functions with non-attrs objects."""
+        regular_obj = {"name": "test", "age": 30}
+
+        assert not is_attrs_instance_with_field(regular_obj, "name")
+        assert not is_attrs_instance_without_field(regular_obj, "name")
+
+
+class TestSchemaIntegration:
+    """Test attrs integration with schema functions."""
+
+    @pytest.mark.skipif(not ATTRS_INSTALLED, reason="attrs not installed")
+    def test_is_schema_with_attrs_class(self) -> None:
+        """Test is_schema function includes attrs classes."""
+        instance = SimpleAttrsClass(name="test", age=30)
+        assert is_schema(instance)
+
+    @pytest.mark.skipif(not ATTRS_INSTALLED, reason="attrs not installed")
+    def test_is_schema_with_field_attrs(self) -> None:
+        """Test is_schema_with_field with attrs classes."""
+        instance = SimpleAttrsClass(name="test", age=30)
+
+        assert is_schema_with_field(instance, "name")
+        assert is_schema_with_field(instance, "age")
+        assert not is_schema_with_field(instance, "nonexistent")
+
+    @pytest.mark.skipif(not ATTRS_INSTALLED, reason="attrs not installed")
+    def test_is_schema_without_field_attrs(self) -> None:
+        """Test is_schema_without_field with attrs classes."""
+        instance = SimpleAttrsClass(name="test", age=30)
+
+        assert not is_schema_without_field(instance, "name")
+        assert not is_schema_without_field(instance, "age")
+        assert is_schema_without_field(instance, "nonexistent")
+
+
+class TestSchemaDump:
+    """Test schema_dump function with attrs classes."""
+
+    @pytest.mark.skipif(not ATTRS_INSTALLED, reason="attrs not installed")
+    def test_schema_dump_simple_attrs(self) -> None:
+        """Test schema_dump with simple attrs class."""
+        instance = SimpleAttrsClass(name="John", age=30)
+        result = schema_dump(instance)
+
+        expected = {"name": "John", "age": 30}
+        assert result == expected
+        assert isinstance(result, dict)
+
+    @pytest.mark.skipif(not ATTRS_INSTALLED, reason="attrs not installed")
+    def test_schema_dump_attrs_with_optional(self) -> None:
+        """Test schema_dump with attrs class having optional fields."""
+        instance = AttrsWithOptional(name="Jane", email="jane@example.com", active=True)
+        result = schema_dump(instance)
+
+        expected = {"name": "Jane", "email": "jane@example.com", "active": True}
+        assert result == expected
+
+    @pytest.mark.skipif(not ATTRS_INSTALLED, reason="attrs not installed")
+    def test_schema_dump_attrs_with_defaults(self) -> None:
+        """Test schema_dump with attrs class having field defaults."""
+        instance = AttrsWithDefaults(title="Test", count=5, tags=["tag1", "tag2"])
+        result = schema_dump(instance)
+
+        expected = {"title": "Test", "count": 5, "tags": ["tag1", "tag2"]}
+        assert result == expected
+
+    @pytest.mark.skipif(not ATTRS_INSTALLED, reason="attrs not installed")
+    def test_schema_dump_nested_attrs(self) -> None:
+        """Test schema_dump with nested attrs classes."""
+        user = SimpleAttrsClass(name="John", age=25)
+        instance = NestedAttrsClass(user=user, metadata={"role": "admin"})
+        result = schema_dump(instance)
+
+        expected = {"user": {"name": "John", "age": 25}, "metadata": {"role": "admin"}}
+        assert result == expected
+
+    @pytest.mark.skipif(not ATTRS_INSTALLED, reason="attrs not installed")
+    def test_schema_dump_attrs_collection_types(self) -> None:
+        """Test schema_dump retains collection types."""
+        instance = AttrsWithDefaults(title="Test", tags=["a", "b", "c"])
+        result = schema_dump(instance)
+
+        assert isinstance(result["tags"], list)
+        assert result["tags"] == ["a", "b", "c"]
+
+    def test_schema_dump_non_attrs_unchanged(self) -> None:
+        """Test schema_dump with non-attrs objects remains unchanged."""
+        # Dict should pass through unchanged
+        dict_data = {"name": "test", "age": 30}
+        assert schema_dump(dict_data) == dict_data
+
+    @pytest.mark.skipif(not ATTRS_INSTALLED, reason="attrs not installed")
+    def test_schema_dump_exclude_unset_parameter(self) -> None:
+        """Test schema_dump exclude_unset parameter (attrs always includes all fields)."""
+        instance = SimpleAttrsClass(name="test", age=30)
+
+        # attrs.asdict doesn't have exclude_unset concept, should return all fields
+        result_with_unset = schema_dump(instance, exclude_unset=True)
+        result_without_unset = schema_dump(instance, exclude_unset=False)
+
+        expected = {"name": "test", "age": 30}
+        assert result_with_unset == expected
+        assert result_without_unset == expected
+
+
+class TestAttrsClassProtocol:
+    """Test AttrsClass protocol."""
+
+    def test_attrs_class_protocol_exists(self) -> None:
+        """Test that AttrsClass protocol is available."""
+        assert AttrsClass is not None
+
+    @pytest.mark.skipif(not ATTRS_INSTALLED, reason="attrs not installed")
+    def test_attrs_class_protocol_with_real_attrs(self) -> None:
+        """Test AttrsClass protocol with real attrs class."""
+        instance = SimpleAttrsClass(name="test", age=30)
+
+        # Should have __attrs_attrs__ attribute when attrs is installed
+        assert hasattr(instance.__class__, "__attrs_attrs__")
+
+    def test_attrs_class_protocol_type_annotation(self) -> None:
+        """Test AttrsClass can be used in type annotations."""
+
+        # This test ensures the protocol is properly defined for type checking
+        def process_attrs(obj: AttrsClass) -> dict[str, Any]:
+            return {"processed": True}
+
+        # Should not raise type errors
+        assert callable(process_attrs)
+
+
+class TestErrorHandling:
+    """Test error handling in attrs integration."""
+
+    @pytest.mark.skipif(ATTRS_INSTALLED, reason="attrs is installed")
+    def test_attrs_functions_when_not_installed(self) -> None:
+        """Test attrs functions behave correctly when attrs not installed."""
+        # When attrs not installed, detection should return False
+        dummy_obj = SimpleAttrsClass(name="test", age=30)
+
+        assert not is_attrs_instance(dummy_obj)
+        assert not is_attrs_instance_with_field(dummy_obj, "name")
+        assert not is_attrs_instance_without_field(dummy_obj, "name")
+
+    @pytest.mark.skipif(ATTRS_INSTALLED, reason="attrs is installed")
+    def test_schema_dump_fallback_when_attrs_not_installed(self) -> None:
+        """Test schema_dump falls back to __dict__ when attrs not installed."""
+        dummy_obj = SimpleAttrsClass(name="test", age=30)
+        result = schema_dump(dummy_obj)
+
+        # Should fall back to __dict__ access
+        expected = {"name": "test", "age": 30}
+        assert result == expected

--- a/tests/unit/test_cattrs_integration.py
+++ b/tests/unit/test_cattrs_integration.py
@@ -1,0 +1,252 @@
+"""Tests for cattrs integration with attrs support in Advanced Alchemy services."""
+
+from __future__ import annotations
+
+import unittest.mock as mock
+from typing import Optional
+
+import pytest
+
+from advanced_alchemy.service.typing import (
+    ATTRS_INSTALLED,
+    CATTRS_INSTALLED,
+    schema_dump,
+)
+
+# pyright: reportAttributeAccessIssue=false
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.skipif(not ATTRS_INSTALLED, reason="attrs not installed"),
+]
+
+if ATTRS_INSTALLED:
+    from attrs import define
+
+    @define
+    class SimpleAttrsModel:
+        """Simple attrs model for testing."""
+
+        name: str
+        age: int
+        email: Optional[str] = None  # noqa: UP045
+
+
+class TestCattrsIntegration:
+    """Test cattrs integration scenarios."""
+
+    @pytest.mark.skipif(not CATTRS_INSTALLED, reason="cattrs not installed")
+    def test_schema_dump_with_cattrs_enabled(self) -> None:
+        """Test schema_dump uses cattrs when available."""
+        instance = SimpleAttrsModel(name="John", age=30, email="john@example.com")
+
+        result = schema_dump(instance)
+
+        assert isinstance(result, dict)
+        assert result["name"] == "John"
+        assert result["age"] == 30
+        assert result["email"] == "john@example.com"
+
+    def test_schema_dump_with_cattrs_disabled(self) -> None:
+        """Test schema_dump falls back to attrs.asdict when cattrs is disabled."""
+        from advanced_alchemy.service import typing as service_typing
+
+        instance = SimpleAttrsModel(name="Jane", age=25)
+
+        # Mock CATTRS_INSTALLED to be False
+        with mock.patch.object(service_typing, "CATTRS_INSTALLED", False):
+            result = schema_dump(instance)
+
+        assert isinstance(result, dict)
+        assert result["name"] == "Jane"
+        assert result["age"] == 25
+        assert result["email"] is None
+
+    @pytest.mark.skipif(not CATTRS_INSTALLED, reason="cattrs not installed")
+    def test_to_schema_with_cattrs_priority(self) -> None:
+        """Test that to_schema uses cattrs over attrs when both are available."""
+        from advanced_alchemy.service._util import ResultConverter
+
+        converter = ResultConverter()
+        data = {"name": "Alice", "age": 28, "email": "alice@example.com"}
+
+        result = converter.to_schema(data, schema_type=SimpleAttrsModel)
+
+        assert isinstance(result, SimpleAttrsModel)
+        assert result.name == "Alice"
+        assert result.age == 28
+        assert result.email == "alice@example.com"
+
+    def test_to_schema_attrs_fallback_when_cattrs_disabled(self) -> None:
+        """Test that to_schema falls back to attrs when cattrs is disabled."""
+        from advanced_alchemy.service import _util
+        from advanced_alchemy.service import typing as service_typing
+        from advanced_alchemy.service._util import ResultConverter
+
+        converter = ResultConverter()
+        data = {"name": "Bob", "age": 35, "email": "bob@example.com"}
+
+        # Mock CATTRS_INSTALLED to be False in both modules
+        with (
+            mock.patch.object(service_typing, "CATTRS_INSTALLED", False),
+            mock.patch.object(_util, "CATTRS_INSTALLED", False),
+        ):
+            result = converter.to_schema(data, schema_type=SimpleAttrsModel)
+
+        assert isinstance(result, SimpleAttrsModel)
+        assert result.name == "Bob"
+        assert result.age == 35
+        assert result.email == "bob@example.com"
+
+    def test_to_schema_sequence_with_cattrs_disabled(self) -> None:
+        """Test that to_schema handles sequences correctly when cattrs is disabled."""
+        from advanced_alchemy.service import _util
+        from advanced_alchemy.service import typing as service_typing
+        from advanced_alchemy.service._util import ResultConverter
+        from advanced_alchemy.service.pagination import OffsetPagination
+
+        converter = ResultConverter()
+        data = [
+            {"name": "Charlie", "age": 40},
+            {"name": "Diana", "age": 45},
+        ]
+
+        # Mock CATTRS_INSTALLED to be False in both modules
+        with (
+            mock.patch.object(service_typing, "CATTRS_INSTALLED", False),
+            mock.patch.object(_util, "CATTRS_INSTALLED", False),
+        ):
+            result = converter.to_schema(data, schema_type=SimpleAttrsModel)
+
+        assert isinstance(result, OffsetPagination)
+        assert len(result.items) == 2
+        assert all(isinstance(item, SimpleAttrsModel) for item in result.items)
+        assert result.items[0].name == "Charlie"
+        assert result.items[1].name == "Diana"
+
+    @pytest.mark.skipif(not CATTRS_INSTALLED, reason="cattrs not installed")
+    def test_cattrs_structure_direct_usage(self) -> None:
+        """Test direct usage of cattrs structure function."""
+        from advanced_alchemy.service.typing import structure
+
+        data = {"name": "Eve", "age": 33, "email": "eve@example.com"}
+        result = structure(data, SimpleAttrsModel)
+
+        assert isinstance(result, SimpleAttrsModel)
+        assert result.name == "Eve"
+        assert result.age == 33
+        assert result.email == "eve@example.com"
+
+    @pytest.mark.skipif(not CATTRS_INSTALLED, reason="cattrs not installed")
+    def test_cattrs_unstructure_direct_usage(self) -> None:
+        """Test direct usage of cattrs unstructure function."""
+        from advanced_alchemy.service.typing import unstructure
+
+        instance = SimpleAttrsModel(name="Frank", age=28)
+        result = unstructure(instance)
+
+        assert isinstance(result, dict)
+        assert result["name"] == "Frank"
+        assert result["age"] == 28
+        assert result["email"] is None
+
+    def test_performance_with_cached_field_names(self) -> None:
+        """Test that field name caching improves performance."""
+        from advanced_alchemy.service import _util
+        from advanced_alchemy.service import typing as service_typing
+        from advanced_alchemy.service._util import ResultConverter, _get_attrs_field_names
+
+        converter = ResultConverter()
+
+        # Clear cache to ensure we're testing caching behavior
+        _get_attrs_field_names.cache_clear()
+
+        # Mock CATTRS_INSTALLED in both modules to be False to use attrs path
+        with (
+            mock.patch.object(service_typing, "CATTRS_INSTALLED", False),
+            mock.patch.object(_util, "CATTRS_INSTALLED", False),
+        ):
+            # First call should populate the cache
+            data1 = {"name": "Grace", "age": 30}
+            result1 = converter.to_schema(data1, schema_type=SimpleAttrsModel)
+
+            # Check cache info - should have 1 miss after first call
+            cache_info_after_first = _get_attrs_field_names.cache_info()
+
+            # Second call should use cached field names
+            data2 = {"name": "Henry", "age": 35}
+            result2 = converter.to_schema(data2, schema_type=SimpleAttrsModel)
+
+            # Check cache info - should have 1 hit now
+            cache_info_after_second = _get_attrs_field_names.cache_info()
+
+        assert isinstance(result1, SimpleAttrsModel)
+        assert isinstance(result2, SimpleAttrsModel)
+        assert result1.name == "Grace"
+        assert result2.name == "Henry"
+
+        # Verify caching is working - should have 1 miss and 1 hit
+        assert cache_info_after_first.misses == 1
+        assert cache_info_after_second.hits >= 1
+        assert cache_info_after_second.currsize >= 1
+
+    def test_integration_with_both_libraries_available(self) -> None:
+        """Test behavior when both cattrs and attrs are available."""
+        if not CATTRS_INSTALLED:
+            pytest.skip("cattrs not available for this test")
+
+        from advanced_alchemy.service._util import ResultConverter
+
+        converter = ResultConverter()
+        data = {"name": "Ivy", "age": 29, "email": "ivy@example.com"}
+
+        # Should prefer cattrs path when both are available
+        result = converter.to_schema(data, schema_type=SimpleAttrsModel)
+
+        assert isinstance(result, SimpleAttrsModel)
+        assert result.name == "Ivy"
+        assert result.age == 29
+        assert result.email == "ivy@example.com"
+
+    def test_edge_case_missing_fields(self) -> None:
+        """Test handling of missing fields in data."""
+        from advanced_alchemy.service import _util
+        from advanced_alchemy.service import typing as service_typing
+        from advanced_alchemy.service._util import ResultConverter
+
+        converter = ResultConverter()
+        # Data missing the 'age' field
+        data = {"name": "Jack"}
+
+        # Mock CATTRS_INSTALLED to be False in both modules to test attrs path
+        with (
+            mock.patch.object(service_typing, "CATTRS_INSTALLED", False),
+            mock.patch.object(_util, "CATTRS_INSTALLED", False),
+        ):
+            # This should handle missing fields gracefully
+            with pytest.raises(TypeError):  # attrs will complain about missing required field
+                converter.to_schema(data, schema_type=SimpleAttrsModel)
+
+    def test_extra_fields_filtered_out(self) -> None:
+        """Test that extra fields not in attrs schema are filtered out."""
+        from advanced_alchemy.service import _util
+        from advanced_alchemy.service import typing as service_typing
+        from advanced_alchemy.service._util import ResultConverter
+
+        converter = ResultConverter()
+        # Data with extra field 'phone' not in SimpleAttrsModel
+        data = {"name": "Kate", "age": 32, "email": "kate@example.com", "phone": "123-456-7890"}
+
+        # Mock CATTRS_INSTALLED to be False in both modules to test attrs filtering path
+        with (
+            mock.patch.object(service_typing, "CATTRS_INSTALLED", False),
+            mock.patch.object(_util, "CATTRS_INSTALLED", False),
+        ):
+            result = converter.to_schema(data, schema_type=SimpleAttrsModel)
+
+        assert isinstance(result, SimpleAttrsModel)
+        assert result.name == "Kate"
+        assert result.age == 32
+        assert result.email == "kate@example.com"
+        # Extra field should not cause issues
+        assert not hasattr(result, "phone")

--- a/uv.lock
+++ b/uv.lock
@@ -67,6 +67,7 @@ dev = [
     { name = "attrs" },
     { name = "auto-pytabs", extra = ["sphinx"] },
     { name = "bump-my-version" },
+    { name = "cattrs" },
     { name = "click", version = "8.1.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "click", version = "8.2.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "coverage" },
@@ -225,6 +226,7 @@ sqlite = [
 test = [
     { name = "asgi-lifespan" },
     { name = "attrs" },
+    { name = "cattrs" },
     { name = "click", version = "8.1.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "click", version = "8.2.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "coverage" },
@@ -281,6 +283,7 @@ dev = [
     { name = "attrs" },
     { name = "auto-pytabs", extras = ["sphinx"], specifier = ">=0.5.0" },
     { name = "bump-my-version" },
+    { name = "cattrs" },
     { name = "click" },
     { name = "coverage", specifier = ">=7.6.1" },
     { name = "dishka", marker = "python_full_version >= '3.10'" },
@@ -420,6 +423,7 @@ sqlite = [{ name = "aiosqlite", specifier = ">=0.20.0" }]
 test = [
     { name = "asgi-lifespan" },
     { name = "attrs" },
+    { name = "cattrs" },
     { name = "click" },
     { name = "coverage", specifier = ">=7.6.1" },
     { name = "dishka", marker = "python_full_version >= '3.10'" },
@@ -1099,6 +1103,20 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6c/81/3747dad6b14fa2cf53fcf10548cf5aea6913e96fab41a3c198676f8948a5/cachetools-5.5.2.tar.gz", hash = "sha256:1a661caa9175d26759571b2e19580f9d6393969e5dfca11fdb1f947a23e640d4", size = 28380, upload-time = "2025-02-20T21:01:19.524Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/72/76/20fa66124dbe6be5cafeb312ece67de6b61dd91a0247d1ea13db4ebb33c2/cachetools-5.5.2-py3-none-any.whl", hash = "sha256:d26a22bcc62eb95c3beabd9f1ee5e820d3d2704fe2967cbe350e20c8ffcd3f0a", size = 10080, upload-time = "2025-02-20T21:01:16.647Z" },
+]
+
+[[package]]
+name = "cattrs"
+version = "25.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/57/2b/561d78f488dcc303da4639e02021311728fb7fda8006dd2835550cddd9ed/cattrs-25.1.1.tar.gz", hash = "sha256:c914b734e0f2d59e5b720d145ee010f1fd9a13ee93900922a2f3f9d593b8382c", size = 435016, upload-time = "2025-06-04T20:27:15.44Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/b0/215274ef0d835bbc1056392a367646648b6084e39d489099959aefcca2af/cattrs-25.1.1-py3-none-any.whl", hash = "sha256:1b40b2d3402af7be79a7e7e097a9b4cd16d4c06e6d526644b0b26a063a1cc064", size = 69386, upload-time = "2025-06-04T20:27:13.969Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -64,6 +64,7 @@ dev = [
     { name = "asyncmy" },
     { name = "asyncpg" },
     { name = "asyncpg-stubs" },
+    { name = "attrs" },
     { name = "auto-pytabs", extra = ["sphinx"] },
     { name = "bump-my-version" },
     { name = "click", version = "8.1.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
@@ -223,6 +224,7 @@ sqlite = [
 ]
 test = [
     { name = "asgi-lifespan" },
+    { name = "attrs" },
     { name = "click", version = "8.1.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "click", version = "8.2.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "coverage" },
@@ -276,6 +278,7 @@ dev = [
     { name = "asyncmy", specifier = ">=0.2.9" },
     { name = "asyncpg", specifier = ">=0.29.0" },
     { name = "asyncpg-stubs" },
+    { name = "attrs" },
     { name = "auto-pytabs", extras = ["sphinx"], specifier = ">=0.5.0" },
     { name = "bump-my-version" },
     { name = "click" },
@@ -416,6 +419,7 @@ spanner = [{ name = "sqlalchemy-spanner", specifier = ">=1.7.0" }]
 sqlite = [{ name = "aiosqlite", specifier = ">=0.20.0" }]
 test = [
     { name = "asgi-lifespan" },
+    { name = "attrs" },
     { name = "click" },
     { name = "coverage", specifier = ">=7.6.1" },
     { name = "dishka", marker = "python_full_version >= '3.10'" },


### PR DESCRIPTION
Adds `attrs` support into the `ResultConverter` mixin.  This enables `to_schema` and `schema_dump` to natively understand `attrs`.