### PR TITLE
fix: import error while generating migrations

### DIFF
--- a/advanced_alchemy/types/password_hash/passlib.py
+++ b/advanced_alchemy/types/password_hash/passlib.py
@@ -2,11 +2,10 @@
 
 from typing import TYPE_CHECKING, Any, Union
 
-from passlib.context import CryptContext  # pyright: ignore
-
 from advanced_alchemy.types.password_hash.base import HashingBackend
 
 if TYPE_CHECKING:
+    from passlib.context import CryptContext
     from sqlalchemy import BinaryExpression, ColumnElement
 
 __all__ = ("PasslibHasher",)
@@ -19,7 +18,7 @@ class PasslibHasher(HashingBackend):
     Install with `pip install passlib` or `uv pip install passlib`.
     """
 
-    def __init__(self, context: CryptContext) -> None:
+    def __init__(self, context: "CryptContext") -> None:
         """Initialize PasslibBackend.
 
         Args:

--- a/advanced_alchemy/types/password_hash/pwdlib.py
+++ b/advanced_alchemy/types/password_hash/pwdlib.py
@@ -5,9 +5,8 @@ from typing import TYPE_CHECKING, Any, Union
 from advanced_alchemy.types.password_hash.base import HashingBackend
 
 if TYPE_CHECKING:
+    from pwdlib.hashers.base import HasherProtocol
     from sqlalchemy import BinaryExpression, ColumnElement
-
-from pwdlib.hashers.base import HasherProtocol
 
 __all__ = ("PwdlibHasher",)
 
@@ -15,7 +14,7 @@ __all__ = ("PwdlibHasher",)
 class PwdlibHasher(HashingBackend):
     """Hashing backend using Pwdlib."""
 
-    def __init__(self, hasher: HasherProtocol) -> None:
+    def __init__(self, hasher: "HasherProtocol") -> None:
         """Initialize PwdlibBackend.
 
         Args:


### PR DESCRIPTION
## Description

- Fixes `passlib` and `pwdlib` import errors while creating migrations

## Cause

We added the `sa.PasslibHasher = PasslibHasher` and `sa.PwdlibHasher = PwdlibHasher` types in `script.py.mako`. As a result, when a user installs only Advanced Alchemy and creates a migration, these files are imported. Since they reference types from `passlib` and `pwdlib`, which are not installed by default, the import fails and triggers this error.

#### References:
- #626 
- #625 
- #624 

