### PR TITLE
fix: suppress `passlib` caused pytest warnings and other session warnings

### DIFF
--- a/advanced_alchemy/service/_typing.py
+++ b/advanced_alchemy/service/_typing.py
@@ -1,167 +1,261 @@
+# ruff: noqa: RUF100, PLR0913, A002, DOC201, PLR6301, PLR0917, ARG004, ARG002, ARG001
 """This is a simple wrapper around a few important classes in each library.
 
 This is used to ensure compatibility when one or more of the libraries are installed.
 """
 
+import enum
 from typing import (
     Any,
     ClassVar,
+    Final,
     Optional,
     Protocol,
+    Union,
     cast,
     runtime_checkable,
 )
 
-from typing_extensions import TypeVar, dataclass_transform
+from typing_extensions import Literal, TypeVar, dataclass_transform
 
 T = TypeVar("T")
 T_co = TypeVar("T_co", covariant=True)
 
+# Always define stub types for type checking
+
+
+class BaseModelStub:
+    """Placeholder implementation."""
+
+    model_fields: ClassVar[dict[str, Any]] = {}
+    __slots__ = ("__dict__", "__pydantic_extra__", "__pydantic_fields_set__", "__pydantic_private__")
+
+    def __init__(self, **data: Any) -> None:
+        for key, value in data.items():
+            setattr(self, key, value)
+
+    def model_dump(  # noqa: PLR0913
+        self,
+        /,
+        *,
+        include: "Optional[Any]" = None,  # noqa: ARG002
+        exclude: "Optional[Any]" = None,  # noqa: ARG002
+        context: "Optional[Any]" = None,  # noqa: ARG002
+        by_alias: bool = False,  # noqa: ARG002
+        exclude_unset: bool = False,  # noqa: ARG002
+        exclude_defaults: bool = False,  # noqa: ARG002
+        exclude_none: bool = False,  # noqa: ARG002
+        round_trip: bool = False,  # noqa: ARG002
+        warnings: "Union[bool, Literal['none', 'warn', 'error']]" = True,  # noqa: ARG002
+        serialize_as_any: bool = False,  # noqa: ARG002
+    ) -> "dict[str, Any]":
+        """Placeholder implementation."""
+        return {k: v for k, v in self.__dict__.items() if not k.startswith("_")}
+
+    def model_dump_json(  # noqa: PLR0913
+        self,
+        /,
+        *,
+        include: "Optional[Any]" = None,  # noqa: ARG002
+        exclude: "Optional[Any]" = None,  # noqa: ARG002
+        context: "Optional[Any]" = None,  # noqa: ARG002
+        by_alias: bool = False,  # noqa: ARG002
+        exclude_unset: bool = False,  # noqa: ARG002
+        exclude_defaults: bool = False,  # noqa: ARG002
+        exclude_none: bool = False,  # noqa: ARG002
+        round_trip: bool = False,  # noqa: ARG002
+        warnings: "Union[bool, Literal['none', 'warn', 'error']]" = True,  # noqa: ARG002
+        serialize_as_any: bool = False,  # noqa: ARG002
+    ) -> str:
+        """Placeholder implementation."""
+        return "{}"
+
+
+class TypeAdapterStub:
+    """Placeholder implementation."""
+
+    def __init__(
+        self,
+        type: Any,  # noqa: A002
+        *,
+        config: "Optional[Any]" = None,  # noqa: ARG002
+        _parent_depth: int = 2,  # noqa: ARG002
+        module: "Optional[str]" = None,  # noqa: ARG002
+    ) -> None:
+        """Initialize."""
+        self._type = type
+
+    def validate_python(  # noqa: PLR0913
+        self,
+        object: Any,
+        /,
+        *,
+        strict: "Optional[bool]" = None,  # noqa: ARG002
+        from_attributes: "Optional[bool]" = None,  # noqa: ARG002
+        context: "Optional[dict[str, Any]]" = None,  # noqa: ARG002
+        experimental_allow_partial: "Union[bool, Literal['off', 'on', 'trailing-strings']]" = False,  # noqa: ARG002
+    ) -> Any:
+        """Validate Python object."""
+        return object
+
+
+class FailFastStub:
+    """Placeholder implementation for FailFast."""
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        """Init."""
+
+
+# Try to import real implementations at runtime
 try:
-    from pydantic import BaseModel, FailFast, TypeAdapter  # pyright: ignore
+    from pydantic import BaseModel, FailFast, TypeAdapter
 
