### PR TITLE
fix: correctly handle lazy attributes on update

### DIFF
--- a/advanced_alchemy/repository/_async.py
+++ b/advanced_alchemy/repository/_async.py
@@ -1507,6 +1507,16 @@ class SQLAlchemyAsyncRepository(SQLAlchemyAsyncRepositoryProtocol[ModelT], Filte
                     # Handle relationships by merging objects into session first
                     for relationship in mapper.mapper.relationships:
                         if (new_value := getattr(data, relationship.key, MISSING)) is not MISSING:
+                            # Skip relationships that cannot be handled by generic merge operations
+                            if relationship.viewonly or relationship.lazy in {
+                                "write_only",
+                                "dynamic",
+                                "raise",
+                                "raise_on_sql",
+                            }:
+                                # Skip relationships with incompatible lazy loading strategies
+                                continue
+
                             if isinstance(new_value, list):
                                 merged_values = [  # pyright: ignore
                                     await self.session.merge(item, load=False)  # pyright: ignore

--- a/advanced_alchemy/repository/_async.py
+++ b/advanced_alchemy/repository/_async.py
@@ -1508,7 +1508,7 @@ class SQLAlchemyAsyncRepository(SQLAlchemyAsyncRepositoryProtocol[ModelT], Filte
                     for relationship in mapper.mapper.relationships:
                         if (new_value := getattr(data, relationship.key, MISSING)) is not MISSING:
                             # Skip relationships that cannot be handled by generic merge operations
-                            if relationship.viewonly or relationship.lazy in {
+                            if relationship.viewonly or relationship.lazy in {  # pragma: no cover
                                 "write_only",
                                 "dynamic",
                                 "raise",

--- a/advanced_alchemy/repository/_sync.py
+++ b/advanced_alchemy/repository/_sync.py
@@ -1509,7 +1509,7 @@ class SQLAlchemySyncRepository(SQLAlchemySyncRepositoryProtocol[ModelT], Filtera
                     for relationship in mapper.mapper.relationships:
                         if (new_value := getattr(data, relationship.key, MISSING)) is not MISSING:
                             # Skip relationships that cannot be handled by generic merge operations
-                            if relationship.viewonly or relationship.lazy in {
+                            if relationship.viewonly or relationship.lazy in {  # pragma: no cover
                                 "write_only",
                                 "dynamic",
                                 "raise",

--- a/advanced_alchemy/repository/_sync.py
+++ b/advanced_alchemy/repository/_sync.py
@@ -1508,6 +1508,16 @@ class SQLAlchemySyncRepository(SQLAlchemySyncRepositoryProtocol[ModelT], Filtera
                     # Handle relationships by merging objects into session first
                     for relationship in mapper.mapper.relationships:
                         if (new_value := getattr(data, relationship.key, MISSING)) is not MISSING:
+                            # Skip relationships that cannot be handled by generic merge operations
+                            if relationship.viewonly or relationship.lazy in {
+                                "write_only",
+                                "dynamic",
+                                "raise",
+                                "raise_on_sql",
+                            }:
+                                # Skip relationships with incompatible lazy loading strategies
+                                continue
+
                             if isinstance(new_value, list):
                                 merged_values = [  # pyright: ignore
                                     self.session.merge(item, load=False)  # pyright: ignore


### PR DESCRIPTION
Correctly handle `viewownly` and `lazy` loaded relationships during update.