### PR TITLE
fix: ensure `has_dict_attribute` checks for `__dict__` attribute

### DIFF
--- a/advanced_alchemy/service/typing.py
+++ b/advanced_alchemy/service/typing.py
@@ -261,7 +261,7 @@ def has_dict_attribute(obj: Any) -> "TypeGuard[DictProtocol]":
         bool
     """
     # Protocol checking returns True for None, so add explicit check
-    return obj is not None and isinstance(obj, DictProtocol)
+    return obj is not None and hasattr(obj, "__dict__")
 
 
 def is_row_mapping(v: Any) -> TypeGuard["RowMapping"]:


### PR DESCRIPTION
## Description

The previous implementation used `isinstance` against the `DictProtocol` type returned `True` for any object.

For example:

```python
from advanced_alchemy.service.typing import has_dict_attribute
has_dict_attribute(1)         # True
has_dict_attribute([1, 2, 3]) # True
```

The `isinstance` call is replaced with `hasattr` (which should also be faster). With this change, I believe the `DictProtocol` class could also be removed, but I kept the changes to a minimum.
