### PR TITLE
feat(types): add Oracle 23c-aware Bool

### DIFF
--- a/advanced_alchemy/alembic/templates/asyncio/script.py.mako
+++ b/advanced_alchemy/alembic/templates/asyncio/script.py.mako
@@ -11,7 +11,7 @@ from typing import TYPE_CHECKING, Any
 
 import sqlalchemy as sa
 from alembic import op
-from advanced_alchemy.types import EncryptedString, EncryptedText, GUID, ORA_JSONB, DateTimeUTC, StoredObject, PasswordHash, FernetBackend
+from advanced_alchemy.types import BooleanType, EncryptedString, EncryptedText, GUID, ORA_JSONB, DateTimeUTC, StoredObject, PasswordHash, FernetBackend
 from advanced_alchemy.types.encrypted_string import PGCryptoBackend
 from sqlalchemy import Text  # noqa: F401
 ${imports if imports else ""}
@@ -34,6 +34,7 @@ if TYPE_CHECKING:
 __all__ = ["downgrade", "upgrade", "schema_upgrades", "schema_downgrades", "data_upgrades", "data_downgrades"]
 
 sa.GUID = GUID
+sa.BooleanType = BooleanType
 sa.DateTimeUTC = DateTimeUTC
 sa.ORA_JSONB = ORA_JSONB
 sa.EncryptedString = EncryptedString

--- a/advanced_alchemy/alembic/templates/asyncio/script.py.mako
+++ b/advanced_alchemy/alembic/templates/asyncio/script.py.mako
@@ -11,7 +11,7 @@ from typing import TYPE_CHECKING, Any
 
 import sqlalchemy as sa
 from alembic import op
-from advanced_alchemy.types import BooleanType, EncryptedString, EncryptedText, GUID, ORA_JSONB, DateTimeUTC, StoredObject, PasswordHash, FernetBackend
+from advanced_alchemy.types import Bool, EncryptedString, EncryptedText, GUID, ORA_JSONB, DateTimeUTC, StoredObject, PasswordHash, FernetBackend
 from advanced_alchemy.types.encrypted_string import PGCryptoBackend
 from sqlalchemy import Text  # noqa: F401
 ${imports if imports else ""}
@@ -34,7 +34,7 @@ if TYPE_CHECKING:
 __all__ = ["downgrade", "upgrade", "schema_upgrades", "schema_downgrades", "data_upgrades", "data_downgrades"]
 
 sa.GUID = GUID
-sa.BooleanType = BooleanType
+sa.Bool = Bool
 sa.DateTimeUTC = DateTimeUTC
 sa.ORA_JSONB = ORA_JSONB
 sa.EncryptedString = EncryptedString

--- a/advanced_alchemy/alembic/templates/sync/script.py.mako
+++ b/advanced_alchemy/alembic/templates/sync/script.py.mako
@@ -11,7 +11,7 @@ from typing import TYPE_CHECKING, Any
 
 import sqlalchemy as sa
 from alembic import op
-from advanced_alchemy.types import EncryptedString, EncryptedText, GUID, ORA_JSONB, DateTimeUTC, StoredObject, PasswordHash, FernetBackend
+from advanced_alchemy.types import BooleanType, EncryptedString, EncryptedText, GUID, ORA_JSONB, DateTimeUTC, StoredObject, PasswordHash, FernetBackend
 from advanced_alchemy.types.encrypted_string import PGCryptoBackend
 from sqlalchemy import Text  # noqa: F401
 ${imports if imports else ""}
@@ -34,6 +34,7 @@ if TYPE_CHECKING:
 __all__ = ["downgrade", "upgrade", "schema_upgrades", "schema_downgrades", "data_upgrades", "data_downgrades"]
 
 sa.GUID = GUID
+sa.BooleanType = BooleanType
 sa.DateTimeUTC = DateTimeUTC
 sa.ORA_JSONB = ORA_JSONB
 sa.EncryptedString = EncryptedString

--- a/advanced_alchemy/alembic/templates/sync/script.py.mako
+++ b/advanced_alchemy/alembic/templates/sync/script.py.mako
@@ -11,7 +11,7 @@ from typing import TYPE_CHECKING, Any
 
 import sqlalchemy as sa
 from alembic import op
