### PR TITLE
fix: adding string representation to StoredObject

### DIFF
--- a/advanced_alchemy/types/file_object/data_type.py
+++ b/advanced_alchemy/types/file_object/data_type.py
@@ -72,6 +72,8 @@ class StoredObject(TypeDecorator[OptionalFileObjectOrList]):
 
     def __repr__(self) -> str:
         """Return a string representation of the StoredObject."""
+        if self.multiple:
+            return f"StoredObject(backend='{self.backend.key}', multiple=True)"
         return f"StoredObject(backend='{self.backend.key}')"
 
     def process_bind_param(


### PR DESCRIPTION
Ran into an issues running migration created for `advanced_alchemy.types.FileObject` column on a model. Below details should shed some more light.

**Code**
```python
from advanced_alchemy.base import UUIDBase
from advanced_alchemy.types.file_object.backends.obstore import ObstoreBackend
from advanced_alchemy.types import storages, FileObject, StoredObject
from sqlalchemy.orm import Mapped, mapped_column

file_storage_backend = ObstoreBackend(
    key="local",
    fs="file://",
    prefix="/path/to/files",
)
storages.register_backend(file_storage_backend)


class Document(UUIDBase):
    __tablename__ = "documents"
    file: Mapped[FileObject] = mapped_column(StoredObject(backend="local"))
```

**Migration file**
```python
...

def upgrade() -> None:
    """Upgrade schema."""
    # ### commands auto generated by Alembic - please adjust! ###
    op.create_table('documents',
    sa.Column('file', advanced_alchemy.types.file_object.data_type.StoredObject(), nullable=False),
    sa.Column('id', advanced_alchemy.types.guid.GUID(length=16), nullable=False),
    sa.Column('sa_orm_sentinel', sa.Integer(), nullable=True),
    sa.PrimaryKeyConstraint('id', name=op.f('pk_documents'))
    )
    # ### end Alembic commands ###
```

**Error**
Happens when applying migrations
```shell
...
  File "/path/to/migrations/versions/202510161151_8b0d40f55e2b.py", line 28, in upgrade
    sa.Column('file', advanced_alchemy.types.file_object.data_type.StoredObject(), nullable=False),
                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
TypeError: StoredObject.__init__() missing 1 required positional argument: 'backend'
```

Proposed change recommended by @glendonyeo fixes this issue.

Side quest would be to add `advanced_alchemy.types.file_object.file.FileObject` type support to [polyfactory](https://github.com/litestar-org/polyfactory).
```python
polyfactory.exceptions.ParameterException: Unsupported type: <class 'advanced_alchemy.types.file_object.file.FileObject'> on field '' from class ImageFactory.
```