### PR TITLE
feat(types): dialect-aware Vector distance operators

### DIFF
--- a/advanced_alchemy/types/vector.py
+++ b/advanced_alchemy/types/vector.py
@@ -15,12 +15,23 @@ inside ``load_dialect_impl`` so ``from advanced_alchemy.types import Vector``
 never requires ``pgvector`` or ``oracledb`` to be installed.
 """
 
-from typing import Any, Optional
+from typing import TYPE_CHECKING, Any, Optional
 
+from sqlalchemy import Float, literal
 from sqlalchemy.engine import Dialect
+from sqlalchemy.ext.compiler import compiles
+from sqlalchemy.sql.expression import ColumnElement
 from sqlalchemy.types import JSON, TypeDecorator, TypeEngine
 
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from sqlalchemy.sql.compiler import SQLCompiler
+
 __all__ = ("Vector",)
+
+_PGVECTOR_OPERATORS = {"cosine": "<=>", "l2": "<->", "inner_product": "<#>"}
+_ORACLE_METRICS = {"cosine": "COSINE", "l2": "EUCLIDEAN", "inner_product": "DOT"}
 
 
 class Vector(TypeDecorator[list[float]]):
@@ -65,3 +76,68 @@ class Vector(TypeDecorator[list[float]]):
         if hasattr(value, "tolist"):
             return list(value.tolist())
         return list(value)
+
+    class Comparator(TypeDecorator.Comparator[list[float]]):
+        """Dialect-aware vector distance operators for similarity search.
+
+        Method names and semantics mirror ``pgvector``'s SQLAlchemy comparator so
+        existing pgvector-based queries can swap to :class:`Vector` unchanged.
+        """
+
+        def _distance(self, other: "Sequence[float]", metric: str) -> "_VectorDistance":
+            operand = literal(list(other), type_=self.type)
+            return _VectorDistance(self.expr, operand, metric)
+
+        def cosine_distance(self, other: "Sequence[float]") -> "_VectorDistance":
+            return self._distance(other, "cosine")
+
+        def l2_distance(self, other: "Sequence[float]") -> "_VectorDistance":
+            return self._distance(other, "l2")
+
+        def max_inner_product(self, other: "Sequence[float]") -> "_VectorDistance":
+            return self._distance(other, "inner_product")
+
+    comparator_factory = Comparator  # pyright: ignore[reportIncompatibleMethodOverride,reportAssignmentType]
+
+
+class _VectorDistance(ColumnElement[float]):
+    """Dialect-deferred vector distance expression.
+
+    The SQL is chosen at compile time so the same expression compiles to native
+    operators on each backend:
+
+    - PostgreSQL / CockroachDB → ``<=>`` / ``<->`` / ``<#>`` (pgvector)
+    - Oracle 23ai → ``VECTOR_DISTANCE(col, :vec, COSINE | EUCLIDEAN | DOT)``
+    - other dialects → :exc:`NotImplementedError` (no native vector backend)
+    """
+
+    inherit_cache = False
+
+    def __init__(self, left: "ColumnElement[Any]", right: "ColumnElement[Any]", metric: str) -> None:
+        self.left = left
+        self.right = right
+        self.metric = metric
+        self.type = Float()
+
+
+@compiles(_VectorDistance)
+def compile_vector_distance(element: _VectorDistance, compiler: "SQLCompiler", **kw: Any) -> str:
+    msg = (
+        "Vector distance operations require a native vector backend "
+        "(PostgreSQL with pgvector, or Oracle 23ai). The current dialect stores "
+        "vectors as JSON and has no distance operator."
+    )
+    raise NotImplementedError(msg)
+
+
+@compiles(_VectorDistance, "postgresql")
+@compiles(_VectorDistance, "cockroachdb")
+def compile_vector_distance_pgvector(element: _VectorDistance, compiler: "SQLCompiler", **kw: Any) -> str:
+    operator = _PGVECTOR_OPERATORS[element.metric]
+    return f"({compiler.process(element.left, **kw)} {operator} {compiler.process(element.right, **kw)})"
+
+
+@compiles(_VectorDistance, "oracle")
+def compile_vector_distance_oracle(element: _VectorDistance, compiler: "SQLCompiler", **kw: Any) -> str:
+    metric = _ORACLE_METRICS[element.metric]
+    return f"VECTOR_DISTANCE({compiler.process(element.left, **kw)}, {compiler.process(element.right, **kw)}, {metric})"

--- a/advanced_alchemy/types/vector.py
+++ b/advanced_alchemy/types/vector.py
@@ -21,6 +21,7 @@ from sqlalchemy import Float, literal
 from sqlalchemy.engine import Dialect
 from sqlalchemy.ext.compiler import compiles
 from sqlalchemy.sql.expression import ColumnElement
+from sqlalchemy.sql.visitors import InternalTraversal
 from sqlalchemy.types import JSON, TypeDecorator, TypeEngine
 
 if TYPE_CHECKING:
@@ -30,8 +31,8 @@ if TYPE_CHECKING:
 
 __all__ = ("Vector",)
 
-_PGVECTOR_OPERATORS = {"cosine": "<=>", "l2": "<->", "inner_product": "<#>"}
-_ORACLE_METRICS = {"cosine": "COSINE", "l2": "EUCLIDEAN", "inner_product": "DOT"}
+_PGVECTOR_OPERATORS = {"cosine": "<=>", "l2": "<->", "l1": "<+>", "inner_product": "<#>"}
+_ORACLE_METRICS = {"cosine": "COSINE", "l2": "EUCLIDEAN", "l1": "MANHATTAN", "inner_product": "DOT"}
 
 
 class Vector(TypeDecorator[list[float]]):
@@ -94,6 +95,9 @@ class Vector(TypeDecorator[list[float]]):
         def l2_distance(self, other: "Sequence[float]") -> "_VectorDistance":
             return self._distance(other, "l2")
 
+        def l1_distance(self, other: "Sequence[float]") -> "_VectorDistance":
+            return self._distance(other, "l1")
+
         def max_inner_product(self, other: "Sequence[float]") -> "_VectorDistance":
             return self._distance(other, "inner_product")
 
@@ -106,12 +110,23 @@ class _VectorDistance(ColumnElement[float]):
     The SQL is chosen at compile time so the same expression compiles to native
     operators on each backend:
 
-    - PostgreSQL / CockroachDB → ``<=>`` / ``<->`` / ``<#>`` (pgvector)
-    - Oracle 23ai → ``VECTOR_DISTANCE(col, :vec, COSINE | EUCLIDEAN | DOT)``
+    - PostgreSQL / CockroachDB → ``<=>`` / ``<->`` / ``<+>`` / ``<#>`` (pgvector)
+    - Oracle 23ai → ``VECTOR_DISTANCE(col, :vec, COSINE | EUCLIDEAN | MANHATTAN | DOT)``
     - other dialects → :exc:`NotImplementedError` (no native vector backend)
+
+    ``max_inner_product`` (pgvector ``<#>``, Oracle ``DOT``) returns the *negated*
+    inner product on both backends, so ascending order yields the nearest match.
+
+    ``_traverse_internals`` makes the expression cache-safe: statements containing
+    a vector distance participate in SQLAlchemy's compiled-statement cache keyed on
+    the operands and metric.
     """
 