-    PYDANTIC_INSTALLED = True
+    PYDANTIC_INSTALLED = True  # pyright: ignore[reportConstantRedefinition]
 except ImportError:
-
-    @runtime_checkable
-    class BaseModel(Protocol):  # type: ignore[no-redef]
-        """Placeholder Implementation"""
-
-        model_fields: "ClassVar[dict[str, Any]]"
-
-        def model_dump(self, *args: Any, **kwargs: Any) -> "dict[str, Any]":
-            """Placeholder"""
-            return {}
-
-    @runtime_checkable
-    class TypeAdapter(Protocol[T_co]):  # type: ignore[no-redef]
-        """Placeholder Implementation"""
-
-        def __init__(
-            self,
-            type: Any,  # noqa: A002
-            *,
-            config: "Optional[Any]" = None,
-            _parent_depth: int = 2,
-            module: "Optional[str]" = None,
-        ) -> None:
-            """Init"""
-
-        def validate_python(
-            self,
-            object: Any,  # noqa: A002
-            /,
-            *,
-            strict: "Optional[bool]" = None,
-            from_attributes: "Optional[bool]" = None,
-            context: "Optional[dict[str, Any]]" = None,
-        ) -> T_co:
-            """Stub"""
-            return cast("T_co", object)
-
-    @runtime_checkable
-    class FailFast(Protocol):  # type: ignore[no-redef]
-        """Placeholder Implementation for FailFast"""
-
-        def __init__(self, *args: Any, **kwargs: Any) -> None:
-            """Init"""
-
+    BaseModel = BaseModelStub  # type: ignore[assignment,misc]
+    TypeAdapter = TypeAdapterStub  # type: ignore[assignment,misc]
+    FailFast = FailFastStub  # type: ignore[assignment,misc]
     PYDANTIC_INSTALLED = False  # pyright: ignore[reportConstantRedefinition]
 
+# Always define stub types for msgspec
+
+
+@dataclass_transform()
+class StructStub:
+    """Placeholder implementation."""
+
+    __struct_fields__: ClassVar[tuple[str, ...]] = ()
+    __slots__ = ()
+
+    def __init__(self, **kwargs: Any) -> None:
+        for key, value in kwargs.items():
+            setattr(self, key, value)
+
+
+def convert_stub(  # noqa: PLR0913
+    obj: Any,  # noqa: ARG001
+    type: Any,  # noqa: A002,ARG001
+    *,
+    strict: bool = True,  # noqa: ARG001
+    from_attributes: bool = False,  # noqa: ARG001
+    dec_hook: "Optional[Any]" = None,  # noqa: ARG001
+    builtin_types: "Optional[Any]" = None,  # noqa: ARG001
+    str_keys: bool = False,  # noqa: ARG001
+) -> Any:
+    """Placeholder implementation."""
+    return {}
+
+
+class UnsetTypeStub(enum.Enum):
+    UNSET = "UNSET"
+
+
+UNSET_STUB = UnsetTypeStub.UNSET
+
+# Try to import real implementations at runtime
 try:
-    from msgspec import (
-        UNSET,
-        Struct,
-        UnsetType,  # pyright: ignore[reportAssignmentType,reportGeneralTypeIssues]
-        convert,  # pyright: ignore[reportGeneralTypeIssues]
-    )
+    from msgspec import UNSET, Struct, UnsetType, convert
 
-    MSGSPEC_INSTALLED: bool = True
+    MSGSPEC_INSTALLED = True  # pyright: ignore[reportConstantRedefinition]
 except ImportError:
-    import enum
-
-    @dataclass_transform()
-    @runtime_checkable
-    class Struct(Protocol):  # type: ignore[no-redef]
-        """Placeholder Implementation"""
-
-        __struct_fields__: "ClassVar[tuple[str, ...]]"
-
-    def convert(*args: Any, **kwargs: Any) -> Any:  # type: ignore[no-redef] # noqa: ARG001
-        """Placeholder implementation"""
-        return {}
-
-    class UnsetType(enum.Enum):  # type: ignore[no-redef]
-        UNSET = "UNSET"
-
-    UNSET = UnsetType.UNSET  # pyright: ignore[reportConstantRedefinition]
+    Struct = StructStub  # type: ignore[assignment,misc]
+    UnsetType = UnsetTypeStub  # type: ignore[assignment,misc]
+    UNSET = UNSET_STUB  # type: ignore[assignment] # pyright: ignore[reportConstantRedefinition]
+    convert = convert_stub
     MSGSPEC_INSTALLED = False  # pyright: ignore[reportConstantRedefinition]
 
