### PR TITLE
refactor: extract provider dependency utilities

### DIFF
--- a/advanced_alchemy/extensions/fastapi/providers.py
+++ b/advanced_alchemy/extensions/fastapi/providers.py
@@ -16,21 +16,18 @@ from typing import (
     Any,
     Callable,
     Literal,
-    NamedTuple,
     Optional,
     TypeVar,
     Union,
     cast,
     overload,
 )
-from uuid import UUID
 
 from fastapi import Depends, Query, Request
 from fastapi.exceptions import RequestValidationError
 from sqlalchemy import Select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import Session
-from typing_extensions import NotRequired, TypedDict
 
 from advanced_alchemy.extensions.fastapi.extension import AdvancedAlchemy
 from advanced_alchemy.filters import (
@@ -51,7 +48,7 @@ from advanced_alchemy.service import (
     SQLAlchemyAsyncRepositoryService,
     SQLAlchemySyncRepositoryService,
 )
-from advanced_alchemy.utils.singleton import SingletonMeta
+from advanced_alchemy.utils.dependencies import DependencyCache, FieldNameType, FilterConfig, make_hashable
 from advanced_alchemy.utils.text import camelize
 
 logger = logging.getLogger("advanced_alchemy.extensions.fastapi")
@@ -67,25 +64,21 @@ IntOrNone = Optional[int]
 BooleanOrNone = Optional[bool]
 SortOrder = Literal["asc", "desc"]
 SortOrderOrNone = Optional[SortOrder]
-FilterConfigValues = Union[
-    bool, str, list[str], type[Union[str, int]]
-]  # Simplified compared to Litestar's UUID/int flexibility for now
 AsyncServiceT_co = TypeVar("AsyncServiceT_co", bound=SQLAlchemyAsyncRepositoryService[Any, Any], covariant=True)
 SyncServiceT_co = TypeVar("SyncServiceT_co", bound=SQLAlchemySyncRepositoryService[Any, Any], covariant=True)
-HashableValue = Union[str, int, float, bool, None]
-HashableType = Union[HashableValue, tuple[Any, ...], tuple[tuple[str, Any], ...], tuple[HashableValue, ...]]
 
+__all__ = (
+    "DEPENDENCY_DEFAULTS",
+    "DependencyCache",
+    "DependencyDefaults",
+    "FieldNameType",
+    "FilterConfig",
+    "dep_cache",
+    "provide_filters",
+    "provide_service",
+)
 
-class FieldNameType(NamedTuple):
-    """Type for field name and associated type information.
-
-    This allows for specifying both the field name and the expected type for filter values.
-    """
-
-    name: str
-    """Name of the field to filter on."""
-    type_hint: type[Any] = str
-    """Type of the filter value. Defaults to str."""
+_CACHE_NAMESPACE = "advanced_alchemy.extensions.fastapi.providers"
 
 
 class DependencyDefaults:
@@ -110,49 +103,7 @@ class DependencyDefaults:
 DEPENDENCY_DEFAULTS = DependencyDefaults()
 
 
-class DependencyCache(metaclass=SingletonMeta):
-    """Simple dependency cache for the application.  This is used to help memoize dependencies that are generated dynamically."""
-
-    def __init__(self) -> None:
-        self.dependencies: dict[int, Callable[[Any], list[FilterTypes]]] = {}
-
-    def add_dependencies(self, key: int, dependencies: Callable[[Any], list[FilterTypes]]) -> None:
-        self.dependencies[key] = dependencies
-
-    def get_dependencies(self, key: int) -> Optional[Callable[[Any], list[FilterTypes]]]:
-        return self.dependencies.get(key)
-
-
 dep_cache = DependencyCache()
-
-
-class FilterConfig(TypedDict):
-    """Configuration for generating dynamic filters for FastAPI."""
-
-    id_filter: NotRequired[type[Union[UUID, int, str]]]
-    """Indicates that the id filter should be enabled."""
-    id_field: NotRequired[str]
-    """The field on the model that stored the primary key or identifier. Defaults to 'id'."""
-    sort_field: NotRequired[Union[str, set[str]]]
-    """The default field(s) to use for the sort filter."""
-    sort_order: NotRequired[SortOrder]
-    """The default order to use for the sort filter. Defaults to 'desc'."""
-    pagination_type: NotRequired[Literal["limit_offset"]]
-    """When set, pagination is enabled based on the type specified."""
-    pagination_size: NotRequired[int]
-    """The size of the pagination. Defaults to `DEFAULT_PAGINATION_SIZE`."""
-    search: NotRequired[Union[str, set[str]]]
-    """Fields to enable search on. Can be a comma-separated string or a set of field names."""
-    search_ignore_case: NotRequired[bool]
-    """When set, search is case insensitive by default. Defaults to False."""
-    created_at: NotRequired[bool]
-    """When set, created_at filter is enabled. Defaults to 'created_at' field."""
-    updated_at: NotRequired[bool]
-    """When set, updated_at filter is enabled. Defaults to 'updated_at' field."""
-    not_in_fields: NotRequired[Union[FieldNameType, set[FieldNameType]]]
-    """Fields that support not-in collection filters. Can be a single field or a set of fields with type information."""
-    in_fields: NotRequired[Union[FieldNameType, set[FieldNameType]]]
-    """Fields that support in-collection filters. Can be a single field or a set of fields with type information."""
 
 
 def _should_commit_for_status(status_code: int, commit_mode: str) -> bool:
@@ -172,6 +123,16 @@ def _should_commit_for_status(status_code: int, commit_mode: str) -> bool:
     if commit_mode == "autocommit_include_redirect":
         return 200 <= status_code < 400  # noqa: PLR2004
     return False
+
+
+def _normalize_field_name_types(
+    field_definitions: Union[str, FieldNameType, set[FieldNameType], list[Union[str, FieldNameType]]],
+) -> set[FieldNameType]:
+    raw_fields = {field_definitions} if isinstance(field_definitions, (str, FieldNameType)) else set(field_definitions)
+    return {
+        FieldNameType(name=field_definition, type_hint=str) if isinstance(field_definition, str) else field_definition
+        for field_definition in raw_fields
+    }
 
 
 @overload
@@ -400,47 +361,16 @@ def provide_filters(
         return list
 
     # Calculate cache key using hashable version of config
-    cache_key = hash(_make_hashable(config))
+    cache_key = hash((_CACHE_NAMESPACE, make_hashable(config)))
 
     # Check cache first
-    cached_dep = dep_cache.get_dependencies(cache_key)
+    cached_dep = cast("Optional[Callable[..., list[FilterTypes]]]", dep_cache.get_dependencies(cache_key))
     if cached_dep is not None:
         return cached_dep
 
     dep = _create_filter_aggregate_function_fastapi(config, dep_defaults)
     dep_cache.add_dependencies(cache_key, dep)
     return dep
-
-
-def _make_hashable(value: Any) -> HashableType:
-    """Convert a value into a hashable type.
-
-    This function converts any value into a hashable type by:
-    - Converting dictionaries to sorted tuples of (key, value) pairs
-    - Converting lists and sets to sorted tuples
-    - Preserving primitive types (str, int, float, bool, None)
-    - Converting any other type to its string representation
-
-    Args:
-        value: Any value that needs to be made hashable.
-
-    Returns:
-        A hashable version of the value.
-    """
-    if isinstance(value, dict):
-        # Convert dict to tuple of tuples with sorted keys
-        items = []
-        for k in sorted(value.keys()):  # pyright: ignore
-            v = value[k]  # pyright: ignore
-            items.append((str(k), _make_hashable(v)))  # pyright: ignore
-        return tuple(items)  # pyright: ignore
-    if isinstance(value, (list, set)):
-        hashable_items = [_make_hashable(item) for item in value]  # pyright: ignore
-        filtered_items = [item for item in hashable_items if item is not None]  # pyright: ignore
-        return tuple(sorted(filtered_items, key=str))
-    if isinstance(value, (str, int, float, bool, type(None))):
-        return value
-    return str(value)
 
 
 def _create_filter_aggregate_function_fastapi(  # noqa: C901, PLR0915
@@ -649,7 +579,7 @@ def _create_filter_aggregate_function_fastapi(  # noqa: C901, PLR0915
                 ),
             ] = config.get("search_ignore_case", False),
         ) -> SearchFilter:
-            field_names = set(search_fields.split(",")) if isinstance(search_fields, str) else search_fields
+            field_names = set(search_fields.split(",")) if isinstance(search_fields, str) else set(search_fields)
 
             return SearchFilter(
                 field_name=field_names,
@@ -703,8 +633,7 @@ def _create_filter_aggregate_function_fastapi(  # noqa: C901, PLR0915
 
     # Add not_in filter providers
     if not_in_fields := config.get("not_in_fields"):
-        not_in_fields = {not_in_fields} if isinstance(not_in_fields, (str, FieldNameType)) else not_in_fields
-        for field_def in not_in_fields:
+        for field_def in _normalize_field_name_types(not_in_fields):
             # Capture field_def by value to avoid Python closure late binding gotcha
             # Without default parameter, all closures would reference the loop variable's final value
             def create_not_in_filter_provider(  # pyright: ignore
@@ -736,8 +665,7 @@ def _create_filter_aggregate_function_fastapi(  # noqa: C901, PLR0915
 
     # Add in filter providers
     if in_fields := config.get("in_fields"):
-        in_fields = {in_fields} if isinstance(in_fields, (str, FieldNameType)) else in_fields
-        for field_def in in_fields:
+        for field_def in _normalize_field_name_types(in_fields):
             # Capture field_def by value to avoid Python closure late binding gotcha
             # Without default parameter, all closures would reference the loop variable's final value
             def create_in_filter_provider(  # pyright: ignore

--- a/advanced_alchemy/extensions/fastapi/providers.py
+++ b/advanced_alchemy/extensions/fastapi/providers.py
@@ -48,7 +48,13 @@ from advanced_alchemy.service import (
     SQLAlchemyAsyncRepositoryService,
     SQLAlchemySyncRepositoryService,
 )
-from advanced_alchemy.utils.dependencies import DependencyCache, FieldNameType, FilterConfig, make_hashable
+from advanced_alchemy.utils.dependencies import (
+    DependencyCache,
+    FieldNameType,
+    FilterConfig,
+    make_hashable,
+    normalize_sort_field,
+)
 from advanced_alchemy.utils.text import camelize
 
 logger = logging.getLogger("advanced_alchemy.extensions.fastapi")
@@ -599,6 +605,7 @@ def _create_filter_aggregate_function_fastapi(  # noqa: C901, PLR0915
 
     # Add sort filter providers
     if sort_field := config.get("sort_field"):
+        sort_field_default = normalize_sort_field(sort_field)
         sort_order_default = config.get("sort_order", "desc")
 
         def provide_order_by(
@@ -609,7 +616,7 @@ def _create_filter_aggregate_function_fastapi(  # noqa: C901, PLR0915
                     description="Field to order by.",
                     required=False,
                 ),
-            ] = sort_field,  # type: ignore[assignment]
+            ] = sort_field_default,
             sort_order: Annotated[
                 Optional[SortOrder],
                 Query(

--- a/advanced_alchemy/extensions/litestar/providers.py
+++ b/advanced_alchemy/extensions/litestar/providers.py
@@ -14,9 +14,7 @@ from typing import (
     Annotated,
     Any,
     Literal,
-    NamedTuple,
     Optional,
-    TypedDict,
     TypeVar,
     Union,
     cast,
@@ -26,7 +24,6 @@ from uuid import UUID
 
 from litestar.di import Provide
 from litestar.params import Dependency, FromQuery, QueryParameter
-from typing_extensions import NotRequired
 
 from advanced_alchemy.filters import (
     BeforeAfter,
@@ -46,6 +43,7 @@ from advanced_alchemy.service import (
     SQLAlchemyAsyncRepositoryService,
     SQLAlchemySyncRepositoryService,
 )
+from advanced_alchemy.utils.dependencies import DependencyCache, FieldNameType, FilterConfig, make_hashable
 from advanced_alchemy.utils.singleton import SingletonMeta
 from advanced_alchemy.utils.text import camelize
 
@@ -66,8 +64,21 @@ SortOrder = Literal["asc", "desc"]
 SortOrderOrNone = Optional[SortOrder]
 AsyncServiceT_co = TypeVar("AsyncServiceT_co", bound=SQLAlchemyAsyncRepositoryService[Any, Any], covariant=True)
 SyncServiceT_co = TypeVar("SyncServiceT_co", bound=SQLAlchemySyncRepositoryService[Any, Any], covariant=True)
-HashableValue = Union[str, int, float, bool, None]
-HashableType = Union[HashableValue, tuple[Any, ...], tuple[tuple[str, Any], ...], tuple[HashableValue, ...]]
+
+__all__ = (
+    "DEPENDENCY_DEFAULTS",
+    "DependencyCache",
+    "DependencyDefaults",
+    "FieldNameType",
+    "FilterConfig",
+    "SingletonMeta",
+    "create_filter_dependencies",
+    "create_service_dependencies",
+    "create_service_provider",
+    "dep_cache",
+)
+
+_CACHE_NAMESPACE = "advanced_alchemy.extensions.litestar.providers"
 
 
 class DependencyDefaults:
@@ -90,60 +101,6 @@ class DependencyDefaults:
 
 
 DEPENDENCY_DEFAULTS = DependencyDefaults()
-
-
-class FieldNameType(NamedTuple):
-    """Type for field name and associated type information.
-
-    This allows for specifying both the field name and the expected type for filter values.
-    """
-
-    name: str
-    """Name of the field to filter on."""
-    type_hint: type[Any] = str
-    """Type of the filter value. Defaults to str."""
-
-
-class FilterConfig(TypedDict):
-    """Configuration for generating dynamic filters."""
-
-    id_filter: NotRequired[type[Union[UUID, int, str]]]
-    """Indicates that the id filter should be enabled.  When set, the type specified will be used for the :class:`CollectionFilter`."""
-    id_field: NotRequired[str]
-    """The field on the model that stored the primary key or identifier."""
-    sort_field: NotRequired[str]
-    """The default field to use for the sort filter."""
-    sort_order: NotRequired[SortOrder]
-    """The default order to use for the sort filter."""
-    pagination_type: NotRequired[Literal["limit_offset"]]
-    """When set, pagination is enabled based on the type specified."""
-    pagination_size: NotRequired[int]
-    """The size of the pagination. Defaults to `DEFAULT_PAGINATION_SIZE`."""
-    search: NotRequired[Union[str, set[str], list[str]]]
-    """Fields to enable search on. Can be a comma-separated string or a set of field names."""
-    search_ignore_case: NotRequired[bool]
-    """When set, search is case insensitive by default."""
-    created_at: NotRequired[bool]
-    """When set, created_at filter is enabled."""
-    updated_at: NotRequired[bool]
-    """When set, updated_at filter is enabled."""
-    not_in_fields: NotRequired[Union[FieldNameType, set[FieldNameType], list[Union[str, FieldNameType]]]]
-    """Fields that support not-in collection filters. Can be a single field or a set of fields with type information."""
-    in_fields: NotRequired[Union[FieldNameType, set[FieldNameType], list[Union[str, FieldNameType]]]]
-    """Fields that support in-collection filters. Can be a single field or a set of fields with type information."""
-
-
-class DependencyCache(metaclass=SingletonMeta):
-    """Simple dependency cache for the application.  This is used to help memoize dependencies that are generated dynamically."""
-
-    def __init__(self) -> None:
-        self.dependencies: dict[Union[int, str], dict[str, Provide]] = {}
-
-    def add_dependencies(self, key: Union[int, str], dependencies: dict[str, Provide]) -> None:
-        self.dependencies[key] = dependencies
-
-    def get_dependencies(self, key: Union[int, str]) -> Optional[dict[str, Provide]]:
-        return self.dependencies.get(key)
 
 
 dep_cache = DependencyCache()
@@ -351,44 +308,13 @@ def create_filter_dependencies(
     Returns:
         A dependency provider function for the combined filter function.
     """
-    cache_key = hash(_make_hashable(config))
-    deps = dep_cache.get_dependencies(cache_key)
+    cache_key = hash((_CACHE_NAMESPACE, make_hashable(config)))
+    deps = cast("Optional[dict[str, Provide]]", dep_cache.get_dependencies(cache_key))
     if deps is not None:
         return deps
     deps = _create_statement_filters(config, dep_defaults)
     dep_cache.add_dependencies(cache_key, deps)
     return deps
-
-
-def _make_hashable(value: Any) -> HashableType:
-    """Convert a value into a hashable type.
-
-    This function converts any value into a hashable type by:
-    - Converting dictionaries to sorted tuples of (key, value) pairs
-    - Converting lists and sets to sorted tuples
-    - Preserving primitive types (str, int, float, bool, None)
-    - Converting any other type to its string representation
-
-    Args:
-        value: Any value that needs to be made hashable.
-
-    Returns:
-        A hashable version of the value.
-    """
-    if isinstance(value, dict):
-        # Convert dict to tuple of tuples with sorted keys
-        items = []
-        for k in sorted(value.keys()):  # pyright: ignore
-            v = value[k]  # pyright: ignore
-            items.append((str(k), _make_hashable(v)))  # pyright: ignore
-        return tuple(items)  # pyright: ignore
-    if isinstance(value, (list, set)):
-        hashable_items = [_make_hashable(item) for item in value]  # pyright: ignore
-        filtered_items = [item for item in hashable_items if item is not None]  # pyright: ignore
-        return tuple(sorted(filtered_items, key=str))
-    if isinstance(value, (str, int, float, bool, type(None))):
-        return value
-    return str(value)
 
 
 def _create_statement_filters(  # noqa: C901
@@ -490,7 +416,7 @@ def _create_statement_filters(  # noqa: C901
                     title="Order by field",
                     name="orderBy",
                 ),
-            ] = sort_field,
+            ] = sort_field,  # type: ignore[assignment]
             sort_order: Annotated[
                 SortOrderOrNone,
                 QueryParameter(

--- a/advanced_alchemy/extensions/litestar/providers.py
+++ b/advanced_alchemy/extensions/litestar/providers.py
@@ -43,7 +43,13 @@ from advanced_alchemy.service import (
     SQLAlchemyAsyncRepositoryService,
     SQLAlchemySyncRepositoryService,
 )
-from advanced_alchemy.utils.dependencies import DependencyCache, FieldNameType, FilterConfig, make_hashable
+from advanced_alchemy.utils.dependencies import (
+    DependencyCache,
+    FieldNameType,
+    FilterConfig,
+    make_hashable,
+    normalize_sort_field,
+)
 from advanced_alchemy.utils.singleton import SingletonMeta
 from advanced_alchemy.utils.text import camelize
 
@@ -317,6 +323,33 @@ def create_filter_dependencies(
     return deps
 
 
+def _create_order_by_filter_provider(
+    sort_field: Union[str, set[str], list[str]],
+    sort_order_default: SortOrder = "desc",
+) -> Callable[..., OrderBy]:
+    sort_field_default = normalize_sort_field(sort_field)
+
+    def provide_order_by(
+        field_name: Annotated[
+            StringOrNone,
+            QueryParameter(
+                title="Order by field",
+                name="orderBy",
+            ),
+        ] = sort_field_default,
+        sort_order: Annotated[
+            SortOrderOrNone,
+            QueryParameter(
+                title="Field to search",
+                name="sortOrder",
+            ),
+        ] = sort_order_default,
+    ) -> OrderBy:
+        return OrderBy(field_name=field_name, sort_order=sort_order or sort_order_default)  # type: ignore[arg-type]
+
+    return provide_order_by
+
+
 def _create_statement_filters(  # noqa: C901
     config: FilterConfig, dep_defaults: DependencyDefaults = DEPENDENCY_DEFAULTS
 ) -> dict[str, Provide]:
@@ -408,26 +441,10 @@ def _create_statement_filters(  # noqa: C901
         filters[dep_defaults.SEARCH_FILTER_DEPENDENCY_KEY] = Provide(provide_search_filter, sync_to_thread=False)
 
     if sort_field := config.get("sort_field"):
-
-        def provide_order_by(
-            field_name: Annotated[
-                StringOrNone,
-                QueryParameter(
-                    title="Order by field",
-                    name="orderBy",
-                ),
-            ] = sort_field,  # type: ignore[assignment]
-            sort_order: Annotated[
-                SortOrderOrNone,
-                QueryParameter(
-                    title="Field to search",
-                    name="sortOrder",
-                ),
-            ] = config.get("sort_order", "desc"),
-        ) -> OrderBy:
-            return OrderBy(field_name=field_name, sort_order=sort_order)  # type: ignore[arg-type]
-
-        filters[dep_defaults.ORDER_BY_FILTER_DEPENDENCY_KEY] = Provide(provide_order_by, sync_to_thread=False)
+        filters[dep_defaults.ORDER_BY_FILTER_DEPENDENCY_KEY] = Provide(
+            _create_order_by_filter_provider(sort_field, config.get("sort_order", "desc")),
+            sync_to_thread=False,
+        )
 
     # Add not_in filter providers
     if not_in_fields := config.get("not_in_fields"):

--- a/advanced_alchemy/filters.py
+++ b/advanced_alchemy/filters.py
@@ -63,6 +63,12 @@ from advanced_alchemy.base import ModelProtocol
 if TYPE_CHECKING:
     from sqlalchemy.orm import InstrumentedAttribute
 
+    FilterFieldName: TypeAlias = Union[str, ColumnElement[Any], InstrumentedAttribute[Any]]
+    InstrumentedField: TypeAlias = Union[ColumnElement[Any], InstrumentedAttribute[Any]]
+else:
+    FilterFieldName: TypeAlias = Any
+    InstrumentedField: TypeAlias = Any
+
 __all__ = (
     "BeforeAfter",
     "CollectionFilter",
@@ -160,9 +166,7 @@ class StatementFilter(ABC):
         return statement
 
     @staticmethod
-    def _get_instrumented_attr(
-        model: Any, key: "Union[str, ColumnElement[Any], InstrumentedAttribute[Any]]"
-    ) -> "Union[ColumnElement[Any], InstrumentedAttribute[Any]]":
+    def _get_instrumented_attr(model: Any, key: FilterFieldName) -> InstrumentedField:
         """Get SQLAlchemy instrumented attribute from model.
 
         Args:
@@ -193,7 +197,7 @@ class BeforeAfter(StatementFilter):
 
     """
 
-    field_name: "Union[str, ColumnElement[Any], InstrumentedAttribute[Any]]"
+    field_name: FilterFieldName
     """Field name, model attribute, or func expression."""
     before: Optional[datetime.datetime]
     """Filter results where field is earlier than this value."""
@@ -239,7 +243,7 @@ class OnBeforeAfter(StatementFilter):
 
     """
 
-    field_name: "Union[str, ColumnElement[Any], InstrumentedAttribute[Any]]"
+    field_name: FilterFieldName
     """Field name, model attribute, or func expression."""
     on_or_before: Optional[datetime.datetime]
     """Filter results where field is on or earlier than this value."""
@@ -287,7 +291,7 @@ class CollectionFilter(InAnyFilter, Generic[T]):
     Use ``prefer_any=True`` in ``append_to_statement`` to use the ``ANY`` operator.
     """
 
-    field_name: "Union[str, ColumnElement[Any], InstrumentedAttribute[Any]]"
+    field_name: FilterFieldName
     """Field name, model attribute, or func expression."""
     values: Union[Collection[T], None]
     """Values for the ``IN`` clause. If this is None, no filter is applied.
@@ -346,7 +350,7 @@ class NotInCollectionFilter(InAnyFilter, Generic[T]):
 
     """
 
-    field_name: "Union[str, ColumnElement[Any], InstrumentedAttribute[Any]]"
+    field_name: FilterFieldName
     """Field name, model attribute, or func expression."""
     values: Union[Collection[T], None]
     """Values for the ``NOT IN`` clause. If None or empty, no filter is applied."""
@@ -419,7 +423,7 @@ class NullFilter(StatementFilter):
         - :meth:`sqlalchemy.sql.expression.ColumnOperators.is_`: IS NULL operator
     """
 
-    field_name: "Union[str, ColumnElement[Any], InstrumentedAttribute[Any]]"
+    field_name: FilterFieldName
     """Field name, model attribute, or func expression."""
 
     def append_to_statement(self, statement: StatementTypeT, model: type[ModelT]) -> StatementTypeT:
@@ -472,7 +476,7 @@ class NotNullFilter(StatementFilter):
         - :meth:`sqlalchemy.sql.expression.ColumnOperators.is_not`: IS NOT NULL operator
     """
 
-    field_name: "Union[str, ColumnElement[Any], InstrumentedAttribute[Any]]"
+    field_name: FilterFieldName
     """Field name, model attribute, or func expression."""
 
     def append_to_statement(self, statement: StatementTypeT, model: type[ModelT]) -> StatementTypeT:
@@ -556,7 +560,7 @@ class OrderBy(StatementFilter):
         - :meth:`sqlalchemy.sql.expression.ColumnElement.desc`: Descending order
     """
 
-    field_name: "Union[str, ColumnElement[Any], InstrumentedAttribute[Any]]"
+    field_name: FilterFieldName
     """Field name, model attribute, or func expression (e.g., ``func.random()``)."""
     sort_order: Literal["asc", "desc"] = "asc"
     """Sort direction ("asc" or "desc")."""
@@ -728,7 +732,7 @@ class ComparisonFilter(StatementFilter):
         ValueError: If an invalid operator is provided
     """
 
-    field_name: "Union[str, ColumnElement[Any], InstrumentedAttribute[Any]]"
+    field_name: FilterFieldName
     """Field name, model attribute, or func expression."""
     operator: str
     """Comparison operator to use (one of 'eq', 'ne', 'gt', 'ge', 'lt', 'le')."""

--- a/advanced_alchemy/utils/dependencies.py
+++ b/advanced_alchemy/utils/dependencies.py
@@ -1,0 +1,134 @@
+"""Shared utilities for framework dependency-injection wiring.
+
+These primitives are framework-agnostic and reused by framework
+``advanced_alchemy.extensions`` provider modules.
+"""
+
+from collections.abc import Iterable, Mapping
+from typing import Any, NamedTuple, Optional, Union, cast
+from uuid import UUID
+
+from typing_extensions import Literal, NotRequired, TypedDict
+
+from advanced_alchemy.utils.singleton import SingletonMeta
+
+__all__ = ("DependencyCache", "FieldNameType", "FilterConfig", "make_hashable")
+
+HashableValue = Union[str, int, float, bool, None]
+HashableType = Union[HashableValue, tuple[Any, ...], tuple[tuple[str, Any], ...], tuple[HashableValue, ...]]
+SortOrder = Literal["asc", "desc"]
+
+
+class FieldNameType(NamedTuple):
+    """Type for field name and associated type information.
+
+    This allows callers to specify both the field name and the expected type
+    for generated filter values.
+    """
+
+    name: str
+    """Name of the field to filter on."""
+    type_hint: type[Any] = str
+    """Type of the filter value. Defaults to ``str``."""
+
+
+class FilterConfig(TypedDict):
+    """Configuration for generating dynamic filters."""
+
+    id_filter: NotRequired[type[Union[UUID, int, str]]]
+    """Enable an id filter using the supplied type."""
+    id_field: NotRequired[str]
+    """Model field storing the primary key or identifier."""
+    sort_field: NotRequired[Union[str, set[str], list[str]]]
+    """Default field or fields to use for sorting."""
+    sort_order: NotRequired[SortOrder]
+    """Default sort order."""
+    pagination_type: NotRequired[Literal["limit_offset"]]
+    """Pagination mode to enable."""
+    pagination_size: NotRequired[int]
+    """Default pagination size."""
+    search: NotRequired[Union[str, set[str], list[str]]]
+    """Fields to enable search on."""
+    search_ignore_case: NotRequired[bool]
+    """Whether search should be case-insensitive."""
+    created_at: NotRequired[bool]
+    """Enable created-at range filtering."""
+    updated_at: NotRequired[bool]
+    """Enable updated-at range filtering."""
+    not_in_fields: NotRequired[Union[FieldNameType, set[FieldNameType], list[Union[str, FieldNameType]]]]
+    """Fields that support not-in collection filters."""
+    in_fields: NotRequired[Union[FieldNameType, set[FieldNameType], list[Union[str, FieldNameType]]]]
+    """Fields that support in-collection filters."""
+
+
+class DependencyCache(metaclass=SingletonMeta):
+    """Singleton cache for dynamically generated dependency providers."""
+
+    def __init__(self) -> None:
+        self.dependencies: dict[HashableType, Any] = {}
+
+    def add_dependencies(self, key: HashableType, dependencies: Any) -> None:
+        """Cache dependency providers by a precomputed key.
+
+        Args:
+            key: Precomputed cache key.
+            dependencies: Dependency provider object to cache.
+        """
+        self.dependencies[key] = dependencies
+
+    def get_dependencies(self, key: HashableType) -> Optional[Any]:
+        """Retrieve dependency providers by a precomputed key.
+
+        Args:
+            key: Precomputed cache key.
+
+        Returns:
+            Cached dependency providers, if present.
+        """
+        return self.dependencies.get(key)
+
+    def set(self, config: FilterConfig, dependencies: Any) -> None:
+        """Cache dependency providers by filter config.
+
+        Args:
+            config: Filter configuration used to derive a cache key.
+            dependencies: Dependency provider object to cache.
+        """
+        self.dependencies[make_hashable(config)] = dependencies
+
+    def get(self, config: FilterConfig) -> Optional[Any]:
+        """Retrieve dependency providers by filter config.
+
+        Args:
+            config: Filter configuration used to derive a cache key.
+
+        Returns:
+            Cached dependency providers, if present.
+        """
+        return self.dependencies.get(make_hashable(config))
+
+
+def make_hashable(value: Any) -> HashableType:
+    """Convert a possibly nested value into a hashable representation.
+
+    Args:
+        value: Value that needs to be made hashable.
+
+    Returns:
+        A hashable representation of ``value``.
+    """
+    if isinstance(value, Mapping):
+        mapping = cast("Mapping[Any, Any]", value)  # type: ignore[redundant-cast]
+        items = [(str(key), make_hashable(mapping[key])) for key in sorted(mapping.keys(), key=str)]
+        return tuple(items)
+    if isinstance(value, (list, set)):
+        values = cast("Iterable[Any]", value)
+        hashable_items = [make_hashable(item) for item in values]
+        filtered_items = [item for item in hashable_items if item is not None]
+        return tuple(sorted(filtered_items, key=str))
+    if isinstance(value, tuple):
+        values = cast("tuple[Any, ...]", value)  # type: ignore[redundant-cast]
+        return tuple(make_hashable(item) for item in values)
+    if isinstance(value, (str, int, float, bool, type(None))):
+        return value
+    return str(value)

--- a/advanced_alchemy/utils/dependencies.py
+++ b/advanced_alchemy/utils/dependencies.py
@@ -12,11 +12,12 @@ from typing_extensions import Literal, NotRequired, TypedDict
 
 from advanced_alchemy.utils.singleton import SingletonMeta
 
-__all__ = ("DependencyCache", "FieldNameType", "FilterConfig", "make_hashable")
+__all__ = ("DependencyCache", "FieldNameType", "FilterConfig", "make_hashable", "normalize_sort_field")
 
 HashableValue = Union[str, int, float, bool, None]
 HashableType = Union[HashableValue, tuple[Any, ...], tuple[tuple[str, Any], ...], tuple[HashableValue, ...]]
 SortOrder = Literal["asc", "desc"]
+SortField = Union[str, set[str], list[str]]
 
 
 class FieldNameType(NamedTuple):
@@ -39,7 +40,7 @@ class FilterConfig(TypedDict):
     """Enable an id filter using the supplied type."""
     id_field: NotRequired[str]
     """Model field storing the primary key or identifier."""
-    sort_field: NotRequired[Union[str, set[str], list[str]]]
+    sort_field: NotRequired[SortField]
     """Default field or fields to use for sorting."""
     sort_order: NotRequired[SortOrder]
     """Default sort order."""
@@ -121,7 +122,10 @@ def make_hashable(value: Any) -> HashableType:
         mapping = cast("Mapping[Any, Any]", value)  # type: ignore[redundant-cast]
         items = [(str(key), make_hashable(mapping[key])) for key in sorted(mapping.keys(), key=str)]
         return tuple(items)
-    if isinstance(value, (list, set)):
+    if isinstance(value, list):
+        values = cast("Iterable[Any]", value)
+        return tuple(make_hashable(item) for item in values)
+    if isinstance(value, set):
         values = cast("Iterable[Any]", value)
         hashable_items = [make_hashable(item) for item in values]
         filtered_items = [item for item in hashable_items if item is not None]
@@ -132,3 +136,12 @@ def make_hashable(value: Any) -> HashableType:
     if isinstance(value, (str, int, float, bool, type(None))):
         return value
     return str(value)
+
+
+def normalize_sort_field(sort_field: SortField) -> str:
+    """Return a scalar default field for a configured sort field value."""
+    if isinstance(sort_field, str):
+        return sort_field
+    if isinstance(sort_field, list):
+        return sort_field[0]
+    return sorted(sort_field)[0]

--- a/tests/unit/test_extensions/test_fastapi/test_providers.py
+++ b/tests/unit/test_extensions/test_fastapi/test_providers.py
@@ -20,6 +20,7 @@ from sqlalchemy.orm import Mapped, mapped_column
 from advanced_alchemy.base import UUIDBase
 from advanced_alchemy.extensions.fastapi import SQLAlchemyAsyncConfig
 from advanced_alchemy.extensions.fastapi.providers import (
+    _CACHE_NAMESPACE,  # pyright: ignore[reportPrivateUsage]
     DEPENDENCY_DEFAULTS,
     DependencyCache,
     DependencyDefaults,
@@ -39,6 +40,7 @@ from advanced_alchemy.filters import (
 )
 from advanced_alchemy.repository import SQLAlchemyAsyncRepository
 from advanced_alchemy.service import SQLAlchemyAsyncRepositoryService
+from advanced_alchemy.utils.dependencies import make_hashable
 from advanced_alchemy.utils.singleton import SingletonMeta
 
 
@@ -93,7 +95,7 @@ def test_create_filter_dependencies_cache_hit() -> None:
 def test_create_filter_dependencies_cache_miss() -> None:
     """Test create_filter_dependencies with cache miss."""
     config = cast(FilterConfig, {"created_at": True})
-    cache_key = hash(tuple(sorted(config.items())))
+    cache_key = hash((_CACHE_NAMESPACE, make_hashable(config)))
     mock_agg_func = lambda: [  # noqa: E731
         BeforeAfter(field_name="created_at", before=None, after=None)
     ]  # Dummy aggregate function
@@ -507,6 +509,25 @@ def test_openapi_schema_comprehensive() -> None:
     assert mock_limit_offset in result
     assert mock_search_filter in result
     assert mock_order_by in result
+
+
+def test_provide_filters_normalizes_list_field_config() -> None:
+    """Test list-based shared FilterConfig values are normalized for FastAPI."""
+    deps = provide_filters(
+        {
+            "search": ["name", "email"],
+            "not_in_fields": ["status", FieldNameType("category", str)],
+            "in_fields": ["tag"],
+        }
+    )
+
+    sig = inspect.signature(deps)
+    assert set(sig.parameters) == {
+        "search_filter",
+        "status_not_in_filter",
+        "category_not_in_filter",
+        "tag_in_filter",
+    }
 
 
 def test_openapi_schema_edge_cases() -> None:

--- a/tests/unit/test_extensions/test_fastapi/test_providers.py
+++ b/tests/unit/test_extensions/test_fastapi/test_providers.py
@@ -530,6 +530,30 @@ def test_provide_filters_normalizes_list_field_config() -> None:
     }
 
 
+def test_provide_filters_uses_scalar_default_from_list_sort_field() -> None:
+    """Test list-based sort fields produce a scalar default order field."""
+    deps = provide_filters({"sort_field": ["name", "id"]})
+
+    app = FastAPI()
+
+    @app.get("/items")
+    async def get_items(filters: Annotated[list[FilterTypes], Depends(deps)]) -> list[dict[str, str]]:
+        return [
+            {"field_name": cast(str, filter_.field_name), "sort_order": filter_.sort_order}
+            for filter_ in filters
+            if isinstance(filter_, OrderBy)
+        ]
+
+    client = TestClient(app)
+    response = client.get("/items")
+    overridden_response = client.get("/items?orderBy=id&sortOrder=asc")
+
+    assert response.status_code == 200
+    assert response.json() == [{"field_name": "name", "sort_order": "desc"}]
+    assert overridden_response.status_code == 200
+    assert overridden_response.json() == [{"field_name": "id", "sort_order": "asc"}]
+
+
 def test_openapi_schema_edge_cases() -> None:
     """Test OpenAPI schema generation for edge cases and special configurations."""
     # Test with minimal configuration

--- a/tests/unit/test_extensions/test_litestar/test_providers.py
+++ b/tests/unit/test_extensions/test_litestar/test_providers.py
@@ -438,6 +438,83 @@ def test_order_by_filter() -> None:
     assert f.sort_order == "desc"
 
 
+def test_order_by_filter_uses_scalar_default_from_list_sort_field() -> None:
+    """Test list-based sort fields produce a scalar default order field."""
+    deps = _create_statement_filters({"sort_field": ["name", "id"]})
+
+    provider_func = deps["order_by_filter"].dependency
+    f = provider_func()
+
+    assert isinstance(f, OrderBy)
+    assert f.field_name == "name"
+    f.append_to_statement(select(DITestModel), DITestModel)
+
+
+def test_order_by_filter_uses_scalar_default_from_set_sort_field() -> None:
+    """Test set-based sort fields produce a deterministic scalar default order field."""
+    deps = _create_statement_filters({"sort_field": {"name", "id"}})
+
+    provider_func = deps["order_by_filter"].dependency
+    f = provider_func()
+
+    assert isinstance(f, OrderBy)
+    assert f.field_name == "id"
+    f.append_to_statement(select(DITestModel), DITestModel)
+
+
+def test_individual_order_by_dependency_injection_skips_runtime_field_validation() -> None:
+    """Test individual Litestar filter dependencies can be injected directly."""
+
+    @get("/", dependencies=create_filter_dependencies({"sort_field": "name"}))
+    async def handler(order_by_filter: OrderBy) -> dict[str, str]:
+        return {"field_name": cast(str, order_by_filter.field_name), "sort_order": order_by_filter.sort_order}
+
+    with TestClient(Litestar([handler])) as client:
+        response = client.get("/")
+        overridden_response = client.get("/?orderBy=id&sortOrder=asc")
+
+    assert response.status_code == 200
+    assert response.json() == {"field_name": "name", "sort_order": "desc"}
+    assert overridden_response.status_code == 200
+    assert overridden_response.json() == {"field_name": "id", "sort_order": "asc"}
+
+
+def test_litestar_openapi_schema_uses_typed_sort_parameters() -> None:
+    """Test sort parameters keep concrete OpenAPI schemas for collection defaults."""
+    filter_dependencies = create_filter_dependencies({"sort_field": ["name", "id"], "sort_order": "asc"})
+
+    @get("/test")
+    async def handler(filters: Annotated[list[FilterTypes], Dependency(skip_validation=True)]) -> list[str]:
+        return [type(filter_).__name__ for filter_ in filters]
+
+    app = Litestar(
+        route_handlers=[handler],
+        signature_namespace=signature_namespace_values,
+        dependencies=filter_dependencies,
+        openapi_config=OpenAPIConfig(title="Test API", version="1.0.0", path="/schema"),
+    )
+
+    with TestClient(app) as client:
+        response = client.get("/schema/openapi.json")
+
+    assert response.status_code == 200
+    parameters = response.json()["paths"]["/test"]["get"]["parameters"]
+    order_by_param = next(param for param in parameters if param["name"] == "orderBy")
+    sort_order_param = next(param for param in parameters if param["name"] == "sortOrder")
+
+    assert order_by_param["schema"] == {
+        "oneOf": [{"type": "string", "default": "name"}, {"type": "null"}],
+        "title": "Order by field",
+        "default": "name",
+    }
+    assert sort_order_param["schema"] == {
+        "type": ["null", "string"],
+        "enum": ["asc", "desc", None],
+        "title": "Field to search",
+        "default": "asc",
+    }
+
+
 def test_not_in_filter() -> None:
     """Test creating not_in filter dependency."""
     deps = _create_statement_filters({"not_in_fields": ["status"]})

--- a/tests/unit/test_extensions/test_litestar/test_providers_wire_compat.py
+++ b/tests/unit/test_extensions/test_litestar/test_providers_wire_compat.py
@@ -1,0 +1,44 @@
+"""Wire-compatibility tests for shared provider utilities."""
+
+import pytest
+
+from advanced_alchemy.utils.dependencies import (
+    DependencyCache as CoreDependencyCache,
+)
+from advanced_alchemy.utils.dependencies import (
+    FieldNameType as CoreFieldNameType,
+)
+from advanced_alchemy.utils.dependencies import (
+    FilterConfig as CoreFilterConfig,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def test_litestar_provider_reexports_core_dependency_utilities() -> None:
+    from advanced_alchemy.extensions.litestar import providers
+
+    assert providers.DependencyCache is CoreDependencyCache
+    assert providers.FieldNameType is CoreFieldNameType
+    assert providers.FilterConfig is CoreFilterConfig
+    assert {"DependencyCache", "FieldNameType", "FilterConfig"} <= set(providers.__all__)
+
+
+def test_fastapi_provider_reexports_core_dependency_utilities() -> None:
+    pytest.importorskip("fastapi")
+
+    from advanced_alchemy.extensions.fastapi import providers
+
+    assert providers.DependencyCache is CoreDependencyCache
+    assert providers.FieldNameType is CoreFieldNameType
+    assert providers.FilterConfig is CoreFilterConfig
+    assert {"DependencyCache", "FieldNameType", "FilterConfig"} <= set(providers.__all__)
+
+
+def test_provider_cache_namespaces_are_framework_scoped() -> None:
+    pytest.importorskip("fastapi")
+
+    from advanced_alchemy.extensions.fastapi import providers as fastapi_providers
+    from advanced_alchemy.extensions.litestar import providers as litestar_providers
+
+    assert litestar_providers._CACHE_NAMESPACE != fastapi_providers._CACHE_NAMESPACE

--- a/tests/unit/test_utils/test_dependencies.py
+++ b/tests/unit/test_utils/test_dependencies.py
@@ -1,0 +1,78 @@
+"""Unit tests for shared dependency-injection utilities."""
+
+from typing import Any, cast
+from unittest.mock import MagicMock
+
+import pytest
+
+from advanced_alchemy.utils.dependencies import DependencyCache, FieldNameType, FilterConfig, make_hashable
+from advanced_alchemy.utils.singleton import SingletonMeta
+
+pytestmark = pytest.mark.unit
+
+
+def test_field_name_type_is_named_tuple_with_default_type_hint() -> None:
+    field = FieldNameType(name="id")
+
+    assert field.name == "id"
+    assert field.type_hint is str
+    assert tuple(field) == ("id", str)
+
+
+def test_filter_config_allows_empty_config() -> None:
+    config: FilterConfig = {}
+
+    assert config == {}
+
+
+def test_make_hashable_dict_order_invariant() -> None:
+    left: dict[str, Any] = {"x": 1, "y": 2}
+    right: dict[str, Any] = {"y": 2, "x": 1}
+
+    assert make_hashable(left) == make_hashable(right)
+
+
+def test_make_hashable_nested_values() -> None:
+    config: FilterConfig = cast(
+        "FilterConfig",
+        {"sort_field": ("a", "b"), "search_ignore_case": True, "in_fields": [FieldNameType("tag")]},
+    )
+
+    assert make_hashable(config) == make_hashable(dict(config))
+
+
+def test_make_hashable_set_order_invariant() -> None:
+    assert make_hashable({1, 2, 3}) == make_hashable({3, 2, 1})
+
+
+def test_dependency_cache_singleton() -> None:
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        monkeypatch.setattr(SingletonMeta, "_instances", {})
+        first = DependencyCache()
+        second = DependencyCache()
+
+    assert first is second
+
+
+def test_dependency_cache_add_get_dependencies() -> None:
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        monkeypatch.setattr(SingletonMeta, "_instances", {})
+        cache = DependencyCache()
+        dependencies = {"filters": MagicMock()}
+
+        cache.add_dependencies("key", dependencies)
+
+        assert cache.get_dependencies("key") == dependencies
+        assert cache.get_dependencies("missing") is None
+
+
+def test_dependency_cache_get_set_by_config() -> None:
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        monkeypatch.setattr(SingletonMeta, "_instances", {})
+        cache = DependencyCache()
+        config: FilterConfig = {"id_field": "uuid"}
+        dependencies = {"filters": MagicMock()}
+
+        cache.set(config, dependencies)
+
+        assert cache.get(config) == dependencies

--- a/tests/unit/test_utils/test_dependencies.py
+++ b/tests/unit/test_utils/test_dependencies.py
@@ -5,7 +5,13 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from advanced_alchemy.utils.dependencies import DependencyCache, FieldNameType, FilterConfig, make_hashable
+from advanced_alchemy.utils.dependencies import (
+    DependencyCache,
+    FieldNameType,
+    FilterConfig,
+    make_hashable,
+    normalize_sort_field,
+)
 from advanced_alchemy.utils.singleton import SingletonMeta
 
 pytestmark = pytest.mark.unit
@@ -43,6 +49,18 @@ def test_make_hashable_nested_values() -> None:
 
 def test_make_hashable_set_order_invariant() -> None:
     assert make_hashable({1, 2, 3}) == make_hashable({3, 2, 1})
+
+
+def test_make_hashable_preserves_list_order() -> None:
+    assert make_hashable(["name", "id"]) != make_hashable(["id", "name"])
+
+
+def test_normalize_sort_field_preserves_list_order() -> None:
+    assert normalize_sort_field(["name", "id"]) == "name"
+
+
+def test_normalize_sort_field_sorts_set_values() -> None:
+    assert normalize_sort_field({"name", "id"}) == "id"
 
 
 def test_dependency_cache_singleton() -> None:


### PR DESCRIPTION
## Summary
- Extract shared provider dependency primitives into `advanced_alchemy.utils.dependencies`
- Normalize multi-field `sort_field` defaults before creating `OrderBy` filters for Litestar and FastAPI
- Keep Litestar individual filter injection working while preserving typed OpenAPI sort parameters
- Scope cache keys per framework so the shared singleton cache cannot cross-return Litestar/FastAPI dependency objects

## Linked Issues
- Refs #602

## Branch State
- Rebased after the `v1.10.0` release onto `main` at `83ec1175`
- PR head: `cofin:feat/service-composition-utility-extraction` at `9f08f2fc`
- Mirrored the same commit to `litestar-org:feat/service-composition-utility-extraction` because #722 uses that branch as its base
- This PR is no longer stacked on #716

## Validation
- `uv run pytest tests/unit/test_utils/test_dependencies.py tests/unit/test_extensions/test_litestar/test_providers.py tests/unit/test_extensions/test_fastapi/test_providers.py tests/unit/test_extensions/test_litestar/test_providers_wire_compat.py`
- `uv run pytest tests/integration/test_filters.py -k "OrderBy or InstrumentedAttribute or func"`
- `make lint`

<!-- docs-preview -->

<hr>
📚 Documentation preview: <a href="https://litestar-org.github.io/advanced-alchemy-docs-preview/721">https://litestar-org.github.io/advanced-alchemy-docs-preview/721</a> 