-    inherit_cache = False
+    _traverse_internals = [
+        ("left", InternalTraversal.dp_clauseelement),
+        ("right", InternalTraversal.dp_clauseelement),
+        ("metric", InternalTraversal.dp_string),
+    ]
 
     def __init__(self, left: "ColumnElement[Any]", right: "ColumnElement[Any]", metric: str) -> None:
         self.left = left

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -46,6 +46,17 @@
         values are normalized to ``list[float]`` so callers can use one API
         across supported dialects.
 
+    .. change:: add vector distance operators for similarity search
+        :type: feature
+        :pr: 756
+
+        Adds ``cosine_distance``, ``l2_distance``, ``l1_distance``, and
+        ``max_inner_product`` comparator methods to the ``Vector`` type so a
+        vector column can be ordered by similarity directly. Each compiles to
+        native SQL per dialect — pgvector operators on PostgreSQL/CockroachDB
+        and ``VECTOR_DISTANCE`` on Oracle 23ai — and raises a clear
+        ``NotImplementedError`` on JSON-fallback dialects.
+
     .. change:: use native Oracle JSON when available
         :type: feature
         :pr: 741

--- a/tests/unit/test_types/test_vector.py
+++ b/tests/unit/test_types/test_vector.py
@@ -161,7 +161,7 @@ def test_vector_process_result_value_returns_list_for_plain_iterable() -> None:
 
 def test_vector_distance_methods_exist_on_column() -> None:
     """``Vector`` columns expose pgvector-compatible distance comparator methods."""