+
+# Always define stub type for DTOData
+@runtime_checkable
+class DTODataStub(Protocol[T]):
+    """Placeholder implementation."""
+
+    __slots__ = ("_backend", "_data_as_builtins")
+
+    def __init__(self, backend: Any, data_as_builtins: Any) -> None:
+        """Initialize."""
+
+    def create_instance(self, **kwargs: Any) -> T:
+        return cast("T", kwargs)
+
+    def update_instance(self, instance: T, **kwargs: Any) -> T:
+        """Update instance."""
+        return cast("T", kwargs)
+
+    def as_builtins(self) -> Any:
+        """Convert to builtins."""
+        return {}
+
+
+# Try to import real implementation at runtime
 try:
     from litestar.dto.data_structures import DTOData
 
-    LITESTAR_INSTALLED = True
+    LITESTAR_INSTALLED = True  # pyright: ignore[reportConstantRedefinition]
 except ImportError:
-
-    @runtime_checkable
-    class DTOData(Protocol[T]):  # type: ignore[no-redef]
-        """Placeholder implementation"""
-
-        __slots__ = ("_backend", "_data_as_builtins")
-
-        def __init__(self, backend: Any, data_as_builtins: Any) -> None:
-            """Placeholder init"""
-
-        def create_instance(self, **kwargs: Any) -> T:
-            """Placeholder implementation"""
-            return cast("T", kwargs)
-
-        def update_instance(self, instance: T, **kwargs: Any) -> T:
-            """Placeholder implementation"""
-            return cast("T", kwargs)
-
-        def as_builtins(self) -> Any:
-            """Placeholder implementation"""
-            return {}
-
+    DTOData = DTODataStub  # type: ignore[assignment,misc]
     LITESTAR_INSTALLED = False  # pyright: ignore[reportConstantRedefinition]
 
+
+# Always define stub types for attrs
+@dataclass_transform()
+class AttrsInstanceStub:
+    """Placeholder Implementation for attrs classes"""
+
+    __attrs_attrs__: ClassVar[tuple[Any, ...]] = ()
+    __slots__ = ()
+
+    def __init__(self, **kwargs: Any) -> None:
+        for key, value in kwargs.items():
+            setattr(self, key, value)
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}()"
+
+
+def asdict_stub(*args: Any, **kwargs: Any) -> "dict[str, Any]":  # noqa: ARG001
+    """Placeholder implementation"""
+    return {}
+
+
+def define_stub(*args: Any, **kwargs: Any) -> Any:  # noqa: ARG001
+    """Placeholder implementation"""
+    return lambda cls: cls  # pyright: ignore[reportUnknownVariableType,reportUnknownLambdaType]
+
+
+def field_stub(*args: Any, **kwargs: Any) -> Any:  # noqa: ARG001
+    """Placeholder implementation"""
+    return None
+
+
+def fields_stub(*args: Any, **kwargs: Any) -> "tuple[Any, ...]":  # noqa: ARG001
+    """Placeholder implementation"""
+    return ()
+
+
+def has_stub(*args: Any, **kwargs: Any) -> bool:  # noqa: ARG001
+    """Placeholder implementation"""
+    return False
+
+
+# Try to import real implementations at runtime
 try:
-    from attrs import AttrsInstance, asdict, define, field, fields, has  # pyright: ignore
+    from attrs import AttrsInstance, asdict, define, field, fields, has
 
-    ATTRS_INSTALLED = True
+    ATTRS_INSTALLED = True  # pyright: ignore[reportConstantRedefinition]
 except ImportError:
