### PR TITLE
docs(litestar): correct and test server-side session backend docs

### DIFF
--- a/docs/conftest.py
+++ b/docs/conftest.py
@@ -4,7 +4,7 @@ import pytest
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, create_async_engine
 from sqlalchemy.orm import sessionmaker
 from sybil import Sybil
-from sybil.parsers.rest import PythonCodeBlockParser
+from sybil.parsers.rest import PythonCodeBlockParser, SkipParser
 
 EXECUTABLE_DOCS = (
     "usage/modeling/basics.rst",
@@ -16,6 +16,9 @@ EXECUTABLE_DOCS = (
     "usage/repositories/filtering.rst",
     "usage/database_seeding.rst",
     "usage/services.rst",
+    # litestar.rst is executable only for the session-integration blocks; all
+    # other code blocks are wrapped in ``.. skip: start``/``.. skip: end``.
+    "usage/frameworks/litestar.rst",
 )
 
 NON_EXECUTABLE_DOCS = (
@@ -23,7 +26,6 @@ NON_EXECUTABLE_DOCS = (
     "usage/cli.rst",
     "usage/frameworks/fastapi.rst",
     "usage/frameworks/flask.rst",
-    "usage/frameworks/litestar.rst",
     "usage/frameworks/sanic.rst",
     "usage/frameworks/starlette.rst",
     "usage/routing.rst",
@@ -47,7 +49,7 @@ async def db_session_fixture(engine: AsyncEngine) -> AsyncGenerator[AsyncSession
 
 
 pytest_collect_file = Sybil(
-    parsers=[PythonCodeBlockParser()],
+    parsers=[PythonCodeBlockParser(), SkipParser()],
     patterns=EXECUTABLE_DOCS,
     fixtures=["db_session", "engine"],
 ).pytest()

--- a/docs/reference/extensions/litestar/index.rst
+++ b/docs/reference/extensions/litestar/index.rst
@@ -56,3 +56,4 @@ Additional API References
     plugins
     cli
     session
+    store

--- a/docs/reference/extensions/litestar/store.rst
+++ b/docs/reference/extensions/litestar/store.rst
@@ -1,0 +1,24 @@
+=====
+Store
+=====
+
+.. currentmodule:: advanced_alchemy.extensions.litestar.store
+
+This module provides a SQLAlchemy-backed implementation of Litestar's
+:class:`Store <litestar.stores.base.Store>` protocol. Register a
+:class:`SQLAlchemyStore` under the ``"sessions"`` store name to back Litestar's
+server-side session middleware with your SQLAlchemy database.
+
+Store Model Mixin
+=================
+
+.. autoclass:: StoreModelMixin
+    :members:
+    :show-inheritance:
+
+SQLAlchemy Store
+================
+
+.. autoclass:: SQLAlchemyStore
+    :members:
+    :show-inheritance:

--- a/docs/usage/frameworks/litestar.rst
+++ b/docs/usage/frameworks/litestar.rst
@@ -10,6 +10,12 @@ Advanced Alchemy provides first-class integration with Litestar through its SQLA
 
 This guide demonstrates building a complete CRUD API for a book management system.
 
+.. The code blocks in this guide are illustrative and share context across sections,
+   so they are not executed individually. Only the self-contained session-integration
+   examples below are run as doctests; everything else is inside a Sybil skip region.
+
+.. skip: start
+
 Key Features
 ------------
 
@@ -523,6 +529,8 @@ The SQLAlchemy session backend provides:
 - **UUID-based sessions**: Uses UUIDv7 for session identifiers
 - **Timezone-aware timestamps**: Proper handling of session expiration times
 
+.. skip: end
+
 Store-Based Integration (Recommended)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -606,6 +614,8 @@ Use a dedicated session backend and wire it into ``SessionMiddleware`` directly.
         middleware=[partial(SessionMiddleware, backend=session_backend)],
     )
 
+.. skip: start
+
 Session Model Configuration
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -623,7 +633,6 @@ The session model must inherit from ``SessionModelMixin``, which provides the re
         # - session_id: String(255) session identifier
         # - data: LargeBinary session data
         # - expires_at: DateTime expiration timestamp
-        # - created_at, updated_at: Audit timestamps
 
 The ``SessionModelMixin`` automatically creates:
 
@@ -641,6 +650,7 @@ You can customize table arguments while keeping the mixin's constraints:
 .. code-block:: python
 
     from sqlalchemy import Index
+    from sqlalchemy.orm import declared_attr
     from advanced_alchemy.extensions.litestar.session import SessionModelMixin
 
     class UserSession(SessionModelMixin):
@@ -649,11 +659,9 @@ You can customize table arguments while keeping the mixin's constraints:
         @declared_attr.directive
         @classmethod
         def __table_args__(cls):
-            # Get the mixin's default constraints
-            base_args = super().__table_args__()
-            # Add your custom indexes/constraints
-            return base_args + (
-                Index("ix_user_sessions_custom", cls.session_id, cls.created_at),
+            # Get the mixin's default constraints (a tuple) and append your own
+            return super().__table_args__ + (
+                Index("ix_user_sessions_custom", cls.session_id, cls.expires_at),
             )
 
 **Sync vs Async Configuration**
@@ -744,14 +752,12 @@ The session table created by ``SessionModelMixin`` has the following structure:
         session_id VARCHAR(255) NOT NULL,
         data BYTEA NOT NULL,
         expires_at TIMESTAMP WITH TIME ZONE,
-        created_at TIMESTAMP WITH TIME ZONE NOT NULL,
-        updated_at TIMESTAMP WITH TIME ZONE NOT NULL,
+        sa_orm_sentinel INTEGER,
 
         CONSTRAINT uq_user_sessions_session_id UNIQUE (session_id)
     );
 
     CREATE INDEX ix_user_sessions_expires_at ON user_sessions (expires_at);
-    CREATE INDEX ix_user_sessions_session_id_unique ON user_sessions (session_id);
 
 **Session ID Handling**
 
@@ -771,7 +777,7 @@ Configure appropriate session timeouts:
     # Sessions are automatically renewed on each request
     session_config = ServerSideSessionConfig(
         max_age=1800,  # 30 minutes
-        https_only=True,  # Require HTTPS in production
+        secure=True,  # Require HTTPS in production
         samesite="strict",  # CSRF protection
     )
 
@@ -793,13 +799,19 @@ The mixin automatically creates optimal indexes, but you can add application-spe
 
 .. code-block:: python
 
+    from sqlalchemy import Index
+    from sqlalchemy.orm import declared_attr
+
     class UserSession(SessionModelMixin):
         __tablename__ = "user_sessions"
 
         # Add indexes for common query patterns
-        __table_args__ = SessionModelMixin.__table_args__ + (
-            Index("ix_user_sessions_created_user", "created_at", "session_id"),
-        )
+        @declared_attr.directive
+        @classmethod
+        def __table_args__(cls):
+            return super().__table_args__ + (
+                Index("ix_user_sessions_session_expires", cls.session_id, cls.expires_at),
+            )
 
 **Connection Pooling**
 
@@ -1356,3 +1368,5 @@ Alternative Patterns
     - Want to avoid the service layer abstraction
     - Have complex repository logic that doesn't fit the service pattern
     - Are building a smaller application with simpler data access patterns
+
+.. skip: end

--- a/docs/usage/frameworks/litestar.rst
+++ b/docs/usage/frameworks/litestar.rst
@@ -10,10 +10,6 @@ Advanced Alchemy provides first-class integration with Litestar through its SQLA
 
 This guide demonstrates building a complete CRUD API for a book management system.
 
-.. The code blocks in this guide are illustrative and share context across sections,
-   so they are not executed individually. Only the self-contained session-integration
-   examples below are run as doctests; everything else is inside a Sybil skip region.
-
 .. skip: start
 
 Key Features

--- a/docs/usage/frameworks/litestar.rst
+++ b/docs/usage/frameworks/litestar.rst
@@ -505,12 +505,12 @@ You can upgrade a database to the latest version by running the following comman
 Server-Side Session Backend
 ---------------------------
 
-Advanced Alchemy provides SQLAlchemy-based session backends for Litestar's server-side session middleware. This allows you to store session data in your existing SQLAlchemy database instead of using external stores like Redis or file-based storage.
+Advanced Alchemy can store Litestar server-side session data in your SQLAlchemy database instead of an external store such as Redis or the in-memory default. There are two integration styles, and it matters which one you pick.
 
-If you need a general-purpose Litestar store outside the session middleware itself, the same
-extension package also exposes ``advanced_alchemy.extensions.litestar.store.SQLAlchemyStore`` and
-``StoreModelMixin``. The examples below focus on the session backend used with
-``ServerSideSessionConfig``.
+Litestar's ``ServerSideSessionConfig.middleware`` always installs Litestar's built-in ``ServerSideSessionBackend``. That backend reads and writes session data through whichever :class:`Store <litestar.stores.base.Store>` is registered under ``ServerSideSessionConfig.store`` (``"sessions"`` by default); it does not pick up a custom backend instance. This gives you two options:
+
+- **Store-based integration (recommended).** Register :class:`SQLAlchemyStore <advanced_alchemy.extensions.litestar.store.SQLAlchemyStore>` under the ``"sessions"`` store name and use ``session_config.middleware`` as usual. Litestar's session backend then persists session data through the SQLAlchemy store.
+- **Backend-based integration.** Use a dedicated :class:`SQLAlchemyAsyncSessionBackend <advanced_alchemy.extensions.litestar.session.SQLAlchemyAsyncSessionBackend>` (or its sync variant) and wire it into ``SessionMiddleware`` yourself with ``partial(SessionMiddleware, backend=...)``. Because ``session_config.middleware`` ignores custom backends, you must construct the middleware directly for this style.
 
 Overview
 ^^^^^^^^
@@ -523,18 +523,55 @@ The SQLAlchemy session backend provides:
 - **UUID-based sessions**: Uses UUIDv7 for session identifiers
 - **Timezone-aware timestamps**: Proper handling of session expiration times
 
-Quick Setup
-^^^^^^^^^^^
+Store-Based Integration (Recommended)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-To use the SQLAlchemy session backend, you need to:
-
-1. Create a session model using the provided mixin
-2. Configure the SQLAlchemy session backend
-3. Register the session middleware with your Litestar application
+Register a :class:`SQLAlchemyStore` under the session store name and let Litestar's middleware use it:
 
 .. code-block:: python
 
     from litestar import Litestar
+    from litestar.middleware.session.server_side import ServerSideSessionConfig
+    from advanced_alchemy.extensions.litestar import SQLAlchemyAsyncConfig, SQLAlchemyPlugin
+    from advanced_alchemy.extensions.litestar.store import SQLAlchemyStore, StoreModelMixin
+
+    # 1. Create the model backing the store table
+    class SessionStore(StoreModelMixin):
+        __tablename__ = "session_store"
+
+    # 2. Configure SQLAlchemy
+    alchemy_config = SQLAlchemyAsyncConfig(
+        connection_string="postgresql+asyncpg://user:password@localhost/mydb",
+        create_all=True,
+    )
+
+    # 3. Configure the session middleware (``store`` defaults to "sessions")
+    session_config = ServerSideSessionConfig(max_age=3600)
+
+    # 4. Build the store and bind it to the session model
+    session_store = SQLAlchemyStore(alchemy_config, model=SessionStore, namespace="my-app")
+
+    # 5. Register the store under the session store name ("sessions")
+    app = Litestar(
+        route_handlers=[],
+        plugins=[SQLAlchemyPlugin(config=alchemy_config)],
+        middleware=[session_config.middleware],
+        stores={"sessions": session_store},
+    )
+
+The registered store name must match ``ServerSideSessionConfig.store``, which is ``"sessions"`` unless you override it.
+
+Backend-Based Integration
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Use a dedicated session backend and wire it into ``SessionMiddleware`` directly. Do not use ``session_config.middleware`` for this style, because that installs Litestar's built-in backend and ignores ``session_backend``:
+
+.. code-block:: python
+
+    from functools import partial
+
+    from litestar import Litestar
+    from litestar.middleware.session import SessionMiddleware
     from litestar.middleware.session.server_side import ServerSideSessionConfig
     from advanced_alchemy.extensions.litestar import SQLAlchemyAsyncConfig, SQLAlchemyPlugin
     from advanced_alchemy.extensions.litestar.session import (
@@ -552,10 +589,8 @@ To use the SQLAlchemy session backend, you need to:
         create_all=True,
     )
 
-    # 3. Configure session backend
-    session_config = ServerSideSessionConfig(
-        max_age=3600,  # 1 hour
-    )
+    # 3. Configure the session middleware
+    session_config = ServerSideSessionConfig(max_age=3600)
 
     # 4. Create the session backend
     session_backend = SQLAlchemyAsyncSessionBackend(
@@ -564,11 +599,11 @@ To use the SQLAlchemy session backend, you need to:
         model=UserSession,
     )
 
-    # 5. Create your Litestar app
+    # 5. Wire the backend into ``SessionMiddleware`` directly
     app = Litestar(
         route_handlers=[],
         plugins=[SQLAlchemyPlugin(config=alchemy_config)],
-        middleware=[session_config.middleware],
+        middleware=[partial(SessionMiddleware, backend=session_backend)],
     )
 
 Session Model Configuration
@@ -810,15 +845,17 @@ Here's a complete working example:
 
 .. code-block:: python
 
+    from functools import partial
+
     from litestar import Litestar, get, post
     from litestar.connection import ASGIConnection
+    from litestar.middleware.session import SessionMiddleware
     from litestar.middleware.session.server_side import ServerSideSessionConfig
     from advanced_alchemy.extensions.litestar import (
         AsyncSessionConfig,
         SQLAlchemyAsyncConfig,
         SQLAlchemyPlugin,
     )
-    from litestar.response import Template
 
     from advanced_alchemy.extensions.litestar.session import (
         SessionModelMixin,
@@ -874,10 +911,10 @@ Here's a complete working example:
     app = Litestar(
         route_handlers=[home, login, logout],
         plugins=[SQLAlchemyPlugin(config=alchemy_config)],
-        middleware=[session_config.middleware],
+        middleware=[partial(SessionMiddleware, backend=session_backend)],
     )
 
-This example provides a complete session-enabled application using SQLAlchemy for session storage.
+This example provides a complete session-enabled application using SQLAlchemy for session storage. To use the store-based integration instead, drop ``session_backend`` and register a :class:`SQLAlchemyStore` under ``stores={"sessions": ...}`` as shown above.
 
 File Object Storage
 -------------------

--- a/tests/integration/test_extensions/test_litestar/test_session.py
+++ b/tests/integration/test_extensions/test_litestar/test_session.py
@@ -9,6 +9,7 @@ import datetime
 import uuid
 from collections.abc import AsyncGenerator, Generator
 from functools import partial
+from pathlib import Path
 from typing import Optional
 from unittest.mock import Mock
 
@@ -22,6 +23,7 @@ from sqlalchemy import Engine, select
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 from sqlalchemy.orm import DeclarativeBase, Session
 
+from advanced_alchemy.extensions.litestar import SQLAlchemyPlugin
 from advanced_alchemy.extensions.litestar.plugins.init.config.asyncio import SQLAlchemyAsyncConfig
 from advanced_alchemy.extensions.litestar.plugins.init.config.sync import SQLAlchemySyncConfig
 from advanced_alchemy.extensions.litestar.session import (
@@ -29,6 +31,7 @@ from advanced_alchemy.extensions.litestar.session import (
     SQLAlchemyAsyncSessionBackend,
     SQLAlchemySyncSessionBackend,
 )
+from advanced_alchemy.extensions.litestar.store import SQLAlchemyStore, StoreModelMixin
 from tests.integration.helpers import cleanup_database, cleanup_database_async
 
 pytestmark = [
@@ -562,3 +565,89 @@ async def test_sync_session_middleware_integration(
         response = await client.get("/get")
         assert response.status_code == 200
         assert response.json() == {"counter": 2}
+
+
+async def test_docs_store_based_session_pattern(tmp_path: Path) -> None:
+    """The documented store-based pattern persists session data to the database.
+
+    Guards the "Store-Based Integration (Recommended)" example in
+    ``docs/usage/frameworks/litestar.rst``: register a ``SQLAlchemyStore`` under
+    the ``"sessions"`` store name and use ``session_config.middleware``.
+    """
+
+    class DocsStoreSession(StoreModelMixin):
+        __tablename__ = "docs_store_based_sessions"
+
+    config = SQLAlchemyAsyncConfig(connection_string=f"sqlite+aiosqlite:///{tmp_path / 'store.db'}")
+    async with config.get_engine().begin() as conn:
+        await conn.run_sync(DocsStoreSession.__table__.create)
+
+    session_config = ServerSideSessionConfig(max_age=3600)
+    store = SQLAlchemyStore(config, model=DocsStoreSession, namespace="docs-app")
+
+    @post("/login")
+    async def login(request: Request) -> "dict[str, str]":
+        request.set_session({"username": "alice"})
+        return {"status": "ok"}
+
+    @get("/")
+    async def home(request: Request) -> "dict[str, Optional[str]]":
+        return {"username": request.session.get("username")}
+
+    app = Litestar(
+        route_handlers=[login, home],
+        plugins=[SQLAlchemyPlugin(config=config)],
+        middleware=[session_config.middleware],
+        stores={"sessions": store},
+    )
+
+    async with AsyncTestClient(app=app) as client:
+        assert (await client.post("/login")).status_code == 201
+        assert (await client.get("/")).json() == {"username": "alice"}
+
+    async with config.get_session() as db_session:
+        rows = (await db_session.scalars(select(DocsStoreSession))).all()
+    assert len(rows) == 1, "store-based session was not persisted to the database"
+
+
+async def test_docs_backend_based_session_pattern(tmp_path: Path) -> None:
+    """The documented backend-based pattern persists session data to the database.
+
+    Guards the "Backend-Based Integration" example in
+    ``docs/usage/frameworks/litestar.rst``: wire the backend with
+    ``partial(SessionMiddleware, backend=...)`` instead of
+    ``session_config.middleware``.
+    """
+
+    class DocsBackendSession(SessionModelMixin):
+        __tablename__ = "docs_backend_based_sessions"
+
+    config = SQLAlchemyAsyncConfig(connection_string=f"sqlite+aiosqlite:///{tmp_path / 'backend.db'}")
+    async with config.get_engine().begin() as conn:
+        await conn.run_sync(DocsBackendSession.__table__.create)
+
+    session_config = ServerSideSessionConfig(max_age=3600)
+    backend = SQLAlchemyAsyncSessionBackend(config=session_config, alchemy_config=config, model=DocsBackendSession)
+
+    @post("/login")
+    async def login(request: Request) -> "dict[str, str]":
+        request.set_session({"username": "alice"})
+        return {"status": "ok"}
+
+    @get("/")
+    async def home(request: Request) -> "dict[str, Optional[str]]":
+        return {"username": request.session.get("username")}
+
+    app = Litestar(
+        route_handlers=[login, home],
+        plugins=[SQLAlchemyPlugin(config=config)],
+        middleware=[partial(SessionMiddleware, backend=backend)],
+    )
+
+    async with AsyncTestClient(app=app) as client:
+        assert (await client.post("/login")).status_code == 201
+        assert (await client.get("/")).json() == {"username": "alice"}
+
+    async with config.get_session() as db_session:
+        rows = (await db_session.scalars(select(DocsBackendSession))).all()
+    assert len(rows) == 1, "backend-based session was not persisted to the database"


### PR DESCRIPTION
## Problem

The "Server-Side Session Backend" guide built a `SQLAlchemyAsyncSessionBackend` and then wired the app with `middleware=[session_config.middleware]`. But `ServerSideSessionConfig.middleware` hardcodes Litestar's built-in `ServerSideSessionBackend` (resolving storage via `app.stores.get(config.store)`, default `"sessions"`), so the constructed backend was **never used** — session data silently went to an in-memory store and the DB table stayed empty. (Verified against litestar 2.23.)

Because `usage/frameworks/litestar.rst` was in `NON_EXECUTABLE_DOCS`, the examples were never run, so this and several related inaccuracies shipped.

Fixes #745
Fixes #707

## Changes

**Docs — two correct integration styles**
- **Store-based (recommended):** register `SQLAlchemyStore` under the `"sessions"` store name and keep `session_config.middleware`. (This is what `litestar-fullstack-inertia` already does.)
- **Backend-based:** wire with `partial(SessionMiddleware, backend=session_backend)` instead of `session_config.middleware`.
- Added a reference page for the previously-undocumented `SQLAlchemyStore` / `StoreModelMixin`.

**Docs — further factual fixes surfaced once the examples actually ran**
- `SessionModelMixin` has no `created_at`/`updated_at` (it extends `UUIDv7Base`, not an audit base) — corrected the field list and the `CREATE TABLE` schema (added `sa_orm_sentinel`).
- `__table_args__` override used `super().__table_args__()` (the directive already returns a tuple) and referenced the nonexistent `created_at` column — corrected.
- `ServerSideSessionConfig` has no `https_only` field — corrected to `secure`.

**Tests / regression guards**
- Behavioral integration tests for both wiring patterns asserting session rows actually persist to the DB.
- Made the session-integration blocks **Sybil-executable** (added `SkipParser`, moved the doc to `EXECUTABLE_DOCS`, wrapped the remaining context-sharing blocks in skip regions) so the examples can't silently rot again.

<!-- docs-preview -->

<hr>
📚 Documentation preview: <a href="https://litestar-org.github.io/advanced-alchemy-docs-preview/749">https://litestar-org.github.io/advanced-alchemy-docs-preview/749</a> 
