### PR TITLE
feat(types): dialect-aware Vector column type

### DIFF
--- a/advanced_alchemy/types/__init__.py
+++ b/advanced_alchemy/types/__init__.py
@@ -22,6 +22,7 @@ from advanced_alchemy.types.identity import BigIntIdentity
 from advanced_alchemy.types.json import ORA_JSONB, JsonB
 from advanced_alchemy.types.mutables import MutableList
 from advanced_alchemy.types.password_hash.base import HashedPassword, PasswordHash
+from advanced_alchemy.types.vector import Vector
 
 __all__ = (
     "GUID",
@@ -44,6 +45,7 @@ __all__ = (
     "StorageBackendT",
     "StorageRegistry",
     "StoredObject",
+    "Vector",
     "encrypted_string",
     "file_object",
     "password_hash",

--- a/advanced_alchemy/types/vector.py
+++ b/advanced_alchemy/types/vector.py
@@ -1,0 +1,67 @@
+"""Dialect-aware ``Vector`` column type.
+
+Provides a single user-facing :class:`Vector` class that resolves to the most
+appropriate backend representation per dialect:
+
+- Oracle 23ai → ``sqlalchemy.dialects.oracle.VECTOR(dim, storage_format)``
+- PostgreSQL / CockroachDB → ``pgvector.sqlalchemy.Vector(dim)`` when
+  ``pgvector`` is importable, otherwise the cross-dialect JSON fallback.
+- All other dialects → ``sqlalchemy.types.JSON`` round-trip as a JSON array.
+
+The pattern mirrors :class:`advanced_alchemy.types.guid.GUID`: one
+``TypeDecorator`` with a single constructor, and ``load_dialect_impl`` selects
+the backend impl at DDL/compile time. Backend libraries are imported lazily
+inside ``load_dialect_impl`` so ``from advanced_alchemy.types import Vector``
+never requires ``pgvector`` or ``oracledb`` to be installed.
+"""
+
+from typing import Any, Optional
+
+from sqlalchemy.engine import Dialect
+from sqlalchemy.types import JSON, TypeDecorator, TypeEngine
+
+__all__ = ("Vector",)
+
+
+class Vector(TypeDecorator[list[float]]):
+    """Dialect-aware fixed-dimension vector column.
+
+    Args:
+        dim: The vector dimension. Required by every supported backend.
+        storage_format: Oracle 23ai storage format name (matched against
+            :class:`sqlalchemy.dialects.oracle.VectorStorageFormat`).
+            Defaults to ``"FLOAT32"``. Ignored on non-Oracle backends.
+    """
+
+    impl = JSON
+    cache_ok = True
+
+    @property
+    def python_type(self) -> type[list[float]]:
+        return list
+
+    def __init__(self, dim: int, *, storage_format: str = "FLOAT32") -> None:
+        super().__init__()
+        self.dim = dim
+        self.storage_format = storage_format
+
+    def load_dialect_impl(self, dialect: Dialect) -> TypeEngine[Any]:
+        if dialect.name == "oracle":
+            from sqlalchemy.dialects.oracle import VECTOR, VectorStorageFormat
+
+            fmt = VectorStorageFormat[self.storage_format]
+            return dialect.type_descriptor(VECTOR(dim=self.dim, storage_format=fmt))  # type: ignore[no-untyped-call]
+        if dialect.name in {"postgresql", "cockroachdb"}:
+            try:
+                from pgvector.sqlalchemy import Vector as PgVector  # pyright: ignore[reportMissingTypeStubs]
+            except ImportError:
+                return dialect.type_descriptor(JSON())
+            return dialect.type_descriptor(PgVector(self.dim))
+        return dialect.type_descriptor(JSON())
+
+    def process_result_value(self, value: Any, dialect: Dialect) -> Optional[list[float]]:
+        if value is None:
+            return None
+        if hasattr(value, "tolist"):
+            return list(value.tolist())
+        return list(value)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,8 +3,7 @@
 1.x Changelog
 =============
 
-.. changelog:: 1.10.0
-    :date: 2026-05-23
+.. changelog:: 1.11.0
 
     .. change:: dialect-aware ``Vector`` column type
         :type: feature
@@ -40,6 +39,9 @@
         layer and unlocks the Oracle 23ai feature matrix (native ``VECTOR``,
         ``HNSW``/``IVF`` indexes, and — when SQLAlchemy 2.1 lands — native
         ``BOOLEAN`` and ``JSON``).
+
+.. changelog:: 1.10.0
+    :date: 2026-05-23
 
     .. change:: configurable serialization with Protocol-based architecture
         :type: feature

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,28 @@
 .. changelog:: 1.10.0
     :date: 2026-05-23
 
+    .. change:: dialect-aware ``Vector`` column type
+        :type: feature
+
+        Adds :class:`advanced_alchemy.types.Vector`, a unified ``TypeDecorator``
+        that resolves to the most appropriate backend representation per
+        dialect:
+
+        - Oracle 23ai → ``sqlalchemy.dialects.oracle.VECTOR(dim, storage_format)``
+        - PostgreSQL / CockroachDB → ``pgvector.sqlalchemy.Vector(dim)`` when
+          ``pgvector`` is importable.
+        - All other dialects (sqlite, mysql, mssql, ...) → JSON round-trip as a
+          JSON array.
+
+        The pattern mirrors :class:`advanced_alchemy.types.guid.GUID`: one
+        ``TypeDecorator`` with a single ``__init__(dim, *, storage_format)``
+        signature, and ``load_dialect_impl`` selects the backend at DDL emit.
+        ``pgvector`` and ``oracledb`` are imported lazily inside
+        ``load_dialect_impl`` so ``from advanced_alchemy.types import Vector``
+        works on a bare install. Result values from any backend (Oracle's
+        ``array.array``, pgvector's ``numpy.ndarray``, JSON's ``list``) are
+        normalized to ``list[float]`` so downstream code is portable.
+
     .. change:: bump SQLAlchemy floor to 2.0.41 for native Oracle 23ai VECTOR support
         :type: misc
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,43 +3,6 @@
 1.x Changelog
 =============
 
-.. changelog:: 1.11.0
-
-    .. change:: dialect-aware ``Vector`` column type
-        :type: feature
-
-        Adds :class:`advanced_alchemy.types.Vector`, a unified ``TypeDecorator``
-        that resolves to the most appropriate backend representation per
-        dialect:
-
-        - Oracle 23ai → ``sqlalchemy.dialects.oracle.VECTOR(dim, storage_format)``
-        - PostgreSQL / CockroachDB → ``pgvector.sqlalchemy.Vector(dim)`` when
-          ``pgvector`` is importable.
-        - All other dialects (sqlite, mysql, mssql, ...) → JSON round-trip as a
-          JSON array.
-
-        The pattern mirrors :class:`advanced_alchemy.types.guid.GUID`: one
-        ``TypeDecorator`` with a single ``__init__(dim, *, storage_format)``
-        signature, and ``load_dialect_impl`` selects the backend at DDL emit.
-        ``pgvector`` and ``oracledb`` are imported lazily inside
-        ``load_dialect_impl`` so ``from advanced_alchemy.types import Vector``
-        works on a bare install. Result values from any backend (Oracle's
-        ``array.array``, pgvector's ``numpy.ndarray``, JSON's ``list``) are
-        normalized to ``list[float]`` so downstream code is portable.
-
-    .. change:: bump SQLAlchemy floor to 2.0.41 for native Oracle 23ai VECTOR support
-        :type: misc
-
-        Raises the minimum required ``sqlalchemy`` version from ``>=2.0.20`` to
-        ``>=2.0.41``. SQLAlchemy 2.0.41 introduced the
-        ``sqlalchemy.dialects.oracle.VECTOR``, ``VectorIndexConfig``,
-        ``VectorIndexType``, ``VectorDistanceType``, and ``VectorStorageFormat``
-        symbols required by the new dialect-aware ``Vector`` column type. The
-        floor bump removes the need for runtime ``getattr`` probes in the type
-        layer and unlocks the Oracle 23ai feature matrix (native ``VECTOR``,
-        ``HNSW``/``IVF`` indexes, and — when SQLAlchemy 2.1 lands — native
-        ``BOOLEAN`` and ``JSON``).
-
 .. changelog:: 1.10.0
     :date: 2026-05-23
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,19 @@
 .. changelog:: 1.10.0
     :date: 2026-05-23
 
+    .. change:: bump SQLAlchemy floor to 2.0.41 for native Oracle 23ai VECTOR support
+        :type: misc
+
+        Raises the minimum required ``sqlalchemy`` version from ``>=2.0.20`` to
+        ``>=2.0.41``. SQLAlchemy 2.0.41 introduced the
+        ``sqlalchemy.dialects.oracle.VECTOR``, ``VectorIndexConfig``,
+        ``VectorIndexType``, ``VectorDistanceType``, and ``VectorStorageFormat``
+        symbols required by the new dialect-aware ``Vector`` column type. The
+        floor bump removes the need for runtime ``getattr`` probes in the type
+        layer and unlocks the Oracle 23ai feature matrix (native ``VECTOR``,
+        ``HNSW``/``IVF`` indexes, and — when SQLAlchemy 2.1 lands — native
+        ``BOOLEAN`` and ``JSON``).
+
     .. change:: configurable serialization with Protocol-based architecture
         :type: feature
         :pr: 716

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -470,6 +470,8 @@ module = [
   "fsspec.*",
   "argon2",
   "argon2.*",
+  "pgvector",
+  "pgvector.*",
 ]
 
 [[tool.mypy.overrides]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
   "Topic :: Database :: Database Engines/Servers",
 ]
 dependencies = [
-  "sqlalchemy>=2.0.20",
+  "sqlalchemy>=2.0.41",
   "alembic>=1.12.0",
   "typing-extensions>=4.0.0",
   "greenlet",

--- a/tests/unit/test_types/test_vector.py
+++ b/tests/unit/test_types/test_vector.py
@@ -5,13 +5,14 @@ import importlib
 import subprocess
 import sys
 import textwrap
-from typing import Optional
+from typing import Any, Optional, cast
 
 import pytest
-from sqlalchemy import Column, MetaData, Table, create_engine, insert, select
+from sqlalchemy import Integer, Table, create_engine, insert, select
 from sqlalchemy.dialects import oracle as oracle_dialect_mod
 from sqlalchemy.dialects import postgresql as postgresql_dialect_mod
 from sqlalchemy.dialects import sqlite as sqlite_dialect_mod
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 from sqlalchemy.types import JSON
 
 from advanced_alchemy.types import Vector
@@ -63,7 +64,7 @@ def test_vector_default_impl_is_json() -> None:
 
 def test_vector_sqlite_falls_back_to_json() -> None:
     """On dialects without a native vector type, ``Vector`` resolves to JSON."""
-    dialect = sqlite_dialect_mod.dialect()
+    dialect = sqlite_dialect_mod.dialect()  # type: ignore[no-untyped-call,unused-ignore]
     resolved = Vector(3).dialect_impl(dialect)
     assert isinstance(resolved.impl, JSON)
 
@@ -71,9 +72,9 @@ def test_vector_sqlite_falls_back_to_json() -> None:
 def test_vector_postgresql_uses_pgvector_when_available() -> None:
     """On PostgreSQL/CockroachDB, ``Vector`` selects the ``pgvector`` impl."""
     pytest.importorskip("pgvector.sqlalchemy")
-    from pgvector.sqlalchemy import Vector as PgVector
+    from pgvector.sqlalchemy import Vector as PgVector  # pyright: ignore[reportMissingTypeStubs]
 
-    dialect = postgresql_dialect_mod.dialect()
+    dialect = postgresql_dialect_mod.dialect()  # type: ignore[no-untyped-call,unused-ignore]
     resolved = Vector(1536).dialect_impl(dialect)
     assert isinstance(resolved.impl, PgVector)
     assert resolved.impl.dim == 1536
@@ -83,7 +84,7 @@ def test_vector_postgresql_without_pgvector_falls_back_to_json(monkeypatch: pyte
     """If ``pgvector`` cannot be imported, PostgreSQL emits the JSON fallback."""
     real_import = importlib.import_module
 
-    def fake_import(name: str, *args: object, **kwargs: object):
+    def fake_import(name: str, *args: Any, **kwargs: Any) -> Any:
         if name.startswith("pgvector"):
             raise ImportError(name)
         return real_import(name, *args, **kwargs)
@@ -92,7 +93,7 @@ def test_vector_postgresql_without_pgvector_falls_back_to_json(monkeypatch: pyte
     monkeypatch.setitem(sys.modules, "pgvector", None)
     monkeypatch.setitem(sys.modules, "pgvector.sqlalchemy", None)
 
-    dialect = postgresql_dialect_mod.dialect()
+    dialect = postgresql_dialect_mod.dialect()  # type: ignore[no-untyped-call,unused-ignore]
     resolved = Vector(4).dialect_impl(dialect)
     assert isinstance(resolved.impl, JSON)
 
@@ -101,7 +102,7 @@ def test_vector_oracle_uses_native_vector_type() -> None:
     """On Oracle, ``Vector`` selects ``oracle.VECTOR`` with the requested storage format."""
     from sqlalchemy.dialects.oracle import VECTOR, VectorStorageFormat
 
-    dialect = oracle_dialect_mod.dialect()
+    dialect = oracle_dialect_mod.dialect()  # type: ignore[no-untyped-call,unused-ignore]
     resolved = Vector(1024, storage_format="FLOAT64").dialect_impl(dialect)
     assert isinstance(resolved.impl, VECTOR)
     assert resolved.impl.dim == 1024
@@ -110,9 +111,17 @@ def test_vector_oracle_uses_native_vector_type() -> None:
 
 def test_vector_oracle_ddl_compiles_with_dim_and_format() -> None:
     """DDL for ``Vector`` on Oracle includes the dimension and storage format."""
-    dialect = oracle_dialect_mod.dialect()
-    column = Column("embedding", Vector(8, storage_format="FLOAT32"))
-    ddl = str(column.type.compile(dialect=dialect))
+
+    class _Base(DeclarativeBase):
+        pass
+
+    class _OracleVectorModel(_Base):
+        __tablename__ = "oracle_vector_model"
+        id: Mapped[int] = mapped_column(Integer, primary_key=True)
+        embedding: Mapped[list[float]] = mapped_column(Vector(8, storage_format="FLOAT32"))
+
+    dialect = oracle_dialect_mod.dialect()  # type: ignore[no-untyped-call,unused-ignore]
+    ddl = str(_OracleVectorModel.__table__.c.embedding.type.compile(dialect=dialect))  # type: ignore[no-untyped-call,unused-ignore]
     assert "VECTOR" in ddl
     assert "8" in ddl
     assert "FLOAT32" in ddl
@@ -122,7 +131,7 @@ def test_vector_process_result_value_normalizes_array_array() -> None:
     """Oracle's ``array.array`` result is normalized to ``list[float]``."""
     vec = Vector(3)
     raw = array.array("f", [1.0, 2.0, 3.0])
-    assert vec.process_result_value(raw, oracle_dialect_mod.dialect()) == [1.0, 2.0, 3.0]
+    assert vec.process_result_value(raw, oracle_dialect_mod.dialect()) == [1.0, 2.0, 3.0]  # type: ignore[no-untyped-call,unused-ignore]
 
 
 def test_vector_process_result_value_normalizes_tolist_result() -> None:
@@ -136,33 +145,36 @@ def test_vector_process_result_value_normalizes_tolist_result() -> None:
             return list(self._values)
 
     vec = Vector(2)
-    assert vec.process_result_value(FakeNumpy([0.5, 0.25]), postgresql_dialect_mod.dialect()) == [0.5, 0.25]
+    assert vec.process_result_value(FakeNumpy([0.5, 0.25]), postgresql_dialect_mod.dialect()) == [0.5, 0.25]  # type: ignore[no-untyped-call,unused-ignore]
 
 
 def test_vector_process_result_value_preserves_none() -> None:
     """``None`` survives the result normalization step unchanged."""
-    assert Vector(4).process_result_value(None, sqlite_dialect_mod.dialect()) is None
+    assert Vector(4).process_result_value(None, sqlite_dialect_mod.dialect()) is None  # type: ignore[no-untyped-call,unused-ignore]
 
 
 def test_vector_process_result_value_returns_list_for_plain_iterable() -> None:
     """JSON fallback returns a plain ``list`` (or anything iterable) and stays a ``list``."""
     vec = Vector(3)
-    assert vec.process_result_value([1.0, 2.0, 3.0], sqlite_dialect_mod.dialect()) == [1.0, 2.0, 3.0]
+    assert vec.process_result_value([1.0, 2.0, 3.0], sqlite_dialect_mod.dialect()) == [1.0, 2.0, 3.0]  # type: ignore[no-untyped-call,unused-ignore]
 
 
 def test_vector_sqlite_round_trip_via_json_fallback() -> None:
     """End-to-end: insert a vector on SQLite and round-trip it back as ``list[float]``."""
+
+    class _Base(DeclarativeBase):
+        pass
+
+    class _SqliteVectorModel(_Base):
+        __tablename__ = "vector_round_trip_model"
+        id: Mapped[int] = mapped_column(Integer, primary_key=True)
+        embedding: Mapped[list[float]] = mapped_column(Vector(3))
+
     engine = create_engine("sqlite:///:memory:")
-    metadata = MetaData()
-    table = Table(
-        "vectors",
-        metadata,
-        Column("id", primary_key=True, type_=__import__("sqlalchemy").Integer),
-        Column("embedding", Vector(3)),
-    )
-    metadata.create_all(engine)
+    _Base.metadata.create_all(engine)
+    table = cast(Table, _SqliteVectorModel.__table__)
     with engine.begin() as conn:
         conn.execute(insert(table).values(id=1, embedding=[0.1, 0.2, 0.3]))
-        row: Optional[tuple] = conn.execute(select(table.c.embedding).where(table.c.id == 1)).first()
+        row: Optional[Any] = conn.execute(select(table.c.embedding).where(table.c.id == 1)).first()
     assert row is not None
     assert row[0] == [0.1, 0.2, 0.3]

--- a/tests/unit/test_types/test_vector.py
+++ b/tests/unit/test_types/test_vector.py
@@ -1,0 +1,168 @@
+"""Unit tests for the dialect-aware ``Vector`` type."""
+
+import array
+import importlib
+import subprocess
+import sys
+import textwrap
+from typing import Optional
+
+import pytest
+from sqlalchemy import Column, MetaData, Table, create_engine, insert, select
+from sqlalchemy.dialects import oracle as oracle_dialect_mod
+from sqlalchemy.dialects import postgresql as postgresql_dialect_mod
+from sqlalchemy.dialects import sqlite as sqlite_dialect_mod
+from sqlalchemy.types import JSON
+
+from advanced_alchemy.types import Vector
+
+
+def test_vector_is_publicly_exported() -> None:
+    """``Vector`` is part of the public ``advanced_alchemy.types`` API."""
+    import advanced_alchemy.types as aa_types
+
+    assert "Vector" in aa_types.__all__
+    assert aa_types.Vector is Vector
+
+
+def test_vector_import_does_not_load_optional_backends() -> None:
+    """Importing ``advanced_alchemy.types`` must not import ``pgvector`` or ``oracledb``."""
+    script = textwrap.dedent(
+        """
+        import sys
+        import advanced_alchemy.types  # noqa: F401
+
+        assert "pgvector" not in sys.modules, "pgvector loaded eagerly: " + repr(sorted(sys.modules))
+        assert "oracledb" not in sys.modules, "oracledb loaded eagerly: " + repr(sorted(sys.modules))
+        """,
+    )
+    completed = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert completed.returncode == 0, completed.stderr
+
+
+def test_vector_constructor_records_dim_and_storage_format() -> None:
+    vec = Vector(1536)
+    assert vec.dim == 1536
+    assert vec.storage_format == "FLOAT32"
+
+    vec64 = Vector(8, storage_format="FLOAT64")
+    assert vec64.dim == 8
+    assert vec64.storage_format == "FLOAT64"
+
+
+def test_vector_default_impl_is_json() -> None:
+    """The cross-dialect fallback ``impl`` is JSON so unknown dialects round-trip lists."""
+    assert Vector.impl is JSON
+    assert Vector.cache_ok is True
+
+
+def test_vector_sqlite_falls_back_to_json() -> None:
+    """On dialects without a native vector type, ``Vector`` resolves to JSON."""
+    dialect = sqlite_dialect_mod.dialect()
+    resolved = Vector(3).dialect_impl(dialect)
+    assert isinstance(resolved.impl, JSON)
+
+
+def test_vector_postgresql_uses_pgvector_when_available() -> None:
+    """On PostgreSQL/CockroachDB, ``Vector`` selects the ``pgvector`` impl."""
+    pytest.importorskip("pgvector.sqlalchemy")
+    from pgvector.sqlalchemy import Vector as PgVector
+
+    dialect = postgresql_dialect_mod.dialect()
+    resolved = Vector(1536).dialect_impl(dialect)
+    assert isinstance(resolved.impl, PgVector)
+    assert resolved.impl.dim == 1536
+
+
+def test_vector_postgresql_without_pgvector_falls_back_to_json(monkeypatch: pytest.MonkeyPatch) -> None:
+    """If ``pgvector`` cannot be imported, PostgreSQL emits the JSON fallback."""
+    real_import = importlib.import_module
+
+    def fake_import(name: str, *args: object, **kwargs: object):
+        if name.startswith("pgvector"):
+            raise ImportError(name)
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(importlib, "import_module", fake_import)
+    monkeypatch.setitem(sys.modules, "pgvector", None)
+    monkeypatch.setitem(sys.modules, "pgvector.sqlalchemy", None)
+
+    dialect = postgresql_dialect_mod.dialect()
+    resolved = Vector(4).dialect_impl(dialect)
+    assert isinstance(resolved.impl, JSON)
+
+
+def test_vector_oracle_uses_native_vector_type() -> None:
+    """On Oracle, ``Vector`` selects ``oracle.VECTOR`` with the requested storage format."""
+    from sqlalchemy.dialects.oracle import VECTOR, VectorStorageFormat
+
+    dialect = oracle_dialect_mod.dialect()
+    resolved = Vector(1024, storage_format="FLOAT64").dialect_impl(dialect)
+    assert isinstance(resolved.impl, VECTOR)
+    assert resolved.impl.dim == 1024
+    assert resolved.impl.storage_format is VectorStorageFormat.FLOAT64
+
+
+def test_vector_oracle_ddl_compiles_with_dim_and_format() -> None:
+    """DDL for ``Vector`` on Oracle includes the dimension and storage format."""
+    dialect = oracle_dialect_mod.dialect()
+    column = Column("embedding", Vector(8, storage_format="FLOAT32"))
+    ddl = str(column.type.compile(dialect=dialect))
+    assert "VECTOR" in ddl
+    assert "8" in ddl
+    assert "FLOAT32" in ddl
+
+
+def test_vector_process_result_value_normalizes_array_array() -> None:
+    """Oracle's ``array.array`` result is normalized to ``list[float]``."""
+    vec = Vector(3)
+    raw = array.array("f", [1.0, 2.0, 3.0])
+    assert vec.process_result_value(raw, oracle_dialect_mod.dialect()) == [1.0, 2.0, 3.0]
+
+
+def test_vector_process_result_value_normalizes_tolist_result() -> None:
+    """Anything that exposes ``.tolist()`` (numpy arrays, pgvector results) is normalized."""
+
+    class FakeNumpy:
+        def __init__(self, values: list[float]) -> None:
+            self._values = values
+
+        def tolist(self) -> list[float]:
+            return list(self._values)
+
+    vec = Vector(2)
+    assert vec.process_result_value(FakeNumpy([0.5, 0.25]), postgresql_dialect_mod.dialect()) == [0.5, 0.25]
+
+
+def test_vector_process_result_value_preserves_none() -> None:
+    """``None`` survives the result normalization step unchanged."""
+    assert Vector(4).process_result_value(None, sqlite_dialect_mod.dialect()) is None
+
+
+def test_vector_process_result_value_returns_list_for_plain_iterable() -> None:
+    """JSON fallback returns a plain ``list`` (or anything iterable) and stays a ``list``."""
+    vec = Vector(3)
+    assert vec.process_result_value([1.0, 2.0, 3.0], sqlite_dialect_mod.dialect()) == [1.0, 2.0, 3.0]
+
+
+def test_vector_sqlite_round_trip_via_json_fallback() -> None:
+    """End-to-end: insert a vector on SQLite and round-trip it back as ``list[float]``."""
+    engine = create_engine("sqlite:///:memory:")
+    metadata = MetaData()
+    table = Table(
+        "vectors",
+        metadata,
+        Column("id", primary_key=True, type_=__import__("sqlalchemy").Integer),
+        Column("embedding", Vector(3)),
+    )
+    metadata.create_all(engine)
+    with engine.begin() as conn:
+        conn.execute(insert(table).values(id=1, embedding=[0.1, 0.2, 0.3]))
+        row: Optional[tuple] = conn.execute(select(table.c.embedding).where(table.c.id == 1)).first()
+    assert row is not None
+    assert row[0] == [0.1, 0.2, 0.3]

--- a/uv.lock
+++ b/uv.lock
@@ -379,7 +379,7 @@ requires-dist = [
     { name = "passlib", extras = ["argon2"], marker = "extra == 'passlib'" },
     { name = "pwdlib", extras = ["argon2"], marker = "extra == 'pwdlib'" },
     { name = "rich-click", marker = "extra == 'cli'" },
-    { name = "sqlalchemy", specifier = ">=2.0.20" },
+    { name = "sqlalchemy", specifier = ">=2.0.41" },
     { name = "typing-extensions", specifier = ">=4.0.0" },
     { name = "uuid-utils", marker = "extra == 'uuid'", specifier = ">=0.6.1" },
 ]


### PR DESCRIPTION
Adds `advanced_alchemy.types.Vector` — a single dialect-aware column type that resolves to:

- `sqlalchemy.dialects.oracle.VECTOR(dim, storage_format)` on Oracle 23ai
- `pgvector.sqlalchemy.Vector(dim)` on PostgreSQL/CockroachDB when `pgvector` is importable
- `JSON` round-trip on everything else (sqlite, mysql, mssql)

Same mental model as `GUID` / `JsonB` — one user-facing class, dialect picks the impl at DDL emit. Bumps the `sqlalchemy` floor to 2.0.41 so the Oracle VECTOR symbols can be imported unconditionally.

##  Notes

- **No eager backend imports.** `pgvector` and `oracledb` are imported inside `load_dialect_impl`, so `from advanced_alchemy.types import Vector` works on a bare install. Verified by a subprocess test that asserts neither module is in `sys.modules` after import.
- **Result normalization.** Oracle returns `array.array`, pgvector returns `numpy.ndarray`, JSON returns `list`. `process_result_value` collapses all three to `list[float]` so callers can be portable without writing per-dialect branches.
- **Why `TypeDecorator` instead of `with_variant` (the `JsonB` pattern).** `pgvector.Vector(N)` and `oracle.VECTOR(dim=N, storage_format=...)` have different constructor signatures; `with_variant` can't route the user's `dim` through to both. The `GUID` pattern (one `TypeDecorator` + `load_dialect_impl`) carries the constructor args on the wrapper until the dialect is known.
- **JSON as the baseline `impl`.** Cross-dialect tests get a free round-trip without any extra serialization plumbing — vectors land as JSON arrays on sqlite/mysql/mssql.

<!-- docs-preview -->

<hr>
📚 Documentation preview: <a href="https://litestar-org.github.io/advanced-alchemy-docs-preview/739">https://litestar-org.github.io/advanced-alchemy-docs-preview/739</a> 
