### PR TITLE
fix: add warning message when using fallback value for a primary key

### DIFF
--- a/advanced_alchemy/mixins/nanoid.py
+++ b/advanced_alchemy/mixins/nanoid.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from sqlalchemy.orm import Mapped, declarative_mixin, mapped_column
 
@@ -10,16 +10,20 @@ if NANOID_INSTALLED and not TYPE_CHECKING:
         generate as nanoid,
     )
 else:
-    import logging
     from uuid import uuid4 as nanoid  # type: ignore[assignment,unused-ignore]
-
-    logger = logging.getLogger("advanced_alchemy")
-    logger.warning("`fastnanoid` not installed, falling back to `uuid4` for NanoID generation.")
 
 
 @declarative_mixin
 class NanoIDPrimaryKey(SentinelMixin):
     """Nano ID Primary Key Field Mixin."""
+
+    def __init_subclass__(cls, **kwargs: Any) -> None:
+        super().__init_subclass__(**kwargs)
+        if not NANOID_INSTALLED and not cls.__module__.startswith("advanced_alchemy"):
+            import logging
+
+            logger = logging.getLogger("advanced_alchemy")
+            logger.warning("`fastnanoid` not installed, falling back to `uuid4` for NanoID generation.")
 
     id: Mapped[str] = mapped_column(default=nanoid, primary_key=True)
     """Nano ID Primary key column."""

--- a/advanced_alchemy/mixins/nanoid.py
+++ b/advanced_alchemy/mixins/nanoid.py
@@ -10,7 +10,11 @@ if NANOID_INSTALLED and not TYPE_CHECKING:
         generate as nanoid,
     )
 else:
+    import logging
     from uuid import uuid4 as nanoid  # type: ignore[assignment,unused-ignore]
+
+    logger = logging.getLogger("advanced_alchemy")
+    logger.warning("`fastnanoid` not installed, falling back to `uuid4` for NanoID generation.")
 
 
 @declarative_mixin

--- a/advanced_alchemy/mixins/nanoid.py
+++ b/advanced_alchemy/mixins/nanoid.py
@@ -1,3 +1,4 @@
+import logging
 from typing import TYPE_CHECKING, Any
 
 from sqlalchemy.orm import Mapped, declarative_mixin, mapped_column
@@ -12,6 +13,8 @@ if NANOID_INSTALLED and not TYPE_CHECKING:
 else:
     from uuid import uuid4 as nanoid  # type: ignore[assignment,unused-ignore]
 
+logger = logging.getLogger("advanced_alchemy")
+
 
 @declarative_mixin
 class NanoIDPrimaryKey(SentinelMixin):
@@ -20,9 +23,6 @@ class NanoIDPrimaryKey(SentinelMixin):
     def __init_subclass__(cls, **kwargs: Any) -> None:
         super().__init_subclass__(**kwargs)
         if not NANOID_INSTALLED and not cls.__module__.startswith("advanced_alchemy"):
-            import logging
-
-            logger = logging.getLogger("advanced_alchemy")
             logger.warning("`fastnanoid` not installed, falling back to `uuid4` for NanoID generation.")
 
     id: Mapped[str] = mapped_column(default=nanoid, primary_key=True)

--- a/advanced_alchemy/mixins/nanoid.py
+++ b/advanced_alchemy/mixins/nanoid.py
@@ -22,7 +22,7 @@ class NanoIDPrimaryKey(SentinelMixin):
 
     def __init_subclass__(cls, **kwargs: Any) -> None:
         super().__init_subclass__(**kwargs)
-        if not NANOID_INSTALLED and not cls.__module__.startswith("advanced_alchemy"):
+        if not NANOID_INSTALLED and not cls.__module__.startswith("advanced_alchemy"):  # pragma: no cover
             logger.warning("`fastnanoid` not installed, falling back to `uuid4` for NanoID generation.")
 
     id: Mapped[str] = mapped_column(default=nanoid, primary_key=True)

--- a/advanced_alchemy/mixins/uuid.py
+++ b/advanced_alchemy/mixins/uuid.py
@@ -36,7 +36,7 @@ class UUIDv6PrimaryKey(SentinelMixin):
 
     def __init_subclass__(cls, **kwargs: Any) -> None:
         super().__init_subclass__(**kwargs)
-        if not UUID_UTILS_INSTALLED and not cls.__module__.startswith("advanced_alchemy"):
+        if not UUID_UTILS_INSTALLED and not cls.__module__.startswith("advanced_alchemy"):  # pragma: no cover
             logger.warning("`uuid-utils` not installed, falling back to `uuid4` for UUID v6 generation.")
 
     id: Mapped[UUID] = mapped_column(default=uuid6, primary_key=True)
@@ -49,7 +49,7 @@ class UUIDv7PrimaryKey(SentinelMixin):
 
     def __init_subclass__(cls, **kwargs: Any) -> None:
         super().__init_subclass__(**kwargs)
-        if not UUID_UTILS_INSTALLED and not cls.__module__.startswith("advanced_alchemy"):
+        if not UUID_UTILS_INSTALLED and not cls.__module__.startswith("advanced_alchemy"):  # pragma: no cover
             logger.warning("`uuid-utils` not installed, falling back to `uuid4` for UUID v7 generation.")
 
     id: Mapped[UUID] = mapped_column(default=uuid7, primary_key=True)

--- a/advanced_alchemy/mixins/uuid.py
+++ b/advanced_alchemy/mixins/uuid.py
@@ -1,4 +1,5 @@
-from typing import TYPE_CHECKING
+import logging
+from typing import TYPE_CHECKING, Any
 from uuid import UUID, uuid4
 
 from sqlalchemy.orm import Mapped, declarative_mixin, mapped_column
@@ -18,6 +19,8 @@ else:
     uuid6 = uuid4  # type: ignore[assignment, unused-ignore]
     uuid7 = uuid4  # type: ignore[assignment, unused-ignore]
 
+logger = logging.getLogger("advanced_alchemy")
+
 
 @declarative_mixin
 class UUIDPrimaryKey(SentinelMixin):
@@ -31,6 +34,11 @@ class UUIDPrimaryKey(SentinelMixin):
 class UUIDv6PrimaryKey(SentinelMixin):
     """UUID v6 Primary Key Field Mixin."""
 
+    def __init_subclass__(cls, **kwargs: Any) -> None:
+        super().__init_subclass__(**kwargs)
+        if not UUID_UTILS_INSTALLED and not cls.__module__.startswith("advanced_alchemy"):
+            logger.warning("`uuid-utils` not installed, falling back to `uuid4` for UUID v6 generation.")
+
     id: Mapped[UUID] = mapped_column(default=uuid6, primary_key=True)
     """UUID Primary key column."""
 
@@ -38,6 +46,11 @@ class UUIDv6PrimaryKey(SentinelMixin):
 @declarative_mixin
 class UUIDv7PrimaryKey(SentinelMixin):
     """UUID v7 Primary Key Field Mixin."""
+
+    def __init_subclass__(cls, **kwargs: Any) -> None:
+        super().__init_subclass__(**kwargs)
+        if not UUID_UTILS_INSTALLED and not cls.__module__.startswith("advanced_alchemy"):
+            logger.warning("`uuid-utils` not installed, falling back to `uuid4` for UUID v7 generation.")
 
     id: Mapped[UUID] = mapped_column(default=uuid7, primary_key=True)
     """UUID Primary key column."""


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

- Add warning message when using `uuid` instead of `nanoid`
- Add warning message when using `uuid4` instead of `uuid6` or `uuid7`

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
## Closes