-    column = Column("embedding", Vector(3))
+    column: Column[list[float]] = Column("embedding", Vector(3))
     assert hasattr(column, "cosine_distance")
     assert hasattr(column, "l2_distance")
     assert hasattr(column, "max_inner_product")
@@ -169,7 +169,7 @@ def test_vector_distance_methods_exist_on_column() -> None:
 
 def test_vector_cosine_distance_postgresql_emits_operator() -> None:
     """Cosine distance compiles to the pgvector ``<=>`` operator on PostgreSQL."""
-    column = Column("embedding", Vector(3))
+    column: Column[list[float]] = Column("embedding", Vector(3))
     statement = column.cosine_distance([1.0, 2.0, 3.0])
     sql = str(statement.compile(dialect=postgresql_dialect_mod.dialect()))  # type: ignore[no-untyped-call,unused-ignore]
     assert "<=>" in sql
@@ -177,7 +177,7 @@ def test_vector_cosine_distance_postgresql_emits_operator() -> None:
 
 def test_vector_l2_distance_postgresql_emits_operator() -> None:
     """L2 distance compiles to the pgvector ``<->`` operator on PostgreSQL."""
-    column = Column("embedding", Vector(3))
+    column: Column[list[float]] = Column("embedding", Vector(3))
     statement = column.l2_distance([1.0, 2.0, 3.0])
     sql = str(statement.compile(dialect=postgresql_dialect_mod.dialect()))  # type: ignore[no-untyped-call,unused-ignore]
     assert "<->" in sql
@@ -185,7 +185,7 @@ def test_vector_l2_distance_postgresql_emits_operator() -> None:
 
 def test_vector_max_inner_product_postgresql_emits_operator() -> None:
     """Negative inner product compiles to the pgvector ``<#>`` operator on PostgreSQL."""
-    column = Column("embedding", Vector(3))
+    column: Column[list[float]] = Column("embedding", Vector(3))
     statement = column.max_inner_product([1.0, 2.0, 3.0])
     sql = str(statement.compile(dialect=postgresql_dialect_mod.dialect()))  # type: ignore[no-untyped-call,unused-ignore]
     assert "<#>" in sql
@@ -193,7 +193,7 @@ def test_vector_max_inner_product_postgresql_emits_operator() -> None:
 
 def test_vector_cosine_distance_oracle_emits_vector_distance() -> None:
     """Cosine distance compiles to ``VECTOR_DISTANCE(..., COSINE)`` on Oracle 23ai."""
-    column = Column("embedding", Vector(3))
+    column: Column[list[float]] = Column("embedding", Vector(3))
     statement = column.cosine_distance([1.0, 2.0, 3.0])
     sql = str(statement.compile(dialect=oracle_dialect_mod.dialect()))  # type: ignore[no-untyped-call,unused-ignore]
     assert "VECTOR_DISTANCE" in sql
@@ -202,7 +202,7 @@ def test_vector_cosine_distance_oracle_emits_vector_distance() -> None:
 
 def test_vector_l2_distance_oracle_uses_euclidean_metric() -> None:
     """L2 distance maps to the Oracle ``EUCLIDEAN`` metric."""
-    column = Column("embedding", Vector(3))
+    column: Column[list[float]] = Column("embedding", Vector(3))
     statement = column.l2_distance([1.0, 2.0, 3.0])
     sql = str(statement.compile(dialect=oracle_dialect_mod.dialect()))  # type: ignore[no-untyped-call,unused-ignore]
     assert "VECTOR_DISTANCE" in sql
@@ -211,7 +211,7 @@ def test_vector_l2_distance_oracle_uses_euclidean_metric() -> None:
 
 def test_vector_max_inner_product_oracle_uses_dot_metric() -> None:
     """Negative inner product maps to the Oracle ``DOT`` metric."""
-    column = Column("embedding", Vector(3))
+    column: Column[list[float]] = Column("embedding", Vector(3))
     statement = column.max_inner_product([1.0, 2.0, 3.0])
     sql = str(statement.compile(dialect=oracle_dialect_mod.dialect()))  # type: ignore[no-untyped-call,unused-ignore]
     assert "VECTOR_DISTANCE" in sql
