### PR TITLE
docs: index repository classes in objects.inv (#729)

### DIFF
--- a/advanced_alchemy/repository/memory/_async.py
+++ b/advanced_alchemy/repository/memory/_async.py
@@ -893,8 +893,10 @@ class SQLAlchemyAsyncMockRepository(SQLAlchemyAsyncRepositoryProtocol[ModelT]):
         bind_group: Optional[str] = None,
         **kwargs: Any,
     ) -> tuple[List[ModelT], int]:
-        """.. deprecated:: 1.10.0
-        Use :meth:`get_many_and_count` instead.
+        """List of records and total count returned by query.
+
+        .. deprecated:: 1.10.0
+            Use :meth:`get_many_and_count` instead.
         """
         warn_deprecation(
             version="1.10.0",
@@ -925,8 +927,10 @@ class SQLAlchemyAsyncMockRepository(SQLAlchemyAsyncRepositoryProtocol[ModelT]):
         bind_group: Optional[str] = None,
         **kwargs: Any,
     ) -> List[ModelT]:
-        """.. deprecated:: 1.10.0
-        Use :meth:`get_many` instead.
+        """List of records returned by query.
+
+        .. deprecated:: 1.10.0
+            Use :meth:`get_many` instead.
         """
         warn_deprecation(
             version="1.10.0",

--- a/advanced_alchemy/repository/memory/_sync.py
+++ b/advanced_alchemy/repository/memory/_sync.py
@@ -894,8 +894,10 @@ class SQLAlchemySyncMockRepository(SQLAlchemySyncRepositoryProtocol[ModelT]):
         bind_group: Optional[str] = None,
         **kwargs: Any,
     ) -> tuple[List[ModelT], int]:
-        """.. deprecated:: 1.10.0
-        Use :meth:`get_many_and_count` instead.
+        """List of records and total count returned by query.
+
+        .. deprecated:: 1.10.0
+            Use :meth:`get_many_and_count` instead.
         """
         warn_deprecation(
             version="1.10.0",
@@ -926,8 +928,10 @@ class SQLAlchemySyncMockRepository(SQLAlchemySyncRepositoryProtocol[ModelT]):
         bind_group: Optional[str] = None,
         **kwargs: Any,
     ) -> List[ModelT]:
-        """.. deprecated:: 1.10.0
-        Use :meth:`get_many` instead.
+        """List of records returned by query.
+
+        .. deprecated:: 1.10.0
+            Use :meth:`get_many` instead.
         """
         warn_deprecation(
             version="1.10.0",

--- a/docs/reference/repository.rst
+++ b/docs/reference/repository.rst
@@ -8,3 +8,12 @@ repositories
     :undoc-members:
     :show-inheritance:
     :exclude-members: Empty, ErrorMessages
+
+memory
+======
+
+.. automodule:: advanced_alchemy.repository.memory
+    :members:
+    :imported-members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/reference/repository.rst
+++ b/docs/reference/repository.rst
@@ -7,4 +7,4 @@ repositories
     :imported-members:
     :undoc-members:
     :show-inheritance:
-    :no-index: Empty, ErrorMessages
+    :exclude-members: Empty, ErrorMessages


### PR DESCRIPTION
## Summary
Repository classes were missing from the published intersphinx inventory (`objects.inv`), so downstream Sphinx projects could not resolve `:class:` cross-references to `advanced_alchemy.repository.*`.

Root cause: `docs/reference/repository.rst` passed arguments to the boolean `:no-index:` autodoc flag (`:no-index: Empty, ErrorMessages`). `:no-index:` takes no arguments — when present it suppressed index entries for the **entire** module. The intent was to exclude the imported re-exports `Empty` and `ErrorMessages`, which is `:exclude-members:`.

## Changes
1. `:no-index: Empty, ErrorMessages` → `:exclude-members: Empty, ErrorMessages` in `repository.rst`.
2. Documented `advanced_alchemy.repository.memory` (new `automodule` section) so the mock-repository classes are indexed too.
3. Fixed malformed `.. deprecated::` directives in `repository/memory/_async.py` docstrings (`list`, `list_and_count`) that otherwise broke the `-W` docs build; regenerated `memory/_sync.py` via `unasyncd`.

## Verification
- Rebuilt docs; decoded `objects.inv`: now contains `py:class` entries under `advanced_alchemy.repository` (incl. `SQLAlchemyAsyncRepository`, `SQLAlchemySyncRepository`) **and** `advanced_alchemy.repository.memory` (`SQLAlchemyAsyncMockRepository`, `SQLAlchemySyncMockRepository`).
- `-W` build introduces no new warnings from these changes.

Closes #729


<!-- docs-preview -->

<hr>
📚 Documentation preview: <a href="https://litestar-org.github.io/advanced-alchemy-docs-preview/751">https://litestar-org.github.io/advanced-alchemy-docs-preview/751</a> 
