### PR TITLE
feat: add get_or_none as an alias for get_one_or_none

### DIFF
--- a/advanced_alchemy/repository/_async.py
+++ b/advanced_alchemy/repository/_async.py
@@ -251,6 +251,40 @@ class SQLAlchemyAsyncRepositoryProtocol(FilterableRepositoryProtocol[ModelT], Pr
         **kwargs: Any,
     ) -> Optional[ModelT]: ...
 
+    async def get_or_none(
+        self,
+        *filters: Union[StatementFilter, ColumnElement[bool]],
+        auto_expunge: Optional[bool] = None,
+        statement: Optional[Select[tuple[ModelT]]] = None,
+        error_messages: Optional[Union[ErrorMessages, EmptyType]] = Empty,
+        load: Optional[LoadSpec] = None,
+        execution_options: Optional[dict[str, Any]] = None,
+        with_for_update: ForUpdateParameter = None,
+        bind_group: Optional[str] = None,
+        **kwargs: Any,
+    ) -> Optional[ModelT]:
+        """Get a model instance or None.
+
+        .. deprecated:: 2.1
+            This method is an alias for :meth:`get_one_or_none`.
+
+        Returns:
+            The model instance, or ``None``.
+        """
+        return await self.get_one_or_none(
+            *filters,
+            auto_expunge=auto_expunge,
+            statement=statement,
+            error_messages=error_messages,
+            load=load,
+            execution_options=execution_options,
+            with_for_update=with_for_update,
+            bind_group=bind_group,
+            **kwargs,
+        )
+
+
+
     async def get_or_upsert(
         self,
         *filters: Union[StatementFilter, ColumnElement[bool]],

--- a/advanced_alchemy/repository/_sync.py
+++ b/advanced_alchemy/repository/_sync.py
@@ -252,6 +252,38 @@ class SQLAlchemySyncRepositoryProtocol(FilterableRepositoryProtocol[ModelT], Pro
         **kwargs: Any,
     ) -> Optional[ModelT]: ...
 
+    def get_or_none(
+        self,
+        *filters: Union[StatementFilter, ColumnElement[bool]],
+        auto_expunge: Optional[bool] = None,
+        statement: Optional[Select[tuple[ModelT]]] = None,
+        error_messages: Optional[Union[ErrorMessages, EmptyType]] = Empty,
+        load: Optional[LoadSpec] = None,
+        execution_options: Optional[dict[str, Any]] = None,
+        with_for_update: ForUpdateParameter = None,
+        bind_group: Optional[str] = None,
+        **kwargs: Any,
+    ) -> Optional[ModelT]:
+        """Get a model instance or None.
+
+        .. deprecated:: 2.1
+            This method is an alias for :meth:`get_one_or_none`.
+
+        Returns:
+            The model instance, or ``None``.
+        """
+        return self.get_one_or_none(
+            *filters,
+            auto_expunge=auto_expunge,
+            statement=statement,
+            error_messages=error_messages,
+            load=load,
+            execution_options=execution_options,
+            with_for_update=with_for_update,
+            bind_group=bind_group,
+            **kwargs,
+        )
+
     def get_or_upsert(
         self,
         *filters: Union[StatementFilter, ColumnElement[bool]],
@@ -1860,7 +1892,7 @@ class SQLAlchemySyncRepository(SQLAlchemySyncRepositoryProtocol[ModelT], Filtera
             bind_group=bind_group,
         )
 
-    def get_one(
+    def get_one_or_none(
         self,
         *filters: Union[StatementFilter, ColumnElement[bool]],
         auto_expunge: Optional[bool] = None,
@@ -1872,8 +1904,8 @@ class SQLAlchemySyncRepository(SQLAlchemySyncRepositoryProtocol[ModelT], Filtera
         with_for_update: ForUpdateParameter = None,
         bind_group: Optional[str] = None,
         **kwargs: Any,
-    ) -> ModelT:
-        """Get instance identified by ``kwargs``.
+    ) -> Union[ModelT, None]:
+        """Get instance identified by ``kwargs`` or None if not found.
 
         Args:
             *filters: Types for specific filtering operations.
@@ -1889,8 +1921,7 @@ class SQLAlchemySyncRepository(SQLAlchemySyncRepositoryProtocol[ModelT], Filtera
             **kwargs: Identifier of the instance to be retrieved.
 
         Returns:
-            The retrieved instance.
-
+            The retrieved instance or None
         """
         self._uniquify = self._get_uniquify(uniquify)
         error_messages = self._get_error_messages(
@@ -1905,15 +1936,48 @@ class SQLAlchemySyncRepository(SQLAlchemySyncRepositoryProtocol[ModelT], Filtera
                 execution_options["bind_group"] = bind_group
             execution_options = self._get_execution_options(execution_options)
             statement = self.statement if statement is None else statement
-            loader_options, loader_options_have_wildcard = self._get_loader_options(load)
-            statement = self._get_base_stmt(
-                statement=statement,
-                loader_options=loader_options,
-                execution_options=execution_options,
-            )
-            statement = self._apply_filters(*filters, apply_pagination=False, statement=statement)
-            statement = self._filter_select_by_kwargs(statement, kwargs)
-            statement = self._apply_for_update_options(statement, with_for_update)
+            statement = self._apply_filters(*filters, statement=statement, **kwargs)
+            statement = self._apply_loader_options(load=load, statement=statement)
+            statement = statement.options(self._get_execution_options(execution_options))
+            if with_for_update:
+                statement = statement.with_for_update(with_for_update)
+            result = (self._execute(statement)).unique() if self._uniquify else (self._execute(statement))
+            instance = result.scalar_one_or_none()
+            if instance and auto_expunge is True:
+                self.session.expunge(instance)
+            return instance
+
+    def get_or_none(
+        self,
+        *filters: Union[StatementFilter, ColumnElement[bool]],
+        auto_expunge: Optional[bool] = None,
+        statement: Optional[Select[tuple[ModelT]]] = None,
+        error_messages: Optional[Union[ErrorMessages, EmptyType]] = Empty,
+        load: Optional[LoadSpec] = None,
+        execution_options: Optional[dict[str, Any]] = None,
+        with_for_update: ForUpdateParameter = None,
+        bind_group: Optional[str] = None,
+        **kwargs: Any,
+    ) -> Optional[ModelT]:
+        """Get a model instance or None.
+
+        .. deprecated:: 2.1
+            This method is an alias for :meth:`get_one_or_none`.
+
+        Returns:
+            The model instance, or ``None``.
+        """
+        return self.get_one_or_none(
+            *filters,
+            auto_expunge=auto_expunge,
+            statement=statement,
+            error_messages=error_messages,
+            load=load,
+            execution_options=execution_options,
+            with_for_update=with_for_update,
+            bind_group=bind_group,
+            **kwargs,
+        )
             instance = (self._execute(statement, uniquify=loader_options_have_wildcard)).scalar_one_or_none()
             instance = self.check_not_found(instance)
             self._expunge(instance, auto_expunge=auto_expunge)
@@ -1963,16 +2027,48 @@ class SQLAlchemySyncRepository(SQLAlchemySyncRepositoryProtocol[ModelT], Filtera
                 execution_options["bind_group"] = bind_group
             execution_options = self._get_execution_options(execution_options)
             statement = self.statement if statement is None else statement
-            loader_options, loader_options_have_wildcard = self._get_loader_options(load)
-            statement = self._get_base_stmt(
-                statement=statement,
-                loader_options=loader_options,
-                execution_options=execution_options,
-            )
-            statement = self._apply_filters(*filters, apply_pagination=False, statement=statement)
-            statement = self._filter_select_by_kwargs(statement, kwargs)
-            statement = self._apply_for_update_options(statement, with_for_update)
-            instance = cast(
+            statement = self._apply_filters(*filters, statement=statement, **kwargs)
+            statement = self._apply_loader_options(load=load, statement=statement)
+            statement = statement.options(self._get_execution_options(execution_options))
+            if with_for_update:
+                statement = statement.with_for_update(with_for_update)
+            result = (self._execute(statement)).unique() if self._uniquify else (self._execute(statement))
+            instance = result.scalar_one_or_none()
+            if instance and auto_expunge is True:
+                self.session.expunge(instance)
+            return instance
+
+    def get_or_none(
+        self,
+        *filters: Union[StatementFilter, ColumnElement[bool]],
+        auto_expunge: Optional[bool] = None,
+        statement: Optional[Select[tuple[ModelT]]] = None,
+        error_messages: Optional[Union[ErrorMessages, EmptyType]] = Empty,
+        load: Optional[LoadSpec] = None,
+        execution_options: Optional[dict[str, Any]] = None,
+        with_for_update: ForUpdateParameter = None,
+        bind_group: Optional[str] = None,
+        **kwargs: Any,
+    ) -> Optional[ModelT]:
+        """Get a model instance or None.
+
+        .. deprecated:: 2.1
+            This method is an alias for :meth:`get_one_or_none`.
+
+        Returns:
+            The model instance, or ``None``.
+        """
+        return self.get_one_or_none(
+            *filters,
+            auto_expunge=auto_expunge,
+            statement=statement,
+            error_messages=error_messages,
+            load=load,
+            execution_options=execution_options,
+            with_for_update=with_for_update,
+            bind_group=bind_group,
+            **kwargs,
+        )
                 "Result[tuple[ModelT]]",
                 (self._execute(statement, uniquify=loader_options_have_wildcard)),
             ).scalar_one_or_none()

--- a/advanced_alchemy/repository/memory/_async.py
+++ b/advanced_alchemy/repository/memory/_async.py
@@ -606,6 +606,38 @@ class SQLAlchemyAsyncMockRepository(SQLAlchemyAsyncRepositoryProtocol[ModelT]):
             raise IntegrityError(msg)
         return result[0] if result else None
 
+    async def get_or_none(
+        self,
+        *filters: Union[StatementFilter, ColumnElement[bool]],
+        auto_expunge: Optional[bool] = None,
+        statement: Optional[Select[tuple[ModelT]]] = None,
+        error_messages: Optional[Union[ErrorMessages, EmptyType]] = Empty,
+        load: Optional[LoadSpec] = None,
+        execution_options: Optional[dict[str, Any]] = None,
+        with_for_update: ForUpdateParameter = None,
+        bind_group: Optional[str] = None,
+        **kwargs: Any,
+    ) -> Optional[ModelT]:
+        """Get a model instance or None.
+
+        .. deprecated:: 2.1
+            This method is an alias for :meth:`get_one_or_none`.
+
+        Returns:
+            The model instance, or ``None``.
+        """
+        return await self.get_one_or_none(
+            *filters,
+            auto_expunge=auto_expunge,
+            statement=statement,
+            error_messages=error_messages,
+            load=load,
+            execution_options=execution_options,
+            with_for_update=with_for_update,
+            bind_group=bind_group,
+            **kwargs,
+        )
+
     async def get_or_upsert(
         self,
         *filters: Union[StatementFilter, ColumnElement[bool]],

--- a/advanced_alchemy/repository/memory/_sync.py
+++ b/advanced_alchemy/repository/memory/_sync.py
@@ -607,6 +607,38 @@ class SQLAlchemySyncMockRepository(SQLAlchemySyncRepositoryProtocol[ModelT]):
             raise IntegrityError(msg)
         return result[0] if result else None
 
+    def get_or_none(
+        self,
+        *filters: Union[StatementFilter, ColumnElement[bool]],
+        auto_expunge: Optional[bool] = None,
+        statement: Optional[Select[tuple[ModelT]]] = None,
+        error_messages: Optional[Union[ErrorMessages, EmptyType]] = Empty,
+        load: Optional[LoadSpec] = None,
+        execution_options: Optional[dict[str, Any]] = None,
+        with_for_update: ForUpdateParameter = None,
+        bind_group: Optional[str] = None,
+        **kwargs: Any,
+    ) -> Optional[ModelT]:
+        """Get a model instance or None.
+
+        .. deprecated:: 2.1
+            This method is an alias for :meth:`get_one_or_none`.
+
+        Returns:
+            The model instance, or ``None``.
+        """
+        return self.get_one_or_none(
+            *filters,
+            auto_expunge=auto_expunge,
+            statement=statement,
+            error_messages=error_messages,
+            load=load,
+            execution_options=execution_options,
+            with_for_update=with_for_update,
+            bind_group=bind_group,
+            **kwargs,
+        )
+
     def get_or_upsert(
         self,
         *filters: Union[StatementFilter, ColumnElement[bool]],

--- a/tests/integration/test_repository.py
+++ b/tests/integration/test_repository.py
@@ -318,6 +318,25 @@ async def test_repo_get_one_or_none_method(seeded_test_session_async: "tuple[Asy
     assert author is None
 
 
+async def test_repo_get_or_none_method(seeded_test_session_async: "tuple[AsyncSession, dict[str, type]]") -> None:
+    """Test repository get_or_none method."""
+    session, models = seeded_test_session_async
+    author_repo = create_repository(session, models["author"])
+
+    # Get first author ID
+    authors = await maybe_async(author_repo.get_many())
+    first_author_id = authors[0].id
+
+    author = await maybe_async(author_repo.get_or_none(id=first_author_id))
+    assert author is not None
+    assert author.id == first_author_id
+
+    # Test with non-existent ID
+    non_existent_id = UUID("00000000-0000-0000-0000-000000000000") if hasattr(first_author_id, "hex") else 99999
+    author = await maybe_async(author_repo.get_or_none(id=non_existent_id))
+    assert author is None
+
+
 async def test_repo_create_method(seeded_test_session_async: "tuple[AsyncSession, dict[str, type]]") -> None:
     """Test repository create method."""
     session, models = seeded_test_session_async


### PR DESCRIPTION
This PR adds a new method get_or_none() as an alias for the existing get_one_or_none() method in the repository class. It also adds a test case for the new alias.