### PR TITLE
feat(cli): add `db` group alias

### DIFF
--- a/advanced_alchemy/extensions/fastapi/cli.py
+++ b/advanced_alchemy/extensions/fastapi/cli.py
@@ -35,7 +35,7 @@ def get_database_migration_plugin(app: "FastAPI") -> "AdvancedAlchemy":  # pragm
 
 
 def register_database_commands(app: "FastAPI") -> click.Group:  # pragma: no cover
-    @click.group(name="database")
+    @click.group(name="database", aliases=["db"])
     @click.pass_context
     def database_group(ctx: click.Context) -> None:
         """Manage SQLAlchemy database components."""

--- a/advanced_alchemy/extensions/flask/cli.py
+++ b/advanced_alchemy/extensions/flask/cli.py
@@ -42,7 +42,7 @@ def get_database_migration_plugin(app: "Flask") -> "AdvancedAlchemy":
     raise ImproperConfigurationError(msg)
 
 
-@click.group(name="database")
+@click.group(name="database", aliases=["db"])
 @with_appcontext
 def database_group() -> None:
     """Manage SQLAlchemy database components.

--- a/advanced_alchemy/extensions/litestar/cli.py
+++ b/advanced_alchemy/extensions/litestar/cli.py
@@ -37,7 +37,7 @@ def get_database_migration_plugin(app: "Litestar") -> "SQLAlchemyInitPlugin":
     raise ImproperConfigurationError(msg)
 
 
-@click.group(cls=LitestarGroup, name="database")
+@click.group(cls=LitestarGroup, name="database", aliases=["db"])
 def database_group(ctx: "click.Context") -> None:
     """Manage SQLAlchemy database components."""
     ctx.obj = {"app": ctx.obj, "configs": get_database_migration_plugin(ctx.obj.app).config}


### PR DESCRIPTION
Add a `db` shorthand alias to the `database` group.  This allows `litestar|alchemy db` or `litestar|alchemy database` to work interchangeably.