### PR TITLE
fix: update documentation URLs to `advanced-alchemy.dev`

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,12 +339,12 @@ or the [project-specific GitHub discussions page][project-discussions].
 </p>
 
 [litestar-org]: https://github.com/litestar-org
-[contributing]: https://docs.advanced-alchemy.litestar.dev/latest/contribution-guide.html
+[contributing]: https://advanced-alchemy.dev/latest/contribution-guide.html
 [discord]: https://discord.gg/litestar
 [litestar-discussions]: https://github.com/orgs/litestar-org/discussions
 [project-discussions]: https://github.com/litestar-org/advanced-alchemy/discussions
-[project-docs]: https://docs.advanced-alchemy.litestar.dev
-[install-guide]: https://docs.advanced-alchemy.litestar.dev/latest/#installation
+[project-docs]: https://advanced-alchemy.dev
+[install-guide]: https://advanced-alchemy.dev/latest/#installation
 [fastapi-example]: https://github.com/litestar-org/advanced-alchemy/blob/main/examples/fastapi/fastapi_service.py
 [flask-example]: https://github.com/litestar-org/advanced-alchemy/blob/main/examples/flask/flask_services.py
 [litestar-example]: https://github.com/litestar-org/advanced-alchemy/blob/main/examples/litestar/litestar_service.py

--- a/docs/PYPI_README.md
+++ b/docs/PYPI_README.md
@@ -326,12 +326,12 @@ or the [project-specific GitHub discussions page][project-discussions].
 </p>
 
 [litestar-org]: https://github.com/litestar-org
-[contributing]: https://docs.advanced-alchemy.litestar.dev/latest/contribution-guide.html
+[contributing]: https://advanced-alchemy.dev/latest/contribution-guide.html
 [discord]: https://discord.gg/litestar
 [litestar-discussions]: https://github.com/orgs/litestar-org/discussions
 [project-discussions]: https://github.com/litestar-org/advanced-alchemy/discussions
-[project-docs]: https://docs.advanced-alchemy.litestar.dev
-[install-guide]: https://docs.advanced-alchemy.litestar.dev/latest/#installation
+[project-docs]: https://advanced-alchemy.dev
+[install-guide]: https://advanced-alchemy.dev/latest/#installation
 [fastapi-example]: https://github.com/litestar-org/advanced-alchemy/blob/main/examples/fastapi/fastapi_service.py
 [flask-example]: https://github.com/litestar-org/advanced-alchemy/blob/main/examples/flask/flask_services.py
 [litestar-example]: https://github.com/litestar-org/advanced-alchemy/blob/main/examples/litestar/litestar_service.py

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -739,7 +739,7 @@
         :pr: 379
         :issue: 338
 
-        Fix query repositories list method according to [documentation](https://docs.advanced-alchemy.litestar.dev/latest/usage/repositories.html#query-repository).
+        Fix query repositories list method according to [documentation](https://advanced-alchemy.dev/latest/usage/repositories.html#query-repository).
 
         Now its return a list of tuples with values instead of first column of the query.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,11 +48,11 @@ requires-python = ">=3.9"
 version = "1.8.0"
 
 [project.urls]
-Changelog = "https://docs.advanced-alchemy.litestar.dev/latest/changelog"
+Changelog = "https://advanced-alchemy.dev/latest/changelog"
 Discord = "https://discord.gg/litestar"
-Documentation = "https://docs.advanced-alchemy.litestar.dev/latest/"
+Documentation = "https://advanced-alchemy.dev/latest/"
 Funding = "https://github.com/sponsors/litestar-org"
-Homepage = "https://docs.advanced-alchemy.litestar.dev/latest/"
+Homepage = "https://advanced-alchemy.dev/latest/"
 Issue = "https://github.com/litestar-org/advanced-alchemy/issues/"
 Source = "https://github.com/litestar-org/advanced-alchemy"
 


### PR DESCRIPTION
Replace previous documentation URLs with the dedicated domain name.