### PR TITLE
fix: register session listeners in framework extension configs (#709)

### DIFF
--- a/advanced_alchemy/extensions/flask/config.py
+++ b/advanced_alchemy/extensions/flask/config.py
@@ -169,19 +169,15 @@ class SQLAlchemyAsyncConfig(_SQLAlchemyAsyncConfig):
     def create_session_maker(self) -> "Callable[[], AsyncSession]":
         """Get a session maker. If none exists yet, create one.
 
+        Delegates to the base-class implementation so that listener
+        registration (file-object, timestamp, cache) runs. See issue #709.
+
         Returns:
             Callable[[], AsyncSession]: Session factory used by the plugin.
         """
         if self.session_maker:
             return self.session_maker
-
-        session_kws = self.session_config_dict
-        if self.engine_instance is None:
-            self.engine_instance = self.get_engine()
-        if session_kws.get("bind") is None:
-            session_kws["bind"] = self.engine_instance
-        self.session_maker = self.session_maker_class(**session_kws)
-        return self.session_maker
+        return super().create_session_maker()
 
     def init_app(self, app: "Flask", portal: "Optional[Portal]" = None) -> None:
         """Initialize the Flask application with this configuration.

--- a/advanced_alchemy/extensions/flask/config.py
+++ b/advanced_alchemy/extensions/flask/config.py
@@ -84,19 +84,15 @@ class SQLAlchemySyncConfig(_SQLAlchemySyncConfig):
     def create_session_maker(self) -> "Callable[[], Session]":
         """Get a session maker. If none exists yet, create one.
 
+        Delegates to the base-class implementation so that listener
+        registration (file-object, timestamp, cache) runs. See issue #709.
+
         Returns:
             Callable[[], Session]: Session factory used by the plugin.
         """
         if self.session_maker:
             return self.session_maker
-
-        session_kws = self.session_config_dict
-        if self.engine_instance is None:
-            self.engine_instance = self.get_engine()
-        if session_kws.get("bind") is None:
-            session_kws["bind"] = self.engine_instance
-        self.session_maker = self.session_maker_class(**session_kws)
-        return self.session_maker
+        return super().create_session_maker()
 
     def init_app(self, app: "Flask", portal: "Optional[Portal]" = None) -> None:
         """Initialize the Flask application with this configuration.

--- a/advanced_alchemy/extensions/flask/config.py
+++ b/advanced_alchemy/extensions/flask/config.py
@@ -84,14 +84,17 @@ class SQLAlchemySyncConfig(_SQLAlchemySyncConfig):
     def create_session_maker(self) -> "Callable[[], Session]":
         """Get a session maker. If none exists yet, create one.
 
-        Delegates to the base-class implementation so that listener
-        registration (file-object, timestamp, cache) runs. See issue #709.
+        Preserves ``engine_instance`` caching and then delegates to the
+        base-class implementation so that listener registration runs.
+        See issue #709.
 
         Returns:
             Callable[[], Session]: Session factory used by the plugin.
         """
         if self.session_maker:
             return self.session_maker
+        if self.engine_instance is None:
+            self.engine_instance = self.get_engine()
         return super().create_session_maker()
 
     def init_app(self, app: "Flask", portal: "Optional[Portal]" = None) -> None:
@@ -169,14 +172,17 @@ class SQLAlchemyAsyncConfig(_SQLAlchemyAsyncConfig):
     def create_session_maker(self) -> "Callable[[], AsyncSession]":
         """Get a session maker. If none exists yet, create one.
 
-        Delegates to the base-class implementation so that listener
-        registration (file-object, timestamp, cache) runs. See issue #709.
+        Preserves ``engine_instance`` caching and then delegates to the
+        base-class implementation so that listener registration runs.
+        See issue #709.
 
         Returns:
             Callable[[], AsyncSession]: Session factory used by the plugin.
         """
         if self.session_maker:
             return self.session_maker
+        if self.engine_instance is None:
+            self.engine_instance = self.get_engine()
         return super().create_session_maker()
 
     def init_app(self, app: "Flask", portal: "Optional[Portal]" = None) -> None:

--- a/advanced_alchemy/extensions/litestar/plugins/init/config/asyncio.py
+++ b/advanced_alchemy/extensions/litestar/plugins/init/config/asyncio.py
@@ -201,16 +201,15 @@ class SQLAlchemyAsyncConfig(_SQLAlchemyAsyncConfig):
     def create_session_maker(self) -> "Callable[[], AsyncSession]":
         """Get a session maker. If none exists yet, create one.
 
+        Delegates to the base-class implementation so that listener
+        registration (file-object, timestamp, cache) runs. See issue #709.
+
         Returns:
             Session factory used by the plugin.
         """
         if self.session_maker:
             return self.session_maker
-
-        session_kws = self.session_config_dict
-        if session_kws.get("bind") is None:
-            session_kws["bind"] = self.get_engine()
-        return self.session_maker_class(**session_kws)  # pyright: ignore[reportUnknownVariableType,reportUnknownMemberType]
+        return super().create_session_maker()
 
     @asynccontextmanager
     async def lifespan(

--- a/advanced_alchemy/extensions/litestar/plugins/init/config/sync.py
+++ b/advanced_alchemy/extensions/litestar/plugins/init/config/sync.py
@@ -202,16 +202,15 @@ class SQLAlchemySyncConfig(_SQLAlchemySyncConfig):
     def create_session_maker(self) -> "Callable[[], Session]":
         """Get a session maker. If none exists yet, create one.
 
+        Delegates to the base-class implementation so that listener
+        registration (file-object, timestamp, cache) runs. See issue #709.
+
         Returns:
             Session factory used by the plugin.
         """
         if self.session_maker:
             return self.session_maker
-
-        session_kws = self.session_config_dict
-        if session_kws.get("bind") is None:
-            session_kws["bind"] = self.get_engine()
-        return self.session_maker_class(**session_kws)
+        return super().create_session_maker()
 
     @asynccontextmanager
     async def lifespan(

--- a/advanced_alchemy/extensions/sanic/config.py
+++ b/advanced_alchemy/extensions/sanic/config.py
@@ -422,19 +422,15 @@ class SQLAlchemySyncConfig(_SQLAlchemySyncConfig):
     def create_session_maker(self) -> Callable[[], "Session"]:
         """Get a session maker. If none exists yet, create one.
 
+        Delegates to the base-class implementation so that listener
+        registration (file-object, timestamp, cache) runs. See issue #709.
+
         Returns:
             Callable[[], Session]: Session factory used by the plugin.
         """
         if self.session_maker:
             return self.session_maker
-
-        session_kws = self.session_config_dict
-        if self.engine_instance is None:
-            self.engine_instance = self.get_engine()
-        if session_kws.get("bind") is None:
-            session_kws["bind"] = self.engine_instance
-        self.session_maker = self.session_maker_class(**session_kws)
-        return self.session_maker
+        return super().create_session_maker()
 
     async def session_handler(
         self, session: "Session", request: "Request", response: "HTTPResponse"

--- a/advanced_alchemy/extensions/sanic/config.py
+++ b/advanced_alchemy/extensions/sanic/config.py
@@ -213,14 +213,17 @@ class SQLAlchemyAsyncConfig(_SQLAlchemyAsyncConfig):
     def create_session_maker(self) -> Callable[[], "AsyncSession"]:
         """Get a session maker. If none exists yet, create one.
 
-        Delegates to the base-class implementation so that listener
-        registration (file-object, timestamp, cache) runs. See issue #709.
+        Preserves ``engine_instance`` caching and then delegates to the
+        base-class implementation so that listener registration
+        (file-object, timestamp, cache) runs. See issue #709.
 
         Returns:
             Callable[[], Session]: Session factory used by the plugin.
         """
         if self.session_maker:
             return self.session_maker
+        if self.engine_instance is None:
+            self.engine_instance = self.get_engine()
         return super().create_session_maker()
 
     async def session_handler(
@@ -422,14 +425,17 @@ class SQLAlchemySyncConfig(_SQLAlchemySyncConfig):
     def create_session_maker(self) -> Callable[[], "Session"]:
         """Get a session maker. If none exists yet, create one.
 
-        Delegates to the base-class implementation so that listener
-        registration (file-object, timestamp, cache) runs. See issue #709.
+        Preserves ``engine_instance`` caching and then delegates to the
+        base-class implementation so that listener registration runs.
+        See issue #709.
 
         Returns:
             Callable[[], Session]: Session factory used by the plugin.
         """
         if self.session_maker:
             return self.session_maker
+        if self.engine_instance is None:
+            self.engine_instance = self.get_engine()
         return super().create_session_maker()
 
     async def session_handler(

--- a/advanced_alchemy/extensions/sanic/config.py
+++ b/advanced_alchemy/extensions/sanic/config.py
@@ -213,19 +213,15 @@ class SQLAlchemyAsyncConfig(_SQLAlchemyAsyncConfig):
     def create_session_maker(self) -> Callable[[], "AsyncSession"]:
         """Get a session maker. If none exists yet, create one.
 
+        Delegates to the base-class implementation so that listener
+        registration (file-object, timestamp, cache) runs. See issue #709.
+
         Returns:
             Callable[[], Session]: Session factory used by the plugin.
         """
         if self.session_maker:
             return self.session_maker
-
-        session_kws = self.session_config_dict
-        if self.engine_instance is None:
-            self.engine_instance = self.get_engine()
-        if session_kws.get("bind") is None:
-            session_kws["bind"] = self.engine_instance
-        self.session_maker = self.session_maker_class(**session_kws)
-        return self.session_maker
+        return super().create_session_maker()
 
     async def session_handler(
         self, session: "AsyncSession", request: "Request", response: "HTTPResponse"

--- a/advanced_alchemy/extensions/starlette/config.py
+++ b/advanced_alchemy/extensions/starlette/config.py
@@ -245,14 +245,17 @@ class SQLAlchemyAsyncConfig(_SQLAlchemyAsyncConfig):
     def create_session_maker(self) -> Callable[[], "AsyncSession"]:
         """Get a session maker. If none exists yet, create one.
 
-        Delegates to the base-class implementation so that listener
-        registration (file-object, timestamp, cache) runs. See issue #709.
+        Preserves ``engine_instance`` caching and then delegates to the
+        base-class implementation so that listener registration
+        (file-object, timestamp, cache) runs. See issue #709.
 
         Returns:
             Callable[[], Session]: Session factory used by the plugin.
         """
         if self.session_maker:
             return self.session_maker
+        if self.engine_instance is None:
+            self.engine_instance = self.get_engine()
         return super().create_session_maker()
 
     async def session_handler(
@@ -404,14 +407,17 @@ class SQLAlchemySyncConfig(_SQLAlchemySyncConfig):
     def create_session_maker(self) -> Callable[[], "Session"]:
         """Get a session maker. If none exists yet, create one.
 
-        Delegates to the base-class implementation so that listener
-        registration (file-object, timestamp, cache) runs. See issue #709.
+        Preserves ``engine_instance`` caching and then delegates to the
+        base-class implementation so that listener registration runs.
+        See issue #709.
 
         Returns:
             Callable[[], Session]: Session factory used by the plugin.
         """
         if self.session_maker:
             return self.session_maker
+        if self.engine_instance is None:
+            self.engine_instance = self.get_engine()
         return super().create_session_maker()
 
     async def session_handler(

--- a/advanced_alchemy/extensions/starlette/config.py
+++ b/advanced_alchemy/extensions/starlette/config.py
@@ -245,19 +245,15 @@ class SQLAlchemyAsyncConfig(_SQLAlchemyAsyncConfig):
     def create_session_maker(self) -> Callable[[], "AsyncSession"]:
         """Get a session maker. If none exists yet, create one.
 
+        Delegates to the base-class implementation so that listener
+        registration (file-object, timestamp, cache) runs. See issue #709.
+
         Returns:
             Callable[[], Session]: Session factory used by the plugin.
         """
         if self.session_maker:
             return self.session_maker
-
-        session_kws = self.session_config_dict
-        if self.engine_instance is None:
-            self.engine_instance = self.get_engine()
-        if session_kws.get("bind") is None:
-            session_kws["bind"] = self.engine_instance
-        self.session_maker = self.session_maker_class(**session_kws)
-        return self.session_maker
+        return super().create_session_maker()
 
     async def session_handler(
         self, session: "AsyncSession", request: "Request", response: "Response"

--- a/advanced_alchemy/extensions/starlette/config.py
+++ b/advanced_alchemy/extensions/starlette/config.py
@@ -404,19 +404,15 @@ class SQLAlchemySyncConfig(_SQLAlchemySyncConfig):
     def create_session_maker(self) -> Callable[[], "Session"]:
         """Get a session maker. If none exists yet, create one.
 
+        Delegates to the base-class implementation so that listener
+        registration (file-object, timestamp, cache) runs. See issue #709.
+
         Returns:
             Callable[[], Session]: Session factory used by the plugin.
         """
         if self.session_maker:
             return self.session_maker
-
-        session_kws = self.session_config_dict
-        if self.engine_instance is None:
-            self.engine_instance = self.get_engine()
-        if session_kws.get("bind") is None:
-            session_kws["bind"] = self.engine_instance
-        self.session_maker = self.session_maker_class(**session_kws)
-        return self.session_maker
+        return super().create_session_maker()
 
     async def session_handler(
         self, session: "Session", request: "Request", response: "Response"

--- a/tests/unit/test_extensions/test_flask_listeners.py
+++ b/tests/unit/test_extensions/test_flask_listeners.py
@@ -1,0 +1,146 @@
+"""Unit tests for Flask SQLAlchemy config listener registration.
+
+Regression tests for https://github.com/litestar-org/advanced-alchemy/issues/709.
+Both Flask async and sync configs override create_session_maker without
+delegating to super(), silently dropping the listener registration performed
+by the base class. These tests lock the contract per subclass.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from sqlalchemy.ext.asyncio import async_sessionmaker
+from sqlalchemy.orm import sessionmaker
+
+from advanced_alchemy.config.common import GenericSQLAlchemyConfig
+from advanced_alchemy.extensions.flask.config import (
+    SQLAlchemyAsyncConfig,
+    SQLAlchemySyncConfig,
+)
+
+
+# --- Async ---
+
+
+def test_async_create_session_maker_registers_all_listeners() -> None:
+    mock_session_maker = MagicMock(spec=async_sessionmaker)
+    config = SQLAlchemyAsyncConfig(connection_string="sqlite+aiosqlite:///")
+
+    with (
+        patch.object(
+            GenericSQLAlchemyConfig,
+            "create_session_maker",
+            return_value=mock_session_maker,
+        ),
+        patch("sqlalchemy.event.listen") as mock_listen,
+        patch("advanced_alchemy.config.asyncio.sync_sessionmaker") as mock_sync_factory,
+    ):
+        mock_sync_maker = MagicMock()
+        mock_sync_factory.return_value = mock_sync_maker
+        result = config.create_session_maker()
+
+    assert result is mock_session_maker
+    assert mock_listen.call_count == 6
+    mock_session_maker.configure.assert_called_once_with(sync_session_class=mock_sync_maker)
+
+
+def test_async_create_session_maker_file_object_listener_disabled() -> None:
+    mock_session_maker = MagicMock(spec=async_sessionmaker)
+    config = SQLAlchemyAsyncConfig(
+        connection_string="sqlite+aiosqlite:///",
+        enable_file_object_listener=False,
+    )
+
+    with (
+        patch.object(
+            GenericSQLAlchemyConfig,
+            "create_session_maker",
+            return_value=mock_session_maker,
+        ),
+        patch("sqlalchemy.event.listen") as mock_listen,
+        patch("advanced_alchemy.config.asyncio.sync_sessionmaker"),
+    ):
+        config.create_session_maker()
+
+    assert mock_listen.call_count == 3
+
+
+def test_async_create_session_maker_timestamp_listener_disabled() -> None:
+    mock_session_maker = MagicMock(spec=async_sessionmaker)
+    config = SQLAlchemyAsyncConfig(
+        connection_string="sqlite+aiosqlite:///",
+        enable_touch_updated_timestamp_listener=False,
+    )
+
+    with (
+        patch.object(
+            GenericSQLAlchemyConfig,
+            "create_session_maker",
+            return_value=mock_session_maker,
+        ),
+        patch("sqlalchemy.event.listen") as mock_listen,
+        patch("advanced_alchemy.config.asyncio.sync_sessionmaker"),
+    ):
+        config.create_session_maker()
+
+    assert mock_listen.call_count == 5
+
+
+# --- Sync ---
+
+
+def test_sync_create_session_maker_registers_all_listeners() -> None:
+    mock_session_maker = MagicMock(spec=sessionmaker)
+    config = SQLAlchemySyncConfig(connection_string="sqlite:///")
+
+    with (
+        patch.object(
+            GenericSQLAlchemyConfig,
+            "create_session_maker",
+            return_value=mock_session_maker,
+        ),
+        patch("sqlalchemy.event.listen") as mock_listen,
+    ):
+        result = config.create_session_maker()
+
+    assert result is mock_session_maker
+    assert mock_listen.call_count == 6
+
+
+def test_sync_create_session_maker_file_object_listener_disabled() -> None:
+    mock_session_maker = MagicMock(spec=sessionmaker)
+    config = SQLAlchemySyncConfig(
+        connection_string="sqlite:///",
+        enable_file_object_listener=False,
+    )
+
+    with (
+        patch.object(
+            GenericSQLAlchemyConfig,
+            "create_session_maker",
+            return_value=mock_session_maker,
+        ),
+        patch("sqlalchemy.event.listen") as mock_listen,
+    ):
+        config.create_session_maker()
+
+    assert mock_listen.call_count == 3
+
+
+def test_sync_create_session_maker_timestamp_listener_disabled() -> None:
+    mock_session_maker = MagicMock(spec=sessionmaker)
+    config = SQLAlchemySyncConfig(
+        connection_string="sqlite:///",
+        enable_touch_updated_timestamp_listener=False,
+    )
+
+    with (
+        patch.object(
+            GenericSQLAlchemyConfig,
+            "create_session_maker",
+            return_value=mock_session_maker,
+        ),
+        patch("sqlalchemy.event.listen") as mock_listen,
+    ):
+        config.create_session_maker()
+
+    assert mock_listen.call_count == 5

--- a/tests/unit/test_extensions/test_flask_listeners.py
+++ b/tests/unit/test_extensions/test_flask_listeners.py
@@ -42,6 +42,10 @@ def test_async_create_session_maker_registers_all_listeners() -> None:
     assert result is mock_session_maker
     assert mock_listen.call_count == 6
     mock_session_maker.configure.assert_called_once_with(sync_session_class=mock_sync_maker)
+    for call in mock_listen.call_args_list:
+        assert call.args[0] is mock_sync_maker
+    listener_events = {c.args[1] for c in mock_listen.call_args_list}
+    assert {"before_flush", "after_commit", "after_rollback"} <= listener_events
 
 
 def test_async_create_session_maker_file_object_listener_disabled() -> None:

--- a/tests/unit/test_extensions/test_flask_listeners.py
+++ b/tests/unit/test_extensions/test_flask_listeners.py
@@ -24,6 +24,7 @@ from advanced_alchemy.extensions.flask.config import (
 def test_async_create_session_maker_registers_all_listeners() -> None:
     mock_session_maker = MagicMock(spec=async_sessionmaker)
     config = SQLAlchemyAsyncConfig(connection_string="sqlite+aiosqlite:///")
+    config.engine_instance = MagicMock()
 
     with (
         patch.object(
@@ -49,6 +50,7 @@ def test_async_create_session_maker_file_object_listener_disabled() -> None:
         connection_string="sqlite+aiosqlite:///",
         enable_file_object_listener=False,
     )
+    config.engine_instance = MagicMock()
 
     with (
         patch.object(
@@ -70,6 +72,7 @@ def test_async_create_session_maker_timestamp_listener_disabled() -> None:
         connection_string="sqlite+aiosqlite:///",
         enable_touch_updated_timestamp_listener=False,
     )
+    config.engine_instance = MagicMock()
 
     with (
         patch.object(
@@ -91,6 +94,7 @@ def test_async_create_session_maker_timestamp_listener_disabled() -> None:
 def test_sync_create_session_maker_registers_all_listeners() -> None:
     mock_session_maker = MagicMock(spec=sessionmaker)
     config = SQLAlchemySyncConfig(connection_string="sqlite:///")
+    config.engine_instance = MagicMock()
 
     with (
         patch.object(
@@ -112,6 +116,7 @@ def test_sync_create_session_maker_file_object_listener_disabled() -> None:
         connection_string="sqlite:///",
         enable_file_object_listener=False,
     )
+    config.engine_instance = MagicMock()
 
     with (
         patch.object(
@@ -132,6 +137,7 @@ def test_sync_create_session_maker_timestamp_listener_disabled() -> None:
         connection_string="sqlite:///",
         enable_touch_updated_timestamp_listener=False,
     )
+    config.engine_instance = MagicMock()
 
     with (
         patch.object(

--- a/tests/unit/test_extensions/test_litestar/test_init_plugin/test_asyncio_listeners.py
+++ b/tests/unit/test_extensions/test_litestar/test_init_plugin/test_asyncio_listeners.py
@@ -1,0 +1,88 @@
+"""Unit tests for Litestar SQLAlchemyAsyncConfig listener registration.
+
+Regression tests for https://github.com/litestar-org/advanced-alchemy/issues/709.
+The Litestar subclass of SQLAlchemyAsyncConfig must register the base-class
+listener set (file-object, timestamp, cache) when create_session_maker() is
+called. Previously the subclass overrode create_session_maker without
+delegating to super() and silently dropped every listener.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from sqlalchemy.ext.asyncio import async_sessionmaker
+
+from advanced_alchemy.config.common import GenericSQLAlchemyConfig
+from advanced_alchemy.extensions.litestar.plugins.init.config.asyncio import (
+    SQLAlchemyAsyncConfig,
+)
+
+
+def test_create_session_maker_registers_all_listeners() -> None:
+    """Default config registers 6 listeners on the synthetic sync_maker."""
+    mock_session_maker = MagicMock(spec=async_sessionmaker)
+    config = SQLAlchemyAsyncConfig(connection_string="sqlite+aiosqlite:///")
+
+    with (
+        patch.object(
+            GenericSQLAlchemyConfig,
+            "create_session_maker",
+            return_value=mock_session_maker,
+        ),
+        patch("sqlalchemy.event.listen") as mock_listen,
+        patch("advanced_alchemy.config.asyncio.sync_sessionmaker") as mock_sync_factory,
+    ):
+        mock_sync_maker = MagicMock()
+        mock_sync_factory.return_value = mock_sync_maker
+        result = config.create_session_maker()
+
+    assert result is mock_session_maker
+    assert mock_listen.call_count == 6
+    mock_session_maker.configure.assert_called_once_with(sync_session_class=mock_sync_maker)
+    for call in mock_listen.call_args_list:
+        assert call.args[0] is mock_sync_maker
+    listener_events = {c.args[1] for c in mock_listen.call_args_list}
+    assert {"before_flush", "after_commit", "after_rollback"} <= listener_events
+
+
+def test_create_session_maker_file_object_listener_disabled() -> None:
+    """With file-object listener disabled, only timestamp + cache listeners register (3)."""
+    mock_session_maker = MagicMock(spec=async_sessionmaker)
+    config = SQLAlchemyAsyncConfig(
+        connection_string="sqlite+aiosqlite:///",
+        enable_file_object_listener=False,
+    )
+
+    with (
+        patch.object(
+            GenericSQLAlchemyConfig,
+            "create_session_maker",
+            return_value=mock_session_maker,
+        ),
+        patch("sqlalchemy.event.listen") as mock_listen,
+        patch("advanced_alchemy.config.asyncio.sync_sessionmaker"),
+    ):
+        config.create_session_maker()
+
+    assert mock_listen.call_count == 3
+
+
+def test_create_session_maker_timestamp_listener_disabled() -> None:
+    """With timestamp listener disabled, only file-object + cache listeners register (5)."""
+    mock_session_maker = MagicMock(spec=async_sessionmaker)
+    config = SQLAlchemyAsyncConfig(
+        connection_string="sqlite+aiosqlite:///",
+        enable_touch_updated_timestamp_listener=False,
+    )
+
+    with (
+        patch.object(
+            GenericSQLAlchemyConfig,
+            "create_session_maker",
+            return_value=mock_session_maker,
+        ),
+        patch("sqlalchemy.event.listen") as mock_listen,
+        patch("advanced_alchemy.config.asyncio.sync_sessionmaker"),
+    ):
+        config.create_session_maker()
+
+    assert mock_listen.call_count == 5

--- a/tests/unit/test_extensions/test_litestar/test_init_plugin/test_sync_listeners.py
+++ b/tests/unit/test_extensions/test_litestar/test_init_plugin/test_sync_listeners.py
@@ -1,0 +1,80 @@
+"""Unit tests for Litestar SQLAlchemySyncConfig listener registration.
+
+Regression tests for https://github.com/litestar-org/advanced-alchemy/issues/709.
+Sync variant: listeners are attached directly to the session_maker, not to a
+synthetic sync_maker, so there is no sync_sessionmaker patch.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from sqlalchemy.orm import sessionmaker
+
+from advanced_alchemy.config.common import GenericSQLAlchemyConfig
+from advanced_alchemy.extensions.litestar.plugins.init.config.sync import (
+    SQLAlchemySyncConfig,
+)
+
+
+def test_create_session_maker_registers_all_listeners() -> None:
+    """Default config registers 6 listeners directly on the session_maker."""
+    mock_session_maker = MagicMock(spec=sessionmaker)
+    config = SQLAlchemySyncConfig(connection_string="sqlite:///")
+
+    with (
+        patch.object(
+            GenericSQLAlchemyConfig,
+            "create_session_maker",
+            return_value=mock_session_maker,
+        ),
+        patch("sqlalchemy.event.listen") as mock_listen,
+    ):
+        result = config.create_session_maker()
+
+    assert result is mock_session_maker
+    assert mock_listen.call_count == 6
+    for call in mock_listen.call_args_list:
+        assert call.args[0] is mock_session_maker
+    listener_events = {c.args[1] for c in mock_listen.call_args_list}
+    assert {"before_flush", "after_commit", "after_rollback"} <= listener_events
+
+
+def test_create_session_maker_file_object_listener_disabled() -> None:
+    """With file-object listener disabled, only timestamp + cache listeners register (3)."""
+    mock_session_maker = MagicMock(spec=sessionmaker)
+    config = SQLAlchemySyncConfig(
+        connection_string="sqlite:///",
+        enable_file_object_listener=False,
+    )
+
+    with (
+        patch.object(
+            GenericSQLAlchemyConfig,
+            "create_session_maker",
+            return_value=mock_session_maker,
+        ),
+        patch("sqlalchemy.event.listen") as mock_listen,
+    ):
+        config.create_session_maker()
+
+    assert mock_listen.call_count == 3
+
+
+def test_create_session_maker_timestamp_listener_disabled() -> None:
+    """With timestamp listener disabled, only file-object + cache listeners register (5)."""
+    mock_session_maker = MagicMock(spec=sessionmaker)
+    config = SQLAlchemySyncConfig(
+        connection_string="sqlite:///",
+        enable_touch_updated_timestamp_listener=False,
+    )
+
+    with (
+        patch.object(
+            GenericSQLAlchemyConfig,
+            "create_session_maker",
+            return_value=mock_session_maker,
+        ),
+        patch("sqlalchemy.event.listen") as mock_listen,
+    ):
+        config.create_session_maker()
+
+    assert mock_listen.call_count == 5

--- a/tests/unit/test_extensions/test_sanic_listeners.py
+++ b/tests/unit/test_extensions/test_sanic_listeners.py
@@ -42,6 +42,10 @@ def test_async_create_session_maker_registers_all_listeners() -> None:
     assert result is mock_session_maker
     assert mock_listen.call_count == 6
     mock_session_maker.configure.assert_called_once_with(sync_session_class=mock_sync_maker)
+    for call in mock_listen.call_args_list:
+        assert call.args[0] is mock_sync_maker
+    listener_events = {c.args[1] for c in mock_listen.call_args_list}
+    assert {"before_flush", "after_commit", "after_rollback"} <= listener_events
 
 
 def test_async_create_session_maker_file_object_listener_disabled() -> None:

--- a/tests/unit/test_extensions/test_sanic_listeners.py
+++ b/tests/unit/test_extensions/test_sanic_listeners.py
@@ -24,6 +24,7 @@ from advanced_alchemy.extensions.sanic.config import (
 def test_async_create_session_maker_registers_all_listeners() -> None:
     mock_session_maker = MagicMock(spec=async_sessionmaker)
     config = SQLAlchemyAsyncConfig(connection_string="sqlite+aiosqlite:///")
+    config.engine_instance = MagicMock()
 
     with (
         patch.object(
@@ -49,6 +50,7 @@ def test_async_create_session_maker_file_object_listener_disabled() -> None:
         connection_string="sqlite+aiosqlite:///",
         enable_file_object_listener=False,
     )
+    config.engine_instance = MagicMock()
 
     with (
         patch.object(
@@ -70,6 +72,7 @@ def test_async_create_session_maker_timestamp_listener_disabled() -> None:
         connection_string="sqlite+aiosqlite:///",
         enable_touch_updated_timestamp_listener=False,
     )
+    config.engine_instance = MagicMock()
 
     with (
         patch.object(
@@ -91,6 +94,7 @@ def test_async_create_session_maker_timestamp_listener_disabled() -> None:
 def test_sync_create_session_maker_registers_all_listeners() -> None:
     mock_session_maker = MagicMock(spec=sessionmaker)
     config = SQLAlchemySyncConfig(connection_string="sqlite:///")
+    config.engine_instance = MagicMock()
 
     with (
         patch.object(
@@ -112,6 +116,7 @@ def test_sync_create_session_maker_file_object_listener_disabled() -> None:
         connection_string="sqlite:///",
         enable_file_object_listener=False,
     )
+    config.engine_instance = MagicMock()
 
     with (
         patch.object(
@@ -132,6 +137,7 @@ def test_sync_create_session_maker_timestamp_listener_disabled() -> None:
         connection_string="sqlite:///",
         enable_touch_updated_timestamp_listener=False,
     )
+    config.engine_instance = MagicMock()
 
     with (
         patch.object(

--- a/tests/unit/test_extensions/test_sanic_listeners.py
+++ b/tests/unit/test_extensions/test_sanic_listeners.py
@@ -1,0 +1,146 @@
+"""Unit tests for Sanic SQLAlchemy config listener registration.
+
+Regression tests for https://github.com/litestar-org/advanced-alchemy/issues/709.
+Both Sanic async and sync configs override create_session_maker without
+delegating to super(), silently dropping the listener registration performed
+by the base class. These tests lock the contract per subclass.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from sqlalchemy.ext.asyncio import async_sessionmaker
+from sqlalchemy.orm import sessionmaker
+
+from advanced_alchemy.config.common import GenericSQLAlchemyConfig
+from advanced_alchemy.extensions.sanic.config import (
+    SQLAlchemyAsyncConfig,
+    SQLAlchemySyncConfig,
+)
+
+
+# --- Async ---
+
+
+def test_async_create_session_maker_registers_all_listeners() -> None:
+    mock_session_maker = MagicMock(spec=async_sessionmaker)
+    config = SQLAlchemyAsyncConfig(connection_string="sqlite+aiosqlite:///")
+
+    with (
+        patch.object(
+            GenericSQLAlchemyConfig,
+            "create_session_maker",
+            return_value=mock_session_maker,
+        ),
+        patch("sqlalchemy.event.listen") as mock_listen,
+        patch("advanced_alchemy.config.asyncio.sync_sessionmaker") as mock_sync_factory,
+    ):
+        mock_sync_maker = MagicMock()
+        mock_sync_factory.return_value = mock_sync_maker
+        result = config.create_session_maker()
+
+    assert result is mock_session_maker
+    assert mock_listen.call_count == 6
+    mock_session_maker.configure.assert_called_once_with(sync_session_class=mock_sync_maker)
+
+
+def test_async_create_session_maker_file_object_listener_disabled() -> None:
+    mock_session_maker = MagicMock(spec=async_sessionmaker)
+    config = SQLAlchemyAsyncConfig(
+        connection_string="sqlite+aiosqlite:///",
+        enable_file_object_listener=False,
+    )
+
+    with (
+        patch.object(
+            GenericSQLAlchemyConfig,
+            "create_session_maker",
+            return_value=mock_session_maker,
+        ),
+        patch("sqlalchemy.event.listen") as mock_listen,
+        patch("advanced_alchemy.config.asyncio.sync_sessionmaker"),
+    ):
+        config.create_session_maker()
+
+    assert mock_listen.call_count == 3
+
+
+def test_async_create_session_maker_timestamp_listener_disabled() -> None:
+    mock_session_maker = MagicMock(spec=async_sessionmaker)
+    config = SQLAlchemyAsyncConfig(
+        connection_string="sqlite+aiosqlite:///",
+        enable_touch_updated_timestamp_listener=False,
+    )
+
+    with (
+        patch.object(
+            GenericSQLAlchemyConfig,
+            "create_session_maker",
+            return_value=mock_session_maker,
+        ),
+        patch("sqlalchemy.event.listen") as mock_listen,
+        patch("advanced_alchemy.config.asyncio.sync_sessionmaker"),
+    ):
+        config.create_session_maker()
+
+    assert mock_listen.call_count == 5
+
+
+# --- Sync ---
+
+
+def test_sync_create_session_maker_registers_all_listeners() -> None:
+    mock_session_maker = MagicMock(spec=sessionmaker)
+    config = SQLAlchemySyncConfig(connection_string="sqlite:///")
+
+    with (
+        patch.object(
+            GenericSQLAlchemyConfig,
+            "create_session_maker",
+            return_value=mock_session_maker,
+        ),
+        patch("sqlalchemy.event.listen") as mock_listen,
+    ):
+        result = config.create_session_maker()
+
+    assert result is mock_session_maker
+    assert mock_listen.call_count == 6
+
+
+def test_sync_create_session_maker_file_object_listener_disabled() -> None:
+    mock_session_maker = MagicMock(spec=sessionmaker)
+    config = SQLAlchemySyncConfig(
+        connection_string="sqlite:///",
+        enable_file_object_listener=False,
+    )
+
+    with (
+        patch.object(
+            GenericSQLAlchemyConfig,
+            "create_session_maker",
+            return_value=mock_session_maker,
+        ),
+        patch("sqlalchemy.event.listen") as mock_listen,
+    ):
+        config.create_session_maker()
+
+    assert mock_listen.call_count == 3
+
+
+def test_sync_create_session_maker_timestamp_listener_disabled() -> None:
+    mock_session_maker = MagicMock(spec=sessionmaker)
+    config = SQLAlchemySyncConfig(
+        connection_string="sqlite:///",
+        enable_touch_updated_timestamp_listener=False,
+    )
+
+    with (
+        patch.object(
+            GenericSQLAlchemyConfig,
+            "create_session_maker",
+            return_value=mock_session_maker,
+        ),
+        patch("sqlalchemy.event.listen") as mock_listen,
+    ):
+        config.create_session_maker()
+
+    assert mock_listen.call_count == 5

--- a/tests/unit/test_extensions/test_starlette_listeners.py
+++ b/tests/unit/test_extensions/test_starlette_listeners.py
@@ -24,6 +24,7 @@ from advanced_alchemy.extensions.starlette.config import (
 def test_async_create_session_maker_registers_all_listeners() -> None:
     mock_session_maker = MagicMock(spec=async_sessionmaker)
     config = SQLAlchemyAsyncConfig(connection_string="sqlite+aiosqlite:///")
+    config.engine_instance = MagicMock()
 
     with (
         patch.object(
@@ -49,6 +50,7 @@ def test_async_create_session_maker_file_object_listener_disabled() -> None:
         connection_string="sqlite+aiosqlite:///",
         enable_file_object_listener=False,
     )
+    config.engine_instance = MagicMock()
 
     with (
         patch.object(
@@ -70,6 +72,7 @@ def test_async_create_session_maker_timestamp_listener_disabled() -> None:
         connection_string="sqlite+aiosqlite:///",
         enable_touch_updated_timestamp_listener=False,
     )
+    config.engine_instance = MagicMock()
 
     with (
         patch.object(
@@ -91,6 +94,7 @@ def test_async_create_session_maker_timestamp_listener_disabled() -> None:
 def test_sync_create_session_maker_registers_all_listeners() -> None:
     mock_session_maker = MagicMock(spec=sessionmaker)
     config = SQLAlchemySyncConfig(connection_string="sqlite:///")
+    config.engine_instance = MagicMock()
 
     with (
         patch.object(
@@ -112,6 +116,7 @@ def test_sync_create_session_maker_file_object_listener_disabled() -> None:
         connection_string="sqlite:///",
         enable_file_object_listener=False,
     )
+    config.engine_instance = MagicMock()
 
     with (
         patch.object(
@@ -132,6 +137,7 @@ def test_sync_create_session_maker_timestamp_listener_disabled() -> None:
         connection_string="sqlite:///",
         enable_touch_updated_timestamp_listener=False,
     )
+    config.engine_instance = MagicMock()
 
     with (
         patch.object(

--- a/tests/unit/test_extensions/test_starlette_listeners.py
+++ b/tests/unit/test_extensions/test_starlette_listeners.py
@@ -42,6 +42,10 @@ def test_async_create_session_maker_registers_all_listeners() -> None:
     assert result is mock_session_maker
     assert mock_listen.call_count == 6
     mock_session_maker.configure.assert_called_once_with(sync_session_class=mock_sync_maker)
+    for call in mock_listen.call_args_list:
+        assert call.args[0] is mock_sync_maker
+    listener_events = {c.args[1] for c in mock_listen.call_args_list}
+    assert {"before_flush", "after_commit", "after_rollback"} <= listener_events
 
 
 def test_async_create_session_maker_file_object_listener_disabled() -> None:

--- a/tests/unit/test_extensions/test_starlette_listeners.py
+++ b/tests/unit/test_extensions/test_starlette_listeners.py
@@ -1,0 +1,146 @@
+"""Unit tests for Starlette SQLAlchemy config listener registration.
+
+Regression tests for https://github.com/litestar-org/advanced-alchemy/issues/709.
+Both Starlette async and sync configs override create_session_maker without
+delegating to super(), silently dropping the listener registration performed
+by the base class. These tests lock the contract per subclass.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from sqlalchemy.ext.asyncio import async_sessionmaker
+from sqlalchemy.orm import sessionmaker
+
+from advanced_alchemy.config.common import GenericSQLAlchemyConfig
+from advanced_alchemy.extensions.starlette.config import (
+    SQLAlchemyAsyncConfig,
+    SQLAlchemySyncConfig,
+)
+
+
+# --- Async ---
+
+
+def test_async_create_session_maker_registers_all_listeners() -> None:
+    mock_session_maker = MagicMock(spec=async_sessionmaker)
+    config = SQLAlchemyAsyncConfig(connection_string="sqlite+aiosqlite:///")
+
+    with (
+        patch.object(
+            GenericSQLAlchemyConfig,
+            "create_session_maker",
+            return_value=mock_session_maker,
+        ),
+        patch("sqlalchemy.event.listen") as mock_listen,
+        patch("advanced_alchemy.config.asyncio.sync_sessionmaker") as mock_sync_factory,
+    ):
+        mock_sync_maker = MagicMock()
+        mock_sync_factory.return_value = mock_sync_maker
+        result = config.create_session_maker()
+
+    assert result is mock_session_maker
+    assert mock_listen.call_count == 6
+    mock_session_maker.configure.assert_called_once_with(sync_session_class=mock_sync_maker)
+
+
+def test_async_create_session_maker_file_object_listener_disabled() -> None:
+    mock_session_maker = MagicMock(spec=async_sessionmaker)
+    config = SQLAlchemyAsyncConfig(
+        connection_string="sqlite+aiosqlite:///",
+        enable_file_object_listener=False,
+    )
+
+    with (
+        patch.object(
+            GenericSQLAlchemyConfig,
+            "create_session_maker",
+            return_value=mock_session_maker,
+        ),
+        patch("sqlalchemy.event.listen") as mock_listen,
+        patch("advanced_alchemy.config.asyncio.sync_sessionmaker"),
+    ):
+        config.create_session_maker()
+
+    assert mock_listen.call_count == 3
+
+
+def test_async_create_session_maker_timestamp_listener_disabled() -> None:
+    mock_session_maker = MagicMock(spec=async_sessionmaker)
+    config = SQLAlchemyAsyncConfig(
+        connection_string="sqlite+aiosqlite:///",
+        enable_touch_updated_timestamp_listener=False,
+    )
+
+    with (
+        patch.object(
+            GenericSQLAlchemyConfig,
+            "create_session_maker",
+            return_value=mock_session_maker,
+        ),
+        patch("sqlalchemy.event.listen") as mock_listen,
+        patch("advanced_alchemy.config.asyncio.sync_sessionmaker"),
+    ):
+        config.create_session_maker()
+
+    assert mock_listen.call_count == 5
+
+
+# --- Sync ---
+
+
+def test_sync_create_session_maker_registers_all_listeners() -> None:
+    mock_session_maker = MagicMock(spec=sessionmaker)
+    config = SQLAlchemySyncConfig(connection_string="sqlite:///")
+
+    with (
+        patch.object(
+            GenericSQLAlchemyConfig,
+            "create_session_maker",
+            return_value=mock_session_maker,
+        ),
+        patch("sqlalchemy.event.listen") as mock_listen,
+    ):
+        result = config.create_session_maker()
+
+    assert result is mock_session_maker
+    assert mock_listen.call_count == 6
+
+
+def test_sync_create_session_maker_file_object_listener_disabled() -> None:
+    mock_session_maker = MagicMock(spec=sessionmaker)
+    config = SQLAlchemySyncConfig(
+        connection_string="sqlite:///",
+        enable_file_object_listener=False,
+    )
+
+    with (
+        patch.object(
+            GenericSQLAlchemyConfig,
+            "create_session_maker",
+            return_value=mock_session_maker,
+        ),
+        patch("sqlalchemy.event.listen") as mock_listen,
+    ):
+        config.create_session_maker()
+
+    assert mock_listen.call_count == 3
+
+
+def test_sync_create_session_maker_timestamp_listener_disabled() -> None:
+    mock_session_maker = MagicMock(spec=sessionmaker)
+    config = SQLAlchemySyncConfig(
+        connection_string="sqlite:///",
+        enable_touch_updated_timestamp_listener=False,
+    )
+
+    with (
+        patch.object(
+            GenericSQLAlchemyConfig,
+            "create_session_maker",
+            return_value=mock_session_maker,
+        ),
+        patch("sqlalchemy.event.listen") as mock_listen,
+    ):
+        config.create_session_maker()
+
+    assert mock_listen.call_count == 5


### PR DESCRIPTION
## Summary

Fixes #709 — framework extension configs (Litestar, Starlette, Sanic, Flask, async and sync each) override `create_session_maker` without delegating to `super()`, silently skipping `AsyncFileObjectListener` / `SyncFileObjectListener`, `touch_updated_timestamp`, and `AsyncCacheListener` / `SyncCacheListener` registration. User-visible effect: file uploads via `FileObject` / `StoredObject` persist metadata to the database but the actual file content is silently discarded.

- **Fix:** Each override now delegates to `super().create_session_maker()` so the middle-layer listener wiring runs. Framework-specific pre-steps (notably Starlette/Sanic/Flask's `engine_instance` caching) are preserved verbatim — the principle is *add listener wiring, preserve every other observable behavior*.
- **Scope:** 8 source files (4 extensions × async + sync). FastAPI inherits from Starlette so gets the fix for free (no override exists there).
- **Tests:** 24 new unit tests in 5 files mirror the existing mocking pattern in `tests/unit/test_config/test_async_config.py`, locking the listener-registration contract per extension so future overrides cannot silently drop it again.

## Design notes

- **Why mock-based unit tests and not integration tests?** The base class's integration tests already cover end-to-end listener behavior. The bug is that listeners *weren't registered at all* in subclasses — a unit-test question. Mocks catch exactly that failure mode loudly and specifically (`call_count == 0` vs expected `6`), whereas an integration test would fail as a confusing silent missing-file, which is exactly the failure mode #709 reported.
- **Why `engine_instance` pre-step preserved in Starlette/Sanic/Flask?** Analysis shows it's technically redundant with `get_engine()`'s internal memoization, so the overrides *could* be deleted outright. But "minimal harm" mandates preserving exact call sequences in case downstream users have subclassed or monkey-patched in unexpected ways. The tests pre-populate `config.engine_instance = MagicMock()` to isolate listener-count assertions from the aiosqlite dialect's internal `event.listen` calls.
- **Atomic commits:** 18 small commits tell the full story: 5 failing-test commits (red) → 8 super() delegation commits (green) → 1 test-isolation commit → 3 pre-step restoration commits → 1 test strengthening commit. Each commit is individually revertable.

## Test Plan

- [x] 24 new unit tests pass (listener registration contract per extension)
- [x] Full `tests/unit/` suite — no regressions (pre-existing failures in `test_repository.py` and `test_utils/test_fixtures.py` confirmed unrelated by checking out base commit)
- [ ] Reviewer manually verifies MCVE from #709 now produces `"file_exists_on_disk": true`
- [ ] Reviewer confirms the "minimal harm" design approach (preserve `engine_instance` pre-step) matches project preference

## Draft status

Drafting for reviewer discussion on:
1. Whether to keep the conservative `engine_instance` pre-step or delete the non-Litestar overrides outright (simpler, provably safe per `get_engine()` memoization analysis).
2. Whether to add CHANGELOG entries or leave them to the release-bump process.

🤖 Generated with [Claude Code](https://claude.com/claude-code)