### PR TITLE
fix: punctuation symbols not visible in dark mode syntax highlighting

### DIFF
--- a/docs/_static/syntax-highlighting.css
+++ b/docs/_static/syntax-highlighting.css
@@ -112,6 +112,10 @@ html.light .highlight .sx {  /* String.Other */
   color: #d73a49 !important;
 }
 
+html.light .highlight .p {   /* Punctuation */
+  color: var(--gray-12) !important;
+}
+
 /* =====================================================
  * Dark Mode Syntax Highlighting
  * ===================================================== */
@@ -206,6 +210,10 @@ html.dark .highlight .ne {   /* Name.Exception */
 html.dark .highlight .si,    /* String.Interpol */
 html.dark .highlight .sx {   /* String.Other */
   color: #a5d6ff !important;
+}
+
+html.dark .highlight .p {    /* Punctuation */
+  color: var(--gray-12) !important;
 }
 
 /* =====================================================


### PR DESCRIPTION
Add explicit color styling for `.highlight .p` (punctuation tokens) in both light and dark modes using Shibuya theme's `--gray-12` variable. This ensures brackets, parentheses, commas, and other punctuation symbols are properly visible when viewing code examples in dark mode.
