### PR TITLE
fix: pin default installed python to 3.10

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ install-uv:                                         ## Install latest version of
 .PHONY: install
 install: destroy clean                              ## Install the project, dependencies, and pre-commit
 	@echo "${INFO} Starting fresh installation..."
-	@uv python pin 3.9 >/dev/null 2>&1
+	@uv python pin 3.10 >/dev/null 2>&1
 	@uv venv >/dev/null 2>&1
 	@uv sync --all-extras --dev
 	@echo "${OK} Installation complete! 🎉"


### PR DESCRIPTION
Update the installation process to set the default Python version to 3.10 instead of 3.9.

There are some testing & docs packages we use that are causing issues.  We can pin 3.10 until 3.9 support is removed.  There is still a CI tests for 3.9