@@ -220,7 +220,7 @@ def test_vector_max_inner_product_oracle_uses_dot_metric() -> None:
 
 def test_vector_distance_unsupported_dialect_raises() -> None:
     """Distance operations require a native vector backend; JSON fallback raises clearly."""
-    column = Column("embedding", Vector(3))
+    column: Column[list[float]] = Column("embedding", Vector(3))
     statement = column.cosine_distance([1.0, 2.0, 3.0])
     with pytest.raises(NotImplementedError):
         str(statement.compile(dialect=sqlite_dialect_mod.dialect()))  # type: ignore[no-untyped-call,unused-ignore]

--- a/tests/unit/test_types/test_vector.py
+++ b/tests/unit/test_types/test_vector.py
@@ -8,7 +8,7 @@ import textwrap
 from typing import Any, Optional, cast
 
 import pytest
-from sqlalchemy import Integer, Table, create_engine, insert, select
+from sqlalchemy import Column, Integer, Table, create_engine, insert, select
 from sqlalchemy.dialects import oracle as oracle_dialect_mod
 from sqlalchemy.dialects import postgresql as postgresql_dialect_mod
 from sqlalchemy.dialects import sqlite as sqlite_dialect_mod
@@ -157,6 +157,90 @@ def test_vector_process_result_value_returns_list_for_plain_iterable() -> None:
     """JSON fallback returns a plain ``list`` (or anything iterable) and stays a ``list``."""
     vec = Vector(3)
     assert vec.process_result_value([1.0, 2.0, 3.0], sqlite_dialect_mod.dialect()) == [1.0, 2.0, 3.0]  # type: ignore[no-untyped-call,unused-ignore]
+
+
+def test_vector_distance_methods_exist_on_column() -> None:
+    """``Vector`` columns expose pgvector-compatible distance comparator methods."""
+    column = Column("embedding", Vector(3))
+    assert hasattr(column, "cosine_distance")
+    assert hasattr(column, "l2_distance")
+    assert hasattr(column, "max_inner_product")
+
+
+def test_vector_cosine_distance_postgresql_emits_operator() -> None:
+    """Cosine distance compiles to the pgvector ``<=>`` operator on PostgreSQL."""
+    column = Column("embedding", Vector(3))
+    statement = column.cosine_distance([1.0, 2.0, 3.0])
+    sql = str(statement.compile(dialect=postgresql_dialect_mod.dialect()))  # type: ignore[no-untyped-call,unused-ignore]
+    assert "<=>" in sql
+
+
+def test_vector_l2_distance_postgresql_emits_operator() -> None:
+    """L2 distance compiles to the pgvector ``<->`` operator on PostgreSQL."""
+    column = Column("embedding", Vector(3))
+    statement = column.l2_distance([1.0, 2.0, 3.0])
+    sql = str(statement.compile(dialect=postgresql_dialect_mod.dialect()))  # type: ignore[no-untyped-call,unused-ignore]
+    assert "<->" in sql
+
+
+def test_vector_max_inner_product_postgresql_emits_operator() -> None:
+    """Negative inner product compiles to the pgvector ``<#>`` operator on PostgreSQL."""
+    column = Column("embedding", Vector(3))
+    statement = column.max_inner_product([1.0, 2.0, 3.0])
+    sql = str(statement.compile(dialect=postgresql_dialect_mod.dialect()))  # type: ignore[no-untyped-call,unused-ignore]
+    assert "<#>" in sql
+
+
+def test_vector_cosine_distance_oracle_emits_vector_distance() -> None:
+    """Cosine distance compiles to ``VECTOR_DISTANCE(..., COSINE)`` on Oracle 23ai."""
+    column = Column("embedding", Vector(3))
+    statement = column.cosine_distance([1.0, 2.0, 3.0])
+    sql = str(statement.compile(dialect=oracle_dialect_mod.dialect()))  # type: ignore[no-untyped-call,unused-ignore]
+    assert "VECTOR_DISTANCE" in sql
+    assert "COSINE" in sql
+
+
+def test_vector_l2_distance_oracle_uses_euclidean_metric() -> None:
+    """L2 distance maps to the Oracle ``EUCLIDEAN`` metric."""
+    column = Column("embedding", Vector(3))
+    statement = column.l2_distance([1.0, 2.0, 3.0])
+    sql = str(statement.compile(dialect=oracle_dialect_mod.dialect()))  # type: ignore[no-untyped-call,unused-ignore]
+    assert "VECTOR_DISTANCE" in sql
+    assert "EUCLIDEAN" in sql
+
+
+def test_vector_max_inner_product_oracle_uses_dot_metric() -> None:
+    """Negative inner product maps to the Oracle ``DOT`` metric."""
+    column = Column("embedding", Vector(3))
+    statement = column.max_inner_product([1.0, 2.0, 3.0])
+    sql = str(statement.compile(dialect=oracle_dialect_mod.dialect()))  # type: ignore[no-untyped-call,unused-ignore]
+    assert "VECTOR_DISTANCE" in sql
+    assert "DOT" in sql
+
+
+def test_vector_distance_unsupported_dialect_raises() -> None:
+    """Distance operations require a native vector backend; JSON fallback raises clearly."""
+    column = Column("embedding", Vector(3))
+    statement = column.cosine_distance([1.0, 2.0, 3.0])
+    with pytest.raises(NotImplementedError):
+        str(statement.compile(dialect=sqlite_dialect_mod.dialect()))  # type: ignore[no-untyped-call,unused-ignore]
+
+
+def test_vector_distance_usable_in_order_by_on_postgresql() -> None:
+    """Distance expressions work as ``ORDER BY`` keys for nearest-neighbour search."""
+
+    class _Base(DeclarativeBase):
+        pass
+
+    class _PgVectorModel(_Base):
+        __tablename__ = "pg_vector_order_by_model"
+        id: Mapped[int] = mapped_column(Integer, primary_key=True)
+        embedding: Mapped[list[float]] = mapped_column(Vector(3))
+
+    statement = select(_PgVectorModel).order_by(_PgVectorModel.embedding.cosine_distance([1.0, 2.0, 3.0]))
+    sql = str(statement.compile(dialect=postgresql_dialect_mod.dialect()))  # type: ignore[no-untyped-call,unused-ignore]
+    assert "ORDER BY" in sql
+    assert "<=>" in sql
 
 
 def test_vector_sqlite_round_trip_via_json_fallback() -> None:

