### PR TITLE
fix: add a call `set_async_context` to `_get_session_from_request` in Sanic extension

### DIFF
--- a/advanced_alchemy/extensions/sanic/extension.py
+++ b/advanced_alchemy/extensions/sanic/extension.py
@@ -198,7 +198,8 @@ class AdvancedAlchemy(Extension):  # type: ignore[no-untyped-call]  # pyright: i
         """
         session = getattr(request.ctx, config.session_key, None)
         if session is None:
-            setattr(request.ctx, config.session_key, config.get_session())
+            session = config.get_session()
+            setattr(request.ctx, config.session_key, session)
         set_async_context(isinstance(session, AsyncSession))
         return cast("Union[Session, AsyncSession]", session)
 

--- a/advanced_alchemy/extensions/sanic/extension.py
+++ b/advanced_alchemy/extensions/sanic/extension.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING, Any, Callable, Optional, Union, cast, overload
 
 from sanic import Request, Sanic
 
+from advanced_alchemy._listeners import set_async_context
 from advanced_alchemy.exceptions import ImproperConfigurationError, MissingDependencyError
 from advanced_alchemy.extensions.sanic.config import SQLAlchemyAsyncConfig, SQLAlchemySyncConfig
 
@@ -197,6 +198,7 @@ class AdvancedAlchemy(Extension):  # type: ignore[no-untyped-call]  # pyright: i
         session = getattr(request.ctx, config.session_key, None)
         if session is None:
             setattr(request.ctx, config.session_key, config.get_session())
+        set_async_context(isinstance(session, AsyncSession))
         return cast("Union[Session, AsyncSession]", session)
 
     def get_session(

--- a/advanced_alchemy/extensions/sanic/extension.py
+++ b/advanced_alchemy/extensions/sanic/extension.py
@@ -3,6 +3,7 @@ from contextlib import asynccontextmanager, contextmanager
 from typing import TYPE_CHECKING, Any, Callable, Optional, Union, cast, overload
 
 from sanic import Request, Sanic
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from advanced_alchemy._listeners import set_async_context
 from advanced_alchemy.exceptions import ImproperConfigurationError, MissingDependencyError
@@ -21,7 +22,7 @@ except ModuleNotFoundError:  # pragma: no cover
 if TYPE_CHECKING:
     from sanic import Sanic
     from sqlalchemy import Engine
-    from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
+    from sqlalchemy.ext.asyncio import AsyncEngine
     from sqlalchemy.orm import Session
 
 


### PR DESCRIPTION
## Description
In other extensions like Starlette we explicitly set async context in method `_get_session_from_request`, however, in Sanic we do not. Even though it's not critical, it seems reasonable to add this line here.

```py
  @staticmethod
  def _get_session_from_request(
      request: Request,
      config: Union[SQLAlchemyAsyncConfig, SQLAlchemySyncConfig],  # pragma: no cover
  ) -> Union["Session", "AsyncSession"]:  # pragma: no cover
      """Get the session for the given key.

      Args:
          request: The request object.
          config: The config object.

      Returns:
          The session for the given key.
      """
      session = getattr(request.state, config.session_key, None)
      if session is None:
          session = config.create_session_maker()()
          setattr(request.state, config.session_key, session)
      set_async_context(isinstance(session, AsyncSession))
      return session
```