### PR TITLE
docs(mixins): document sort_order column ordering (#584)

### DIFF
--- a/docs/usage/modeling/basics.rst
+++ b/docs/usage/modeling/basics.rst
@@ -76,6 +76,110 @@ Additionally, Advanced Alchemy provides mixins to enhance model functionality:
      - Automatic Select or Create for many-to-many relationships
 
 
+Column Ordering
+---------------
+
+The mixin and base columns carry a ``sort_order`` so that tables created with
+``metadata.create_all()`` have a consistent, predictable column layout. Primary keys come
+first, your model's own columns sit in the middle, and the sentinel and audit columns are
+grouped at the end.
+
+.. list-table:: Mixin Column ``sort_order`` Values
+   :header-rows: 1
+   :widths: 40 30 30
+
+   * - Column
+     - Source
+     - ``sort_order``
+   * - ``id`` (primary key)
+     - ``UUIDPrimaryKey``, ``BigIntPrimaryKey``, ``IdentityPrimaryKey``, ``NanoIDPrimaryKey``
+     - ``-100``
+   * - Your model's columns
+     - User-defined
+     - ``0`` (default)
+   * - ``sa_orm_sentinel``
+     - ``SentinelMixin``
+     - ``3001``
+   * - ``created_at``
+     - ``AuditColumns``
+     - ``3002``
+   * - ``updated_at``
+     - ``AuditColumns``
+     - ``3003``
+
+Columns are emitted in ascending ``sort_order``; columns sharing a value (such as your own
+columns, which all use the default of ``0``) keep their declaration order. The negative value
+on the primary key pins it ahead of user columns, and the high values on the sentinel and audit
+columns push them to the end of the table.
+
+Consider a model that declares ``name`` and ``email`` on top of ``UUIDAuditBase``:
+
+.. code-block:: python
+
+    from advanced_alchemy.base import UUIDAuditBase
+    from sqlalchemy.orm import Mapped
+
+
+    class User(UUIDAuditBase):
+        __tablename__ = "users"
+
+        name: Mapped[str]
+        email: Mapped[str]
+
+The resulting table has the following physical column order:
+
+.. code-block:: text
+
+    id              -- sort_order -100 (primary key)
+    name            -- sort_order 0    (declaration order)
+    email           -- sort_order 0    (declaration order)
+    sa_orm_sentinel -- sort_order 3001
+    created_at      -- sort_order 3002
+    updated_at      -- sort_order 3003
+
+.. note::
+
+   This ordering applies to **new table creation** through ``metadata.create_all()`` only. It
+   does not reorder columns in tables that already exist, and Alembic autogenerate does not
+   detect column-order changes, so it will not emit a migration to reorder an existing table.
+
+Positioning Your Own Columns
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``sort_order`` is a standard :func:`~sqlalchemy.orm.mapped_column` argument, so you can place your
+own columns anywhere in the table by setting it explicitly. Give a column a value between the
+primary key (``-100``) and the sentinel (``3001``) to position it within the body of the table;
+columns that share a value keep their declaration order.
+
+.. code-block:: python
+
+    from advanced_alchemy.base import UUIDAuditBase
+    from sqlalchemy.orm import Mapped, mapped_column
+
+
+    class User(UUIDAuditBase):
+        __tablename__ = "users"
+
+        email: Mapped[str] = mapped_column(sort_order=-50)
+        name: Mapped[str]
+        signup_source: Mapped[str] = mapped_column(sort_order=100)
+
+This pins ``email`` ahead of the default columns and pushes ``signup_source`` after them:
+
+.. code-block:: text
+
+    id              -- sort_order -100 (primary key)
+    email           -- sort_order -50
+    name            -- sort_order 0    (default)
+    signup_source   -- sort_order 100
+    sa_orm_sentinel -- sort_order 3001
+    created_at      -- sort_order 3002
+    updated_at      -- sort_order 3003
+
+Use a value below ``-100`` to place a column ahead of the primary key, or above ``3003`` to place
+it after the audit columns.
+
+
 Basic Model Example
 -------------------
 


### PR DESCRIPTION
## Summary
Documents the mixin column-ordering behavior (`sort_order`) that produces a consistent physical column layout when tables are created via `metadata.create_all()`.

## Change
- New "Column Ordering" section in `docs/usage/modeling/basics.rst` with the real `sort_order` values from source:
  - primary key `id`: `-100`
  - user columns: `0` (default)
  - `sa_orm_sentinel`: `3001`
  - `created_at`: `3002`, `updated_at`: `3003`
- Before/after example + a note clarifying scope: applies to new-table creation only; does not reorder existing tables, and Alembic autogenerate does not detect column-order changes.

Closes #584


<!-- docs-preview -->

<hr>
📚 Documentation preview: <a href="https://litestar-org.github.io/advanced-alchemy-docs-preview/753">https://litestar-org.github.io/advanced-alchemy-docs-preview/753</a> 