-from advanced_alchemy.types import BooleanType, EncryptedString, EncryptedText, GUID, ORA_JSONB, DateTimeUTC, StoredObject, PasswordHash, FernetBackend
+from advanced_alchemy.types import Bool, EncryptedString, EncryptedText, GUID, ORA_JSONB, DateTimeUTC, StoredObject, PasswordHash, FernetBackend
 from advanced_alchemy.types.encrypted_string import PGCryptoBackend
 from sqlalchemy import Text  # noqa: F401
 ${imports if imports else ""}
@@ -34,7 +34,7 @@ if TYPE_CHECKING:
 __all__ = ["downgrade", "upgrade", "schema_upgrades", "schema_downgrades", "data_upgrades", "data_downgrades"]
 
 sa.GUID = GUID
-sa.BooleanType = BooleanType
+sa.Bool = Bool
 sa.DateTimeUTC = DateTimeUTC
 sa.ORA_JSONB = ORA_JSONB
 sa.EncryptedString = EncryptedString

--- a/advanced_alchemy/types/__init__.py
+++ b/advanced_alchemy/types/__init__.py
@@ -1,6 +1,7 @@
 """SQLAlchemy custom types for use with the ORM."""
 
 from advanced_alchemy.types import encrypted_string, file_object, password_hash
