### PR TITLE
fix: prevent AttributeError when schema_dump receives None values

### DIFF
--- a/advanced_alchemy/service/typing.py
+++ b/advanced_alchemy/service/typing.py
@@ -259,8 +259,8 @@ def has_dict_attribute(obj: Any) -> "TypeGuard[DictProtocol]":
     Returns:
         bool
     """
-
-    return isinstance(obj, DictProtocol)
+    # Protocol checking returns True for None, so add explicit check
+    return obj is not None and isinstance(obj, DictProtocol)
 
 
 def is_row_mapping(v: Any) -> TypeGuard["RowMapping"]:

--- a/tests/unit/test_attrs_integration.py
+++ b/tests/unit/test_attrs_integration.py
@@ -230,6 +230,17 @@ class TestSchemaDump:
         dict_data = {"name": "test", "age": 30}
         assert schema_dump(dict_data) == dict_data
 
+    def test_schema_dump_none_value(self) -> None:
+        """Test that schema_dump correctly handles None values.
+
+        schema_dump should gracefully handle None input values without raising
+        AttributeError, returning None as-is through the fallback mechanism.
+        This is important for nullable database fields that may contain None.
+        """
+        # schema_dump should handle None without raising AttributeError
+        result = schema_dump(None)
+        assert result is None
+
     @pytest.mark.skipif(not ATTRS_INSTALLED, reason="attrs not installed")
     def test_schema_dump_exclude_unset_parameter(self) -> None:
         """Test schema_dump exclude_unset parameter (attrs always includes all fields)."""


### PR DESCRIPTION
## Description

Fixes an AttributeError that occurs when `schema_dump()` receives `None` values, which commonly happens with nullable database fields using `StoredObject` types during JSON serialization.

## Problem

When nullable `StoredObject` fields contain `None` values, the JSON serialization process fails with:
```
AttributeError: 'NoneType' object has no attribute '__dict__'
```

This error occurs in the serialization chain: SQLAlchemy → `serializer()` → `schema_dump()` → `has_dict_attribute()`.

## Root Cause

The issue was introduced in commit 7fd8161 where `hasattr(data, "__dict__")` was replaced with `has_dict_attribute(data)`. The new function uses `isinstance(obj, DictProtocol)` which incorrectly returns `True` for `None` due to Python's structural protocol checking behavior, even though `None` doesn't actually have a `__dict__` attribute.

## Solution

Added an explicit `None` check to the `has_dict_attribute()` function:

```python
def has_dict_attribute(obj: Any) -> "TypeGuard[DictProtocol]":
    # Protocol checking incorrectly returns True for None, so add explicit check
    return obj is not None and isinstance(obj, DictProtocol)
```

## Testing

- Added test case `test_schema_dump_none_value()` that verifies `None` values are handled correctly
- All existing tests continue to pass
- Verified end-to-end serialization scenarios work properly

## Changes

- `advanced_alchemy/service/typing.py`: Fixed `has_dict_attribute()` function
- `tests/unit/test_attrs_integration.py`: Added test case for `None` value handling

This is a minimal, targeted fix that resolves the immediate issue without affecting the broader functionality of the protocol-based type checking system.