-
-    @runtime_checkable
-    class AttrsInstance(Protocol):  # type: ignore[no-redef]
-        """Placeholder Implementation for attrs classes"""
-
-    def asdict(*args: Any, **kwargs: Any) -> "dict[str, Any]":  # type: ignore[misc] # noqa: ARG001
-        """Placeholder implementation"""
-        return {}
-
-    def define(*args: Any, **kwargs: Any) -> Any:  # type: ignore[no-redef] # noqa: ARG001
-        """Placeholder implementation"""
-        return lambda cls: cls  # pyright: ignore[reportUnknownVariableType,reportUnknownLambdaType]
-
-    def field(*args: Any, **kwargs: Any) -> Any:  # type: ignore[no-redef] # noqa: ARG001
-        """Placeholder implementation"""
-        return None
-
-    def fields(*args: Any, **kwargs: Any) -> "tuple[Any, ...]":  # type: ignore[misc] # noqa: ARG001
-        """Placeholder implementation"""
-        return ()
-
-    def has(*args: Any, **kwargs: Any) -> bool:  # type: ignore[misc] # noqa: ARG001
-        """Placeholder implementation"""
-        return False
-
+    AttrsInstance = AttrsInstanceStub  # type: ignore[misc]
+    asdict = asdict_stub
+    define = define_stub
+    field = field_stub
+    fields = fields_stub
+    has = has_stub  # type: ignore[assignment]
     ATTRS_INSTALLED = False  # pyright: ignore[reportConstantRedefinition]
 
 try:
-    from cattrs import structure, unstructure  # pyright: ignore # type: ignore[import-not-found]
+    from cattrs import structure, unstructure
 
-    CATTRS_INSTALLED = True
+    CATTRS_INSTALLED = True  # pyright: ignore[reportConstantRedefinition]
 except ImportError:
 
     def unstructure(*args: Any, **kwargs: Any) -> Any:  # noqa: ARG001
@@ -172,7 +266,17 @@ except ImportError:
         """Placeholder implementation"""
         return {}
 
-    CATTRS_INSTALLED = False  # pyright: ignore[reportConstantRedefinition]
+    CATTRS_INSTALLED = False  # pyright: ignore[reportConstantRedefinition]  # pyright: ignore[reportConstantRedefinition]
+
+
+class EmptyEnum(enum.Enum):
+    """A sentinel enum used as placeholder."""
+
+    EMPTY = 0
+
+
+EmptyType = Union[Literal[EmptyEnum.EMPTY], UnsetType]
+Empty: Final = EmptyEnum.EMPTY
 
 __all__ = (
     "ATTRS_INSTALLED",
@@ -181,19 +285,36 @@ __all__ = (
     "MSGSPEC_INSTALLED",
     "PYDANTIC_INSTALLED",
     "UNSET",
+    "UNSET_STUB",
     "AttrsInstance",
+    "AttrsInstanceStub",
     "BaseModel",
+    "BaseModelStub",
     "DTOData",
+    "DTODataStub",
+    "Empty",
+    "EmptyEnum",
+    "EmptyType",
     "FailFast",
+    "FailFastStub",
     "Struct",
+    "StructStub",
     "TypeAdapter",
+    "TypeAdapterStub",
     "UnsetType",
+    "UnsetTypeStub",
     "asdict",
+    "asdict_stub",
     "convert",
+    "convert_stub",
     "define",
+    "define_stub",
     "field",
+    "field_stub",
     "fields",
+    "fields_stub",
     "has",
+    "has_stub",
     "structure",
     "unstructure",
 )

--- a/advanced_alchemy/service/_util.py
+++ b/advanced_alchemy/service/_util.py
@@ -215,13 +215,16 @@ class ResultConverter:
             )
         if MSGSPEC_INSTALLED and issubclass(schema_type, Struct):
             if not isinstance(data, Sequence):