--- a/tests/unit/test_types/test_vector.py
+++ b/tests/unit/test_types/test_vector.py
@@ -164,6 +164,7 @@ def test_vector_distance_methods_exist_on_column() -> None:
     column: Column[list[float]] = Column("embedding", Vector(3))
     assert hasattr(column, "cosine_distance")
     assert hasattr(column, "l2_distance")
+    assert hasattr(column, "l1_distance")
     assert hasattr(column, "max_inner_product")
 
 
@@ -181,6 +182,14 @@ def test_vector_l2_distance_postgresql_emits_operator() -> None:
     statement = column.l2_distance([1.0, 2.0, 3.0])
     sql = str(statement.compile(dialect=postgresql_dialect_mod.dialect()))  # type: ignore[no-untyped-call,unused-ignore]
     assert "<->" in sql
+
+
+def test_vector_l1_distance_postgresql_emits_operator() -> None:
+    """L1 distance compiles to the pgvector ``<+>`` operator on PostgreSQL."""
+    column: Column[list[float]] = Column("embedding", Vector(3))
+    statement = column.l1_distance([1.0, 2.0, 3.0])
+    sql = str(statement.compile(dialect=postgresql_dialect_mod.dialect()))  # type: ignore[no-untyped-call,unused-ignore]
+    assert "<+>" in sql
 
 
 def test_vector_max_inner_product_postgresql_emits_operator() -> None:
@@ -209,6 +218,15 @@ def test_vector_l2_distance_oracle_uses_euclidean_metric() -> None:
     assert "EUCLIDEAN" in sql
 
 
+def test_vector_l1_distance_oracle_uses_manhattan_metric() -> None:
+    """L1 distance maps to the Oracle ``MANHATTAN`` metric."""
+    column: Column[list[float]] = Column("embedding", Vector(3))
+    statement = column.l1_distance([1.0, 2.0, 3.0])
+    sql = str(statement.compile(dialect=oracle_dialect_mod.dialect()))  # type: ignore[no-untyped-call,unused-ignore]
+    assert "VECTOR_DISTANCE" in sql
+    assert "MANHATTAN" in sql
+
+
 def test_vector_max_inner_product_oracle_uses_dot_metric() -> None:
     """Negative inner product maps to the Oracle ``DOT`` metric."""
     column: Column[list[float]] = Column("embedding", Vector(3))