+from advanced_alchemy.types.boolean import BooleanType
 from advanced_alchemy.types.datetime import DateTimeUTC
 from advanced_alchemy.types.encrypted_string import (
     EncryptedString,
@@ -29,6 +30,7 @@ __all__ = (
     "ORA_JSONB",
     "UUID_UTILS_INSTALLED",
     "BigIntIdentity",
+    "BooleanType",
     "DateTimeUTC",
     "EncryptedString",
     "EncryptedText",

--- a/advanced_alchemy/types/__init__.py
+++ b/advanced_alchemy/types/__init__.py
@@ -1,7 +1,7 @@
 """SQLAlchemy custom types for use with the ORM."""
 
 from advanced_alchemy.types import encrypted_string, file_object, password_hash
-from advanced_alchemy.types.boolean import BooleanType
+from advanced_alchemy.types.boolean import Bool
 from advanced_alchemy.types.datetime import DateTimeUTC
 from advanced_alchemy.types.encrypted_string import (
     EncryptedString,
@@ -30,7 +30,7 @@ __all__ = (
     "ORA_JSONB",
     "UUID_UTILS_INSTALLED",
     "BigIntIdentity",
-    "BooleanType",
+    "Bool",
     "DateTimeUTC",
     "EncryptedString",
     "EncryptedText",

--- a/advanced_alchemy/types/boolean.py
+++ b/advanced_alchemy/types/boolean.py
@@ -27,13 +27,14 @@ class _OracleAwareBoolean(TypeDecorator[bool]):
     def load_dialect_impl(self, dialect: Dialect) -> TypeEngine[Any]:
         if dialect.name != "oracle":
             return dialect.type_descriptor(Boolean())
-        try:
-            from sqlalchemy.dialects.oracle import BOOLEAN as ORA_BOOLEAN
-        except ImportError:
+        from sqlalchemy.dialects import oracle as _ora_dialect
+
+        ora_boolean = getattr(_ora_dialect, "BOOLEAN", None)
+        if ora_boolean is None:
             return dialect.type_descriptor(Boolean())
         sv = dialect.server_version_info
         if sv and sv[0] >= _ORACLE_NATIVE_BOOLEAN_MIN_VERSION:
-            return dialect.type_descriptor(ORA_BOOLEAN())
+            return dialect.type_descriptor(ora_boolean())
         return dialect.type_descriptor(Boolean())
 
 

--- a/advanced_alchemy/types/boolean.py
+++ b/advanced_alchemy/types/boolean.py
@@ -3,7 +3,7 @@ from typing import Any
 from sqlalchemy.engine import Dialect
 from sqlalchemy.types import Boolean, TypeDecorator, TypeEngine
 
-__all__ = ("BooleanType",)
+__all__ = ("Bool",)
 
 
 _ORACLE_NATIVE_BOOLEAN_MIN_VERSION = 23
@@ -38,4 +38,4 @@ class _OracleAwareBoolean(TypeDecorator[bool]):
         return dialect.type_descriptor(Boolean())
 
 
-BooleanType = _OracleAwareBoolean
+Bool = _OracleAwareBoolean

--- a/advanced_alchemy/types/boolean.py
+++ b/advanced_alchemy/types/boolean.py
@@ -1,0 +1,40 @@
+from typing import Any
+
+from sqlalchemy.engine import Dialect
+from sqlalchemy.types import Boolean, TypeDecorator, TypeEngine
+
+__all__ = ("BooleanType",)
+
+
+_ORACLE_NATIVE_BOOLEAN_MIN_VERSION = 23
+
+
+class _OracleAwareBoolean(TypeDecorator[bool]):
+    """Render native BOOLEAN on Oracle 23c+ when SA 2.1+ exposes it.
+
+    Falls back to SA stock Boolean (SMALLINT on Oracle) on SA 2.0.x or
+    Oracle servers older than 23c. Non-Oracle dialects always use stock
+    Boolean - no behavior change.
+    """
+
+    impl = Boolean
+    cache_ok = True
+
+    @property
+    def python_type(self) -> type[bool]:
+        return bool
+
+    def load_dialect_impl(self, dialect: Dialect) -> TypeEngine[Any]:
+        if dialect.name != "oracle":
+            return dialect.type_descriptor(Boolean())
+        try:
+            from sqlalchemy.dialects.oracle import BOOLEAN as ORA_BOOLEAN
+        except ImportError:
+            return dialect.type_descriptor(Boolean())
+        sv = dialect.server_version_info
+        if sv and sv[0] >= _ORACLE_NATIVE_BOOLEAN_MIN_VERSION:
+            return dialect.type_descriptor(ORA_BOOLEAN())
+        return dialect.type_descriptor(Boolean())
+
+
+BooleanType = _OracleAwareBoolean

--- a/tests/unit/test_types/test_boolean.py
+++ b/tests/unit/test_types/test_boolean.py
@@ -6,7 +6,7 @@ from sqlalchemy.dialects import oracle as oracle_dialect_module
 from sqlalchemy.engine import Dialect
 from sqlalchemy.types import Boolean
 
-from advanced_alchemy.types import BooleanType
+from advanced_alchemy.types import Bool
 from advanced_alchemy.types.boolean import _OracleAwareBoolean
 
 
@@ -37,42 +37,42 @@ def _make_dialect(name: str, server_version_info: Optional[tuple[int, ...]] = No
 
 
 def test_python_type_and_cache_ok() -> None:
-    assert BooleanType is _OracleAwareBoolean
-    instance = BooleanType()
+    assert Bool is _OracleAwareBoolean
+    instance = Bool()
     assert instance.python_type is bool
     assert instance.cache_ok is True
 
 
 def test_oracle_23_with_sa_2_1_uses_native_boolean(fake_oracle_boolean: type[Boolean]) -> None:
     dialect = _make_dialect("oracle", server_version_info=(23, 0, 0, 0, 0))
-    result = BooleanType().load_dialect_impl(dialect)
+    result = Bool().load_dialect_impl(dialect)
     assert isinstance(result, fake_oracle_boolean)
 
 
 def test_oracle_23_with_sa_2_0_falls_back_to_boolean(remove_oracle_boolean: None) -> None:
     dialect = _make_dialect("oracle", server_version_info=(23, 0, 0, 0, 0))
-    result = BooleanType().load_dialect_impl(dialect)
+    result = Bool().load_dialect_impl(dialect)
     assert isinstance(result, Boolean)
     assert not isinstance(result, _FakeOracleBoolean)
 
 
 def test_oracle_19_with_sa_2_1_falls_back_to_boolean(fake_oracle_boolean: type[Boolean]) -> None:
     dialect = _make_dialect("oracle", server_version_info=(19, 0, 0, 0, 0))
-    result = BooleanType().load_dialect_impl(dialect)
+    result = Bool().load_dialect_impl(dialect)
     assert isinstance(result, Boolean)
     assert not isinstance(result, _FakeOracleBoolean)
 
 
 def test_oracle_18_with_sa_2_1_falls_back_to_boolean(fake_oracle_boolean: type[Boolean]) -> None:
     dialect = _make_dialect("oracle", server_version_info=(18, 0, 0, 0, 0))
-    result = BooleanType().load_dialect_impl(dialect)
+    result = Bool().load_dialect_impl(dialect)
     assert isinstance(result, Boolean)
     assert not isinstance(result, _FakeOracleBoolean)
 
 
 def test_oracle_with_no_server_version_falls_back(fake_oracle_boolean: type[Boolean]) -> None:
     dialect = _make_dialect("oracle", server_version_info=None)
-    result = BooleanType().load_dialect_impl(dialect)
+    result = Bool().load_dialect_impl(dialect)
     assert isinstance(result, Boolean)
     assert not isinstance(result, _FakeOracleBoolean)
 
@@ -83,14 +83,14 @@ def test_non_oracle_dialects_use_stock_boolean(
     fake_oracle_boolean: type[Boolean],
 ) -> None:
     dialect = _make_dialect(dialect_name, server_version_info=(99, 0, 0))
-    result = BooleanType().load_dialect_impl(dialect)
+    result = Bool().load_dialect_impl(dialect)
     assert isinstance(result, Boolean)
     assert not isinstance(result, _FakeOracleBoolean)
 
 
 def test_load_dialect_impl_returns_type_engine(fake_oracle_boolean: type[Boolean]) -> None:
     dialect = _make_dialect("oracle", server_version_info=(23, 0, 0, 0, 0))
-    instance = BooleanType()
+    instance = Bool()
     result: Any = instance.load_dialect_impl(dialect)
     assert result is not None
     assert dialect.type_descriptor.called

--- a/tests/unit/test_types/test_boolean.py
+++ b/tests/unit/test_types/test_boolean.py
@@ -1,0 +1,96 @@
+from typing import Any, Optional
+from unittest.mock import MagicMock
+
+import pytest
+from sqlalchemy.dialects import oracle as oracle_dialect_module
+from sqlalchemy.engine import Dialect
+from sqlalchemy.types import Boolean
+
+from advanced_alchemy.types import BooleanType
+from advanced_alchemy.types.boolean import _OracleAwareBoolean
+
+
+class _FakeOracleBoolean(Boolean):
+    """Sentinel subclass used to simulate SA 2.1+ exposing oracle.BOOLEAN."""
+
+
+@pytest.fixture
+def fake_oracle_boolean(monkeypatch: pytest.MonkeyPatch) -> type[Boolean]:
+    """Inject a BOOLEAN attribute into sqlalchemy.dialects.oracle to simulate SA 2.1+."""
+    monkeypatch.setattr(oracle_dialect_module, "BOOLEAN", _FakeOracleBoolean, raising=False)
+    return _FakeOracleBoolean
+
+
+@pytest.fixture
+def remove_oracle_boolean(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ensure oracle.BOOLEAN is absent to simulate SA 2.0.x."""
+    if hasattr(oracle_dialect_module, "BOOLEAN"):
+        monkeypatch.delattr(oracle_dialect_module, "BOOLEAN")
+
+
+def _make_dialect(name: str, server_version_info: Optional[tuple[int, ...]] = None) -> Dialect:
+    dialect = MagicMock(spec=Dialect)
+    dialect.name = name
+    dialect.server_version_info = server_version_info
+    dialect.type_descriptor.side_effect = lambda t: t
+    return dialect
+
+
+def test_python_type_and_cache_ok() -> None:
+    assert BooleanType is _OracleAwareBoolean
+    instance = BooleanType()
+    assert instance.python_type is bool
+    assert instance.cache_ok is True
+
+
+def test_oracle_23_with_sa_2_1_uses_native_boolean(fake_oracle_boolean: type[Boolean]) -> None:
+    dialect = _make_dialect("oracle", server_version_info=(23, 0, 0, 0, 0))
+    result = BooleanType().load_dialect_impl(dialect)
+    assert isinstance(result, fake_oracle_boolean)
+
+
+def test_oracle_23_with_sa_2_0_falls_back_to_boolean(remove_oracle_boolean: None) -> None:
+    dialect = _make_dialect("oracle", server_version_info=(23, 0, 0, 0, 0))
+    result = BooleanType().load_dialect_impl(dialect)
+    assert isinstance(result, Boolean)
+    assert not isinstance(result, _FakeOracleBoolean)
+
+
+def test_oracle_19_with_sa_2_1_falls_back_to_boolean(fake_oracle_boolean: type[Boolean]) -> None:
+    dialect = _make_dialect("oracle", server_version_info=(19, 0, 0, 0, 0))
+    result = BooleanType().load_dialect_impl(dialect)
+    assert isinstance(result, Boolean)
+    assert not isinstance(result, _FakeOracleBoolean)
+
+
+def test_oracle_18_with_sa_2_1_falls_back_to_boolean(fake_oracle_boolean: type[Boolean]) -> None:
+    dialect = _make_dialect("oracle", server_version_info=(18, 0, 0, 0, 0))
+    result = BooleanType().load_dialect_impl(dialect)
+    assert isinstance(result, Boolean)
+    assert not isinstance(result, _FakeOracleBoolean)
+
+
+def test_oracle_with_no_server_version_falls_back(fake_oracle_boolean: type[Boolean]) -> None:
+    dialect = _make_dialect("oracle", server_version_info=None)
+    result = BooleanType().load_dialect_impl(dialect)
+    assert isinstance(result, Boolean)
+    assert not isinstance(result, _FakeOracleBoolean)
+
+
+@pytest.mark.parametrize("dialect_name", ["postgresql", "mysql", "sqlite", "mssql", "duckdb", "cockroachdb"])
+def test_non_oracle_dialects_use_stock_boolean(
+    dialect_name: str,
+    fake_oracle_boolean: type[Boolean],
+) -> None:
+    dialect = _make_dialect(dialect_name, server_version_info=(99, 0, 0))
+    result = BooleanType().load_dialect_impl(dialect)
+    assert isinstance(result, Boolean)
+    assert not isinstance(result, _FakeOracleBoolean)
+
+
+def test_load_dialect_impl_returns_type_engine(fake_oracle_boolean: type[Boolean]) -> None:
+    dialect = _make_dialect("oracle", server_version_info=(23, 0, 0, 0, 0))
+    instance = BooleanType()
+    result: Any = instance.load_dialect_impl(dialect)
+    assert result is not None
+    assert dialect.type_descriptor.called


### PR DESCRIPTION
## Summary

Adds `advanced_alchemy/types/boolean.py` with `Bool` (a `TypeDecorator`) that resolves to native `oracle.BOOLEAN` on Oracle 23c+ when SA 2.1+ exposes it. Falls back to stock SA `Boolean` (which renders as `SMALLINT` on Oracle) on SA 2.0.x or Oracle 18c/19c. Non-Oracle dialects always use stock `Boolean` — zero behavior change.

Pattern mirrors `GUID` and `DateTimeUTC`: TypeDecorator + `load_dialect_impl`, with attribute-presence detection via `getattr` so SA-version gating stays type-checker clean.

Exports `Bool` from `advanced_alchemy.types` and adds it to the alembic `script.py.mako` migration templates so autogenerated migrations can reference `sa.Bool`.

> Named `Bool` (not `Boolean`) to avoid shadowing `sqlalchemy.types.Boolean` at the import site. Mirrors `JsonB`'s pattern of a distinctive shortening over the SA stock name.

## Matrix

| Stack | DDL emitted |
|---|---|
| SA 2.0.x, any Oracle | `SMALLINT` (unchanged) |
| SA 2.1+, Oracle 18c/19c | `SMALLINT` (unchanged) |
| SA 2.1+, Oracle 23ai | native `BOOLEAN` |
| any non-Oracle dialect | stock `Boolean` (unchanged) |

<!-- docs-preview -->

<hr>
📚 Documentation preview: <a href="https://litestar-org.github.io/advanced-alchemy-docs-preview/742">https://litestar-org.github.io/advanced-alchemy-docs-preview/742</a> 