-                return convert(
-                    obj=data,
-                    type=schema_type,
-                    from_attributes=True,
-                    dec_hook=partial(
-                        _default_msgspec_deserializer,
-                        type_decoders=DEFAULT_TYPE_DECODERS,
+                return cast(  # type: ignore[redundant-cast]
+                    "ModelDTOT",
+                    convert(
+                        obj=data,
+                        type=schema_type,
+                        from_attributes=True,
+                        dec_hook=partial(
+                            _default_msgspec_deserializer,
+                            type_decoders=DEFAULT_TYPE_DECODERS,
+                        ),
                     ),
                 )
             converted_items = convert(
@@ -251,7 +254,7 @@ class ResultConverter:
 
         if ATTRS_INSTALLED and is_attrs_schema(schema_type):
             # Cache field names for performance
-            field_names = _get_attrs_field_names(schema_type)
+            field_names = _get_attrs_field_names(schema_type)  # type: ignore[arg-type]
 
             if not isinstance(data, Sequence):
                 return cast("ModelDTOT", _convert_attrs_item(data, schema_type, field_names))

--- a/advanced_alchemy/service/typing.py
+++ b/advanced_alchemy/service/typing.py
@@ -543,9 +543,9 @@ if TYPE_CHECKING:
         from litestar.dto import DTOData  # type: ignore[assignment] # noqa: TC004
 
     if not ATTRS_INSTALLED:
-        from advanced_alchemy.service._typing import asdict, has
+        from advanced_alchemy.service._typing import AttrsInstance, asdict, has
     else:
-        from attrs import asdict, has  # type: ignore[assignment] # noqa: TC004
+        from attrs import AttrsInstance, asdict, has  # type: ignore[assignment] # noqa: TC004
 
     if not CATTRS_INSTALLED:
         from advanced_alchemy.service._typing import structure, unstructure

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -219,6 +219,7 @@ filterwarnings = [
   "ignore::DeprecationWarning:google",
   "ignore::DeprecationWarning:websockets.connection",
   "ignore::DeprecationWarning:websockets.legacy",
+  "ignore:Accessing argon2.__version__ is deprecated:DeprecationWarning:passlib.handlers.argon2",
 ]
 markers = [
   "integration: SQLAlchemy integration tests",

--- a/tests/integration/test_loader_and_execution_options.py
+++ b/tests/integration/test_loader_and_execution_options.py
@@ -80,10 +80,11 @@ def test_loader(monkeypatch: MonkeyPatch, engine: Engine) -> None:
         france = UUIDCountry(name="France")
         db_session.add(usa)
         db_session.add(france)
+        db_session.flush()  # Ensure countries are in session before creating states
 
-        california = UUIDState(name="California", country=usa)
-        oregon = UUIDState(name="Oregon", country=usa)
-        ile_de_france = UUIDState(name="Île-de-France", country=france)
+        california = UUIDState(name="California", country_id=usa.id)
+        oregon = UUIDState(name="Oregon", country_id=usa.id)
+        ile_de_france = UUIDState(name="Île-de-France", country_id=france.id)
 
         repo = USStateRepository(session=db_session)
         repo.add(california)
@@ -202,10 +203,11 @@ async def test_async_loader(monkeypatch: MonkeyPatch, async_engine: AsyncEngine)
         france = BigIntCountry(name="France")
         db_session.add(usa)
         db_session.add(france)
+        await db_session.flush()  # Ensure countries are in session before creating states
 
-        california = BigIntState(name="California", country=usa)
-        oregon = BigIntState(name="Oregon", country=usa)
-        ile_de_france = BigIntState(name="Île-de-France", country=france)
+        california = BigIntState(name="California", country_id=usa.id)
+        oregon = BigIntState(name="Oregon", country_id=usa.id)
+        ile_de_france = BigIntState(name="Île-de-France", country_id=france.id)
 
         repo = USStateRepository(session=db_session)
         await repo.add(california)
@@ -323,10 +325,11 @@ def test_default_overrides_loader(monkeypatch: MonkeyPatch, engine: Engine) -> N
         france = UUIDCountryTest(name="France")
         db_session.add(usa)
         db_session.add(france)
+        db_session.flush()  # Ensure countries are in session before creating states
 
-        california = UUIDStateTest(name="California", country=usa)
-        oregon = UUIDStateTest(name="Oregon", country=usa)
-        ile_de_france = UUIDStateTest(name="Île-de-France", country=france)
+        california = UUIDStateTest(name="California", country_id=usa.id)
+        oregon = UUIDStateTest(name="Oregon", country_id=usa.id)
+        ile_de_france = UUIDStateTest(name="Île-de-France", country_id=france.id)
 
         repo = USStateRepository(session=db_session)
         repo.add(california)
@@ -421,10 +424,11 @@ async def test_default_overrides_async_loader(monkeypatch: MonkeyPatch, async_en
         france = BigIntCountryTest(name="France")
         db_session.add(usa)
         db_session.add(france)
+        await db_session.flush()  # Ensure countries are in session before creating states
 
-        california = BigIntStateTest(name="California", country=usa)
-        oregon = BigIntStateTest(name="Oregon", country=usa)
-        ile_de_france = BigIntStateTest(name="Île-de-France", country=france)
+        california = BigIntStateTest(name="California", country_id=usa.id)
+        oregon = BigIntStateTest(name="Oregon", country_id=usa.id)
+        ile_de_france = BigIntStateTest(name="Île-de-France", country_id=france.id)
 
         repo = USStateRepository(session=db_session)
         await repo.add(california)


### PR DESCRIPTION
Suppress warnings caused by `passlib` during testing.