### PR TITLE
feat(types): swap ORA_JSONB to native oracle.JSON on SA 2.1+

### DIFF
--- a/advanced_alchemy/alembic/templates/asyncio/script.py.mako
+++ b/advanced_alchemy/alembic/templates/asyncio/script.py.mako
@@ -11,7 +11,7 @@ from typing import TYPE_CHECKING, Any
 
 import sqlalchemy as sa
 from alembic import op
-from advanced_alchemy.types import EncryptedString, EncryptedText, GUID, ORA_JSONB, DateTimeUTC, StoredObject, PasswordHash, FernetBackend
+from advanced_alchemy.types import EncryptedString, EncryptedText, GUID, JsonB, ORA_JSONB, DateTimeUTC, StoredObject, PasswordHash, FernetBackend
 from advanced_alchemy.types.encrypted_string import PGCryptoBackend
 from sqlalchemy import Text  # noqa: F401
 ${imports if imports else ""}
@@ -35,6 +35,7 @@ __all__ = ["downgrade", "upgrade", "schema_upgrades", "schema_downgrades", "data
 
 sa.GUID = GUID
 sa.DateTimeUTC = DateTimeUTC
+sa.JsonB = JsonB
 sa.ORA_JSONB = ORA_JSONB
 sa.EncryptedString = EncryptedString
 sa.EncryptedText = EncryptedText

--- a/advanced_alchemy/alembic/templates/sync/script.py.mako
+++ b/advanced_alchemy/alembic/templates/sync/script.py.mako
@@ -11,7 +11,7 @@ from typing import TYPE_CHECKING, Any
 
 import sqlalchemy as sa
 from alembic import op
-from advanced_alchemy.types import EncryptedString, EncryptedText, GUID, ORA_JSONB, DateTimeUTC, StoredObject, PasswordHash, FernetBackend
+from advanced_alchemy.types import EncryptedString, EncryptedText, GUID, JsonB, ORA_JSONB, DateTimeUTC, StoredObject, PasswordHash, FernetBackend
 from advanced_alchemy.types.encrypted_string import PGCryptoBackend
 from sqlalchemy import Text  # noqa: F401
 ${imports if imports else ""}
@@ -35,6 +35,7 @@ __all__ = ["downgrade", "upgrade", "schema_upgrades", "schema_downgrades", "data
 
 sa.GUID = GUID
 sa.DateTimeUTC = DateTimeUTC
+sa.JsonB = JsonB
 sa.ORA_JSONB = ORA_JSONB
 sa.EncryptedString = EncryptedString
 sa.EncryptedText = EncryptedText

--- a/advanced_alchemy/types/json.py
+++ b/advanced_alchemy/types/json.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional, Union, cast
+from typing import Any, Optional, Union
 
 from sqlalchemy import text, util
 from sqlalchemy.dialects.oracle import BLOB as ORA_BLOB
@@ -10,6 +10,10 @@ from sqlalchemy.types import SchemaType, TypeDecorator, TypeEngine
 from advanced_alchemy.utils.serialization import decode_json, encode_json
 
 __all__ = ("ORA_JSONB",)
+
+
+_ORACLE_NATIVE_JSON_MIN_VERSION = 21
+"""Oracle Database major version that introduced the native ``JSON`` data type."""
 
 
 class ORA_JSONB(TypeDecorator[dict[str, Any]], SchemaType):  # noqa: N801
@@ -35,6 +39,13 @@ class ORA_JSONB(TypeDecorator[dict[str, Any]], SchemaType):  # noqa: N801
         return self.impl.coerce_compared_value(op=op, value=value)  # type: ignore[no-untyped-call, call-arg]
 
     def load_dialect_impl(self, dialect: Dialect) -> TypeEngine[Any]:
+        try:
+            from sqlalchemy.dialects.oracle import JSON as ORA_JSON
+        except ImportError:
+            return dialect.type_descriptor(ORA_BLOB())
+        sv = dialect.server_version_info
+        if sv and sv[0] >= _ORACLE_NATIVE_JSON_MIN_VERSION:
+            return dialect.type_descriptor(ORA_JSON())
         return dialect.type_descriptor(ORA_BLOB())
 
     def process_bind_param(self, value: Any, dialect: Dialect) -> Optional[Any]:
@@ -46,7 +57,14 @@ class ORA_JSONB(TypeDecorator[dict[str, Any]], SchemaType):  # noqa: N801
         return value
 
     def _should_create_constraint(self, compiler: Any, **kw: Any) -> bool:
-        return cast("bool", compiler.dialect.name == "oracle")
+        if compiler.dialect.name != "oracle":
+            return False
+        try:
+            from sqlalchemy.dialects.oracle import JSON as ORA_JSON  # noqa: F401
+        except ImportError:
+            return True
+        sv = compiler.dialect.server_version_info
+        return not (sv and sv[0] >= _ORACLE_NATIVE_JSON_MIN_VERSION)
 
     def _variant_mapping_for_set_table(self, column: Any) -> Optional[dict[str, Any]]:
         if column.type._variant_mapping:  # noqa: SLF001

--- a/advanced_alchemy/types/json.py
+++ b/advanced_alchemy/types/json.py
@@ -39,13 +39,14 @@ class ORA_JSONB(TypeDecorator[dict[str, Any]], SchemaType):  # noqa: N801
         return self.impl.coerce_compared_value(op=op, value=value)  # type: ignore[no-untyped-call, call-arg]
 
     def load_dialect_impl(self, dialect: Dialect) -> TypeEngine[Any]:
-        try:
-            from sqlalchemy.dialects.oracle import JSON as ORA_JSON
-        except ImportError:
+        from sqlalchemy.dialects import oracle as _ora_dialect
+
+        ora_json = getattr(_ora_dialect, "JSON", None)
+        if ora_json is None:
             return dialect.type_descriptor(ORA_BLOB())
         sv = dialect.server_version_info
         if sv and sv[0] >= _ORACLE_NATIVE_JSON_MIN_VERSION:
-            return dialect.type_descriptor(ORA_JSON())
+            return dialect.type_descriptor(ora_json())
         return dialect.type_descriptor(ORA_BLOB())
 
     def process_bind_param(self, value: Any, dialect: Dialect) -> Optional[Any]:
@@ -59,9 +60,9 @@ class ORA_JSONB(TypeDecorator[dict[str, Any]], SchemaType):  # noqa: N801
     def _should_create_constraint(self, compiler: Any, **kw: Any) -> bool:
         if compiler.dialect.name != "oracle":
             return False
-        try:
-            from sqlalchemy.dialects.oracle import JSON as ORA_JSON  # noqa: F401
-        except ImportError:
+        from sqlalchemy.dialects import oracle as _ora_dialect
+
+        if not hasattr(_ora_dialect, "JSON"):
             return True
         sv = compiler.dialect.server_version_info
         return not (sv and sv[0] >= _ORACLE_NATIVE_JSON_MIN_VERSION)

--- a/tests/unit/test_types/test_json.py
+++ b/tests/unit/test_types/test_json.py
@@ -1,0 +1,120 @@
+"""Unit tests for advanced_alchemy.types.json.ORA_JSONB dialect dispatch."""
+
+import sys
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from sqlalchemy.dialects.oracle import BLOB as ORA_BLOB
+from sqlalchemy.engine import Dialect
+
+from advanced_alchemy.types.json import ORA_JSONB
+
+
+def _make_dialect(server_version_info: Any) -> MagicMock:
+    """Build a MagicMock dialect that returns the input descriptor unchanged."""
+    dialect = MagicMock(spec=Dialect)
+    dialect.name = "oracle"
+    dialect.server_version_info = server_version_info
+    dialect.type_descriptor.side_effect = lambda t: t
+    return dialect
+
+
+@pytest.fixture
+def _no_oracle_json(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Simulate SA 2.0.x where sqlalchemy.dialects.oracle has no JSON symbol."""
+    import sqlalchemy.dialects.oracle as ora
+
+    monkeypatch.delattr(ora, "JSON", raising=False)
+    monkeypatch.setitem(
+        sys.modules,
+        "sqlalchemy.dialects.oracle",
+        ora,
+    )
+
+
+@pytest.fixture
+def _with_oracle_json(monkeypatch: pytest.MonkeyPatch) -> type:
+    """Simulate SA 2.1+ by injecting a fake JSON class into sqlalchemy.dialects.oracle."""
+    import sqlalchemy.dialects.oracle as ora
+
+    class _FakeOracleJSON:
+        def __init__(self) -> None:
+            self.is_fake_native_oracle_json = True
+
+    monkeypatch.setattr(ora, "JSON", _FakeOracleJSON, raising=False)
+    return _FakeOracleJSON
+
+
+def test_load_dialect_impl_sa20_returns_blob(_no_oracle_json: None) -> None:
+    """SA 2.0.x: no native oracle.JSON available, fall back to ORA_BLOB."""
+    dialect = _make_dialect(server_version_info=(23, 0))
+    result = ORA_JSONB().load_dialect_impl(dialect)
+    assert isinstance(result, ORA_BLOB)
+
+
+def test_load_dialect_impl_sa21_oracle_23c_returns_native_json(_with_oracle_json: type) -> None:
+    """SA 2.1+ on Oracle 21c or newer returns native oracle.JSON."""
+    dialect = _make_dialect(server_version_info=(23, 0))
+    result = ORA_JSONB().load_dialect_impl(dialect)
+    assert isinstance(result, _with_oracle_json)
+
+
+def test_load_dialect_impl_sa21_oracle_21c_returns_native_json(_with_oracle_json: type) -> None:
+    """SA 2.1+ on Oracle 21c exactly returns native oracle.JSON."""
+    dialect = _make_dialect(server_version_info=(21, 0))
+    result = ORA_JSONB().load_dialect_impl(dialect)
+    assert isinstance(result, _with_oracle_json)
+
+
+def test_load_dialect_impl_sa21_oracle_19c_returns_blob(_with_oracle_json: type) -> None:
+    """SA 2.1+ on Oracle 19c falls back to ORA_BLOB."""
+    dialect = _make_dialect(server_version_info=(19, 0))
+    result = ORA_JSONB().load_dialect_impl(dialect)
+    assert isinstance(result, ORA_BLOB)
+
+
+def test_load_dialect_impl_sa21_missing_server_version_returns_blob(_with_oracle_json: type) -> None:
+    """SA 2.1+ but server_version_info is None (offline / first-connect) falls back to ORA_BLOB."""
+    dialect = _make_dialect(server_version_info=None)
+    result = ORA_JSONB().load_dialect_impl(dialect)
+    assert isinstance(result, ORA_BLOB)
+
+
+def test_should_create_constraint_non_oracle_dialect_returns_false() -> None:
+    """Non-oracle dialects never get the JSON CHECK constraint."""
+    compiler = MagicMock()
+    compiler.dialect.name = "postgresql"
+    assert ORA_JSONB()._should_create_constraint(compiler) is False
+
+
+def test_should_create_constraint_sa20_oracle_returns_true(_no_oracle_json: None) -> None:
+    """SA 2.0.x oracle still emits the 'is json (strict)' CHECK."""
+    compiler = MagicMock()
+    compiler.dialect.name = "oracle"
+    compiler.dialect.server_version_info = (23, 0)
+    assert ORA_JSONB()._should_create_constraint(compiler) is True
+
+
+def test_should_create_constraint_sa21_oracle_21c_returns_false(_with_oracle_json: type) -> None:
+    """SA 2.1+ oracle 21c+ skips CHECK because native JSON validates itself."""
+    compiler = MagicMock()
+    compiler.dialect.name = "oracle"
+    compiler.dialect.server_version_info = (21, 0)
+    assert ORA_JSONB()._should_create_constraint(compiler) is False
+
+
+def test_should_create_constraint_sa21_oracle_19c_returns_true(_with_oracle_json: type) -> None:
+    """SA 2.1+ oracle 19c still needs CHECK because we keep ORA_BLOB path."""
+    compiler = MagicMock()
+    compiler.dialect.name = "oracle"
+    compiler.dialect.server_version_info = (19, 0)
+    assert ORA_JSONB()._should_create_constraint(compiler) is True
+
+
+def test_should_create_constraint_sa21_oracle_missing_version_returns_true(_with_oracle_json: type) -> None:
+    """SA 2.1+ oracle with no server version info is treated like older Oracle and keeps CHECK."""
+    compiler = MagicMock()
+    compiler.dialect.name = "oracle"
+    compiler.dialect.server_version_info = None
+    assert ORA_JSONB()._should_create_constraint(compiler) is True


### PR DESCRIPTION
## Summary

Extends `ORA_JSONB.load_dialect_impl` to prefer `sqlalchemy.dialects.oracle.JSON` when available (SA 2.1+) on Oracle 21c+ servers. Falls back to the existing `ORA_BLOB` + `is json (strict)` CHECK constraint on SA 2.0.x or older Oracle. **Zero user-visible API change** — `mapped_column(JsonB)` keeps working everywhere.

Also exposes `JsonB` in the alembic `script.py.mako` migration templates (`sa.JsonB = JsonB`), since `JsonB` is the public type users write but was missing from the template alongside `ORA_JSONB`.

## Matrix

| Stack | DDL emitted |
|---|---|
| SA 2.0.x, any Oracle | `BLOB` + `CHECK (col is json strict)` (unchanged) |
| SA 2.1+, Oracle 18c/19c | `BLOB` + `CHECK (col is json strict)` (unchanged) |
| SA 2.1+, Oracle 21c/23ai | native `JSON`, no CHECK |
| postgresql / cockroachdb | `JSONB` (unchanged) |

SA-version detection uses attribute-presence (`getattr`) on `sqlalchemy.dialects.oracle`, not version-string parsing.

<!-- docs-preview -->

<hr>
📚 Documentation preview: <a href="https://litestar-org.github.io/advanced-alchemy-docs-preview/741">https://litestar-org.github.io/advanced-alchemy-docs-preview/741</a> 