@@ -216,6 +234,16 @@ def test_vector_max_inner_product_oracle_uses_dot_metric() -> None:
     sql = str(statement.compile(dialect=oracle_dialect_mod.dialect()))  # type: ignore[no-untyped-call,unused-ignore]
     assert "VECTOR_DISTANCE" in sql
     assert "DOT" in sql
+
+
+def test_vector_distance_is_cacheable() -> None:
+    """Distance expressions generate a SQLAlchemy cache key keyed on operands and metric."""
+    column: Column[list[float]] = Column("embedding", Vector(3))
+    cosine = column.cosine_distance([1.0, 2.0, 3.0])
+    l2 = column.l2_distance([1.0, 2.0, 3.0])
+    assert cosine._generate_cache_key() is not None  # pyright: ignore[reportPrivateUsage]
+    assert cosine._generate_cache_key() == column.cosine_distance([1.0, 2.0, 3.0])._generate_cache_key()  # pyright: ignore[reportPrivateUsage]
+    assert cosine._generate_cache_key() != l2._generate_cache_key()  # pyright: ignore[reportPrivateUsage]
 
 
 def test_vector_distance_unsupported_dialect_raises() -> None:


### PR DESCRIPTION
## Summary

Adds similarity-search operators to the first-party `advanced_alchemy.types.Vector` type so a `Mapped[list[float]]` column can be ordered by vector distance directly — without dropping down to the third-party `pgvector.sqlalchemy.Vector` type.

```python
stmt = select(Memory).order_by(Memory.embedding.cosine_distance(query_vec))
```

Four comparator methods are added. Their names and semantics mirror pgvector's SQLAlchemy comparator, so existing pgvector-based queries swap to the first-party type unchanged:

- `cosine_distance`
- `l2_distance`
- `l1_distance`
- `max_inner_product`

A dialect-deferred `_VectorDistance` column element resolves to native SQL at statement-compile time:

| Backend | Compiles to |
|---|---|
| PostgreSQL / CockroachDB | pgvector operators `<=>` (cosine), `<->` (l2), `<+>` (l1), `<#>` (negative inner product) |
| Oracle 23ai | `VECTOR_DISTANCE(col, :vec, COSINE \| EUCLIDEAN \| MANHATTAN \| DOT)` |
| JSON-fallback dialects (SQLite / MySQL / …) | `NotImplementedError` (no native vector backend) |

`max_inner_product` returns the negated inner product on both PostgreSQL (`<#>`) and Oracle (`DOT`), so ascending order yields the nearest match.

The `_VectorDistance` element is cache-safe: it defines `_traverse_internals` keyed on its operands and metric, so statements containing a vector distance participate in SQLAlchemy's compiled-statement cache rather than recompiling on every query.

Importing `advanced_alchemy.types` still never requires `pgvector` or `oracledb`. All new imports are SQLAlchemy core, and the backend libraries remain lazily imported inside `load_dialect_impl` (covered by the existing lazy-import test).

## Why

This is the enabling piece that lets the first-party `Vector` type fully replace third-party pgvector in similarity search — including the Google ADK memory service, which currently hard-imports pgvector and is PostgreSQL-gated. It also unlocks vector search on **Oracle 23ai**, which the pgvector-only path cannot reach.

## Verification

- `uv run pytest tests/unit/test_types/test_vector.py -q` — 26 passed (12 new)
- `uv run ruff check` / `uv run ruff format --check` — clean
- `uv run mypy advanced_alchemy/types/vector.py` — clean
- `uv run pyright advanced_alchemy/types/vector.py` — clean
- `uv run slotscheck -m advanced_alchemy.types.vector` — clean

## Scope

- Vector *index* helpers (HNSW / IVF / AlloyDB ScaNN) are **not** included — index DDL is a separate concern with divergent per-backend parameters, tracked separately.
- User docs land with the broader Vector documentation pass (separate task).

<!-- docs-preview -->

<hr>
📚 Documentation preview: <a href="https://litestar-org.github.io/advanced-alchemy-docs-preview/756">https://litestar-org.github.io/advanced-alchemy-docs-preview/756</a> 
