### PR TITLE
feat: add NullFilter/NotNullFilter and with_for_update to get_one methods

### DIFF
--- a/advanced_alchemy/filters.py
+++ b/advanced_alchemy/filters.py
@@ -78,6 +78,8 @@ __all__ = (
     "NotExistsFilter",
     "NotInCollectionFilter",
     "NotInSearchFilter",
+    "NotNullFilter",
+    "NullFilter",
     "OnBeforeAfter",
     "OrderBy",
     "PaginationFilter",
@@ -107,6 +109,8 @@ class FilterMap(TypedDict):
     collection: "type[CollectionFilter[Any]]"
     not_in_collection: "type[NotInCollectionFilter[Any]]"
     limit_offset: "type[LimitOffset]"
+    null: "type[NullFilter]"
+    not_null: "type[NotNullFilter]"
     order_by: "type[OrderBy]"
     search: "type[SearchFilter]"
     not_in_search: "type[NotInSearchFilter]"
@@ -377,6 +381,112 @@ class NotInCollectionFilter(InAnyFilter, Generic[T]):
         if prefer_any:
             return cast("StatementTypeT", statement.where(any_(self.values) != field))  # type: ignore[arg-type]
         return cast("StatementTypeT", statement.where(field.notin_(self.values)))
+
+
+@dataclass
+class NullFilter(StatementFilter):
+    """Filter for NULL values (IS NULL).
+
+    This filter creates IS NULL conditions for database fields.
+    Use this to find records where a field has no value.
+
+    Example:
+        Basic NULL filtering::
+
+            from advanced_alchemy.filters import NullFilter
+
+            # Find records where email_verified_at is NULL
+            null_filter = NullFilter("email_verified_at")
+            unverified = await repo.list(null_filter)
+
+        With multiple filters::
+
+            from advanced_alchemy.filters import (
+                NullFilter,
+                CollectionFilter,
+            )
+
+            # Find unverified users in specific roles
+            filters = [
+                NullFilter("email_verified_at"),
+                CollectionFilter("role", ["admin", "moderator"]),
+            ]
+            results = await repo.list(*filters)
+
+    See Also:
+        - :class:`NotNullFilter`: Filter for NOT NULL values
+        - :class:`CollectionFilter`: Filter by collection membership
+        - :meth:`sqlalchemy.sql.expression.ColumnOperators.is_`: IS NULL operator
+    """
+
+    field_name: "Union[str, ColumnElement[Any], InstrumentedAttribute[Any]]"
+    """Field name, model attribute, or func expression."""
+
+    def append_to_statement(self, statement: StatementTypeT, model: type[ModelT]) -> StatementTypeT:
+        """Apply IS NULL condition to the statement.
+
+        Args:
+            statement: The SQLAlchemy statement to modify
+            model: The SQLAlchemy model class
+
+        Returns:
+            StatementTypeT: Modified statement with IS NULL condition applied
+        """
+        field = self._get_instrumented_attr(model, self.field_name)
+        return cast("StatementTypeT", statement.where(field.is_(None)))
+
+
+@dataclass
+class NotNullFilter(StatementFilter):
+    """Filter for NOT NULL values (IS NOT NULL).
+
+    This filter creates IS NOT NULL conditions for database fields.
+    Use this to find records where a field has a value.
+
+    Example:
+        Basic NOT NULL filtering::
+
+            from advanced_alchemy.filters import NotNullFilter
+
+            # Find records where email_verified_at is NOT NULL
+            not_null_filter = NotNullFilter("email_verified_at")
+            verified = await repo.list(not_null_filter)
+
+        With multiple filters::
+
+            from advanced_alchemy.filters import (
+                NotNullFilter,
+                CollectionFilter,
+            )
+
+            # Find verified users in specific roles
+            filters = [
+                NotNullFilter("email_verified_at"),
+                CollectionFilter("role", ["admin", "moderator"]),
+            ]
+            results = await repo.list(*filters)
+
+    See Also:
+        - :class:`NullFilter`: Filter for NULL values
+        - :class:`CollectionFilter`: Filter by collection membership
+        - :meth:`sqlalchemy.sql.expression.ColumnOperators.is_not`: IS NOT NULL operator
+    """
+
+    field_name: "Union[str, ColumnElement[Any], InstrumentedAttribute[Any]]"
+    """Field name, model attribute, or func expression."""
+
+    def append_to_statement(self, statement: StatementTypeT, model: type[ModelT]) -> StatementTypeT:
+        """Apply IS NOT NULL condition to the statement.
+
+        Args:
+            statement: The SQLAlchemy statement to modify
+            model: The SQLAlchemy model class
+
+        Returns:
+            StatementTypeT: Modified statement with IS NOT NULL condition applied
+        """
+        field = self._get_instrumented_attr(model, self.field_name)
+        return cast("StatementTypeT", statement.where(field.is_not(None)))
 
 
 class PaginationFilter(StatementFilter, ABC):
@@ -1024,6 +1134,8 @@ class MultiFilter(StatementFilter):
         "collection": CollectionFilter,
         "not_in_collection": NotInCollectionFilter,
         "limit_offset": LimitOffset,
+        "null": NullFilter,
+        "not_null": NotNullFilter,
         "order_by": OrderBy,
         "search": SearchFilter,
         "not_in_search": NotInSearchFilter,
@@ -1117,6 +1229,8 @@ FilterTypes: TypeAlias = Union[
     OnBeforeAfter,
     CollectionFilter[Any],
     LimitOffset,
+    NullFilter,
+    NotNullFilter,
     OrderBy,
     SearchFilter,
     NotInCollectionFilter[Any],

--- a/advanced_alchemy/repository/_sync.py
+++ b/advanced_alchemy/repository/_sync.py
@@ -214,6 +214,7 @@ class SQLAlchemySyncRepositoryProtocol(FilterableRepositoryProtocol[ModelT], Pro
         error_messages: Optional[Union[ErrorMessages, EmptyType]] = Empty,
         load: Optional[LoadSpec] = None,
         execution_options: Optional[dict[str, Any]] = None,
+        with_for_update: ForUpdateParameter = None,
         **kwargs: Any,
     ) -> ModelT: ...
 
@@ -225,6 +226,7 @@ class SQLAlchemySyncRepositoryProtocol(FilterableRepositoryProtocol[ModelT], Pro
         error_messages: Optional[Union[ErrorMessages, EmptyType]] = Empty,
         load: Optional[LoadSpec] = None,
         execution_options: Optional[dict[str, Any]] = None,
+        with_for_update: ForUpdateParameter = None,
         **kwargs: Any,
     ) -> Optional[ModelT]: ...
 
@@ -1151,6 +1153,7 @@ class SQLAlchemySyncRepository(SQLAlchemySyncRepositoryProtocol[ModelT], Filtera
         load: Optional[LoadSpec] = None,
         execution_options: Optional[dict[str, Any]] = None,
         uniquify: Optional[bool] = None,
+        with_for_update: ForUpdateParameter = None,
         **kwargs: Any,
     ) -> ModelT:
         """Get instance identified by ``kwargs``.
@@ -1164,6 +1167,7 @@ class SQLAlchemySyncRepository(SQLAlchemySyncRepositoryProtocol[ModelT], Filtera
             load: Set relationships to be loaded
             execution_options: Set default execution options
             uniquify: Optionally apply the ``unique()`` method to results before returning.
+            with_for_update: Optional FOR UPDATE clause / parameters to apply to the SELECT statement.
             **kwargs: Identifier of the instance to be retrieved.
 
         Returns:
@@ -1188,6 +1192,7 @@ class SQLAlchemySyncRepository(SQLAlchemySyncRepositoryProtocol[ModelT], Filtera
             )
             statement = self._apply_filters(*filters, apply_pagination=False, statement=statement)
             statement = self._filter_select_by_kwargs(statement, kwargs)
+            statement = self._apply_for_update_options(statement, with_for_update)
             instance = (self._execute(statement, uniquify=loader_options_have_wildcard)).scalar_one_or_none()
             instance = self.check_not_found(instance)
             self._expunge(instance, auto_expunge=auto_expunge)
@@ -1202,6 +1207,7 @@ class SQLAlchemySyncRepository(SQLAlchemySyncRepositoryProtocol[ModelT], Filtera
         load: Optional[LoadSpec] = None,
         execution_options: Optional[dict[str, Any]] = None,
         uniquify: Optional[bool] = None,
+        with_for_update: ForUpdateParameter = None,
         **kwargs: Any,
     ) -> Union[ModelT, None]:
         """Get instance identified by ``kwargs`` or None if not found.
@@ -1215,6 +1221,7 @@ class SQLAlchemySyncRepository(SQLAlchemySyncRepositoryProtocol[ModelT], Filtera
             load: Set relationships to be loaded
             execution_options: Set default execution options
             uniquify: Optionally apply the ``unique()`` method to results before returning.
+            with_for_update: Optional FOR UPDATE clause / parameters to apply to the SELECT statement.
             **kwargs: Identifier of the instance to be retrieved.
 
         Returns:
@@ -1238,6 +1245,7 @@ class SQLAlchemySyncRepository(SQLAlchemySyncRepositoryProtocol[ModelT], Filtera
             )
             statement = self._apply_filters(*filters, apply_pagination=False, statement=statement)
             statement = self._filter_select_by_kwargs(statement, kwargs)
+            statement = self._apply_for_update_options(statement, with_for_update)
             instance = cast(
                 "Result[tuple[ModelT]]",
                 (self._execute(statement, uniquify=loader_options_have_wildcard)),

--- a/advanced_alchemy/service/_async.py
+++ b/advanced_alchemy/service/_async.py
@@ -303,6 +303,7 @@ class SQLAlchemyAsyncRepositoryReadService(ResultConverter, Generic[ModelT, SQLA
         error_messages: Optional[Union[ErrorMessages, EmptyType]] = Empty,
         execution_options: Optional[dict[str, Any]] = None,
         uniquify: Optional[bool] = None,
+        with_for_update: ForUpdateParameter = None,
         **kwargs: Any,
     ) -> ModelT:
         """Wrap repository scalar operation.
@@ -316,6 +317,7 @@ class SQLAlchemyAsyncRepositoryReadService(ResultConverter, Generic[ModelT, SQLA
             load: Set default relationships to be loaded
             execution_options: Set default execution options
             uniquify: Optionally apply the ``unique()`` method to results before returning.
+            with_for_update: Optional FOR UPDATE clause / parameters to apply to the SELECT statement.
             **kwargs: Identifier of the instance to be retrieved.
 
         Returns:
@@ -331,6 +333,7 @@ class SQLAlchemyAsyncRepositoryReadService(ResultConverter, Generic[ModelT, SQLA
                 load=load,
                 execution_options=execution_options,
                 uniquify=self._get_uniquify(uniquify),
+                with_for_update=with_for_update,
                 **kwargs,
             ),
         )
@@ -344,6 +347,7 @@ class SQLAlchemyAsyncRepositoryReadService(ResultConverter, Generic[ModelT, SQLA
         load: Optional[LoadSpec] = None,
         execution_options: Optional[dict[str, Any]] = None,
         uniquify: Optional[bool] = None,
+        with_for_update: ForUpdateParameter = None,
         **kwargs: Any,
     ) -> Optional[ModelT]:
         """Wrap repository scalar operation.
@@ -357,6 +361,7 @@ class SQLAlchemyAsyncRepositoryReadService(ResultConverter, Generic[ModelT, SQLA
             load: Set default relationships to be loaded
             execution_options: Set default execution options
             uniquify: Optionally apply the ``unique()`` method to results before returning.
+            with_for_update: Optional FOR UPDATE clause / parameters to apply to the SELECT statement.
             **kwargs: Identifier of the instance to be retrieved.
 
         Returns:
@@ -372,6 +377,7 @@ class SQLAlchemyAsyncRepositoryReadService(ResultConverter, Generic[ModelT, SQLA
                 load=load,
                 execution_options=execution_options,
                 uniquify=self._get_uniquify(uniquify),
+                with_for_update=with_for_update,
                 **kwargs,
             ),
         )

--- a/advanced_alchemy/service/_sync.py
+++ b/advanced_alchemy/service/_sync.py
@@ -302,6 +302,7 @@ class SQLAlchemySyncRepositoryReadService(ResultConverter, Generic[ModelT, SQLAl
         error_messages: Optional[Union[ErrorMessages, EmptyType]] = Empty,
         execution_options: Optional[dict[str, Any]] = None,
         uniquify: Optional[bool] = None,
+        with_for_update: ForUpdateParameter = None,
         **kwargs: Any,
     ) -> ModelT:
         """Wrap repository scalar operation.
@@ -315,6 +316,7 @@ class SQLAlchemySyncRepositoryReadService(ResultConverter, Generic[ModelT, SQLAl
             load: Set default relationships to be loaded
             execution_options: Set default execution options
             uniquify: Optionally apply the ``unique()`` method to results before returning.
+            with_for_update: Optional FOR UPDATE clause / parameters to apply to the SELECT statement.
             **kwargs: Identifier of the instance to be retrieved.
 
         Returns:
@@ -330,6 +332,7 @@ class SQLAlchemySyncRepositoryReadService(ResultConverter, Generic[ModelT, SQLAl
                 load=load,
                 execution_options=execution_options,
                 uniquify=self._get_uniquify(uniquify),
+                with_for_update=with_for_update,
                 **kwargs,
             ),
         )
@@ -343,6 +346,7 @@ class SQLAlchemySyncRepositoryReadService(ResultConverter, Generic[ModelT, SQLAl
         load: Optional[LoadSpec] = None,
         execution_options: Optional[dict[str, Any]] = None,
         uniquify: Optional[bool] = None,
+        with_for_update: ForUpdateParameter = None,
         **kwargs: Any,
     ) -> Optional[ModelT]:
         """Wrap repository scalar operation.
@@ -356,6 +360,7 @@ class SQLAlchemySyncRepositoryReadService(ResultConverter, Generic[ModelT, SQLAl
             load: Set default relationships to be loaded
             execution_options: Set default execution options
             uniquify: Optionally apply the ``unique()`` method to results before returning.
+            with_for_update: Optional FOR UPDATE clause / parameters to apply to the SELECT statement.
             **kwargs: Identifier of the instance to be retrieved.
 
         Returns:
@@ -371,6 +376,7 @@ class SQLAlchemySyncRepositoryReadService(ResultConverter, Generic[ModelT, SQLAl
                 load=load,
                 execution_options=execution_options,
                 uniquify=self._get_uniquify(uniquify),
+                with_for_update=with_for_update,
                 **kwargs,
             ),
         )


### PR DESCRIPTION
## Summary

- Add `NullFilter` class for IS NULL conditions (simple, single-purpose design)
- Add `NotNullFilter` class for IS NOT NULL conditions (matches ExistsFilter/NotExistsFilter pattern)
- Add `with_for_update` parameter to `get_one()` and `get_one_or_none()` methods in both repository and service layers for API consistency with `get()`

## Changes

### NullFilter & NotNullFilter (#623)
- New filter classes following the established pattern (like ExistsFilter/NotExistsFilter)
- Added to FilterMap, MultiFilter._filter_map, and FilterTypes
- Comprehensive integration tests with SQLite

### get_one with_for_update (#488)
- Added `with_for_update: ForUpdateParameter = None` to `get_one()` and `get_one_or_none()` 
- Updated protocol/overload signatures
- Updated service layer to pass through the parameter
- Uses existing `_apply_for_update_options()` helper

## Test plan

- [x] All filter tests pass with SQLite
- [x] All repository unit tests pass
- [x] Linting clean (ruff check)
- [x] Type checking clean (mypy)
- [x] Sync files generated correctly (unasyncd)

Closes #488
Closes #623