### PR TITLE
refactor: break down long methods to resolve too-many-statements

### DIFF
--- a/advanced_alchemy/_listeners.py
+++ b/advanced_alchemy/_listeners.py
@@ -1,4 +1,4 @@
-# ruff: noqa: BLE001, C901, PLR0915
+# ruff: noqa: BLE001
 """Application ORM configuration."""
 
 import asyncio
@@ -19,6 +19,7 @@ if TYPE_CHECKING:
 
     from advanced_alchemy.cache import CacheManager
     from advanced_alchemy.types.file_object import FileObject, FileObjectSessionTracker, StorageRegistry
+    from advanced_alchemy.types.mutables import MutableList
 
 _active_file_operations: set[asyncio.Task[Any]] = set()
 """Stores active file operations to prevent them from being garbage collected."""
@@ -204,25 +205,17 @@ class FileObjectInspector:
             tracker.add_pending_delete(original_value)
 
     @staticmethod
-    def handle_multiple_attribute(
-        instance: Any,
-        attr_name: str,
-        attr_state: Any,
-        tracker: "FileObjectSessionTracker",
-    ) -> None:
-        """Handle inspection of multiple FileObject attributes (MutableList)."""
+    def _collect_deletions(
+        current_list_instance: "Optional[MutableList[FileObject]]",
+        original_list_from_history: "Optional[MutableList[FileObject]]",
+        current_list_from_history: "Optional[MutableList[FileObject]]",
+    ) -> "set[FileObject]":
+        """Collect items to delete from mutations and replacements."""
         from advanced_alchemy.types.file_object import FileObject
         from advanced_alchemy.types.mutables import MutableList
 
-        history = attr_state.history
         items_to_delete: set[FileObject] = set()
-        items_to_save: dict[FileObject, Any] = {}
 
-        current_list_instance: Optional[MutableList[FileObject]] = getattr(instance, attr_name, None)
-        original_list_from_history: Optional[MutableList[FileObject]] = history.deleted[0] if history.deleted else None
-        current_list_from_history: Optional[MutableList[FileObject]] = history.added[0] if history.added else None
-
-        # 1. Deletions from Mutations (Primary source: _pending_removed set)
         if isinstance(current_list_instance, MutableList):
             removed_items_internal: set[FileObject] = getattr(
                 current_list_instance,
@@ -237,8 +230,7 @@ class FileObjectInspector:
                 )
                 items_to_delete.update(valid_removed_internal)
 
-        # 2. Deletions from Replacements (Secondary source: history)
-        if original_list_from_history:  # Indicates list replacement
+        if original_list_from_history:
             logger.debug("[Multiple-Replacement] Processing list replacement via history.")
             original_items_set = {item for item in original_list_from_history if item.path}
             current_items_set = (
@@ -254,8 +246,19 @@ class FileObjectInspector:
                 )
                 items_to_delete.update(removed_due_to_replacement)
 
-        # 3. Determine items to save
-        # Saves from pending appends (Mutation or New)
+        return items_to_delete
+
+    @staticmethod
+    def _collect_saves(
+        current_list_instance: "Optional[MutableList[FileObject]]",
+        current_list_from_history: "Optional[MutableList[FileObject]]",
+        original_list_from_history: "Optional[MutableList[FileObject]]",
+    ) -> "dict[FileObject, Any]":
+        """Collect items to save from pending appends and history."""
+        from advanced_alchemy.types.mutables import MutableList
+
+        items_to_save: dict[FileObject, Any] = {}
+
         if isinstance(current_list_instance, MutableList):
             pending_append = getattr(current_list_instance, "_pending_append", [])
             if pending_append:
@@ -268,7 +271,6 @@ class FileObjectInspector:
                     elif pending_source_path is not None:
                         items_to_save[item] = pending_source_path
 
-        # Saves from newly added list items (New Instance or Replacement)
         if current_list_from_history:
             log_prefix = "[Multiple-New]" if not original_list_from_history else "[Multiple-Replacement]"
             logger.debug(
@@ -286,14 +288,48 @@ class FileObjectInspector:
                     logger.debug("%s Found pending source path for %r", log_prefix, item.filename)
                     items_to_save[item] = pending_source_path
 
-        # 4. Finalize MutableList state (if applicable)
+        return items_to_save
+
+    @staticmethod
+    def _finalize_mutable_list(
+        current_list_instance: "Optional[MutableList[FileObject]]",
+    ) -> None:
+        """Finalize MutableList state if applicable."""
+        from advanced_alchemy.types.mutables import MutableList
+
         if isinstance(current_list_instance, MutableList):
             finalize_method = getattr(current_list_instance, "_finalize_pending", None)
             if finalize_method:
                 logger.debug("[Multiple] Calling _finalize_pending on list instance.")
                 finalize_method()
 
-        # 5. Schedule all collected operations
+    @staticmethod
+    def handle_multiple_attribute(
+        instance: Any,
+        attr_name: str,
+        attr_state: Any,
+        tracker: "FileObjectSessionTracker",
+    ) -> None:
+        """Handle inspection of multiple FileObject attributes (MutableList)."""
+
+        history = attr_state.history
+
+        current_list_instance: Optional[MutableList[FileObject]] = getattr(instance, attr_name, None)
+        original_list_from_history: Optional[MutableList[FileObject]] = history.deleted[0] if history.deleted else None
+        current_list_from_history: Optional[MutableList[FileObject]] = history.added[0] if history.added else None
+
+        items_to_delete = FileObjectInspector._collect_deletions(
+            current_list_instance,
+            original_list_from_history,
+            current_list_from_history,
+        )
+        items_to_save = FileObjectInspector._collect_saves(
+            current_list_instance,
+            current_list_from_history,
+            original_list_from_history,
+        )
+        FileObjectInspector._finalize_mutable_list(current_list_instance)
+
         if items_to_delete:
             logger.debug("[Multiple] Scheduling %d items for deletion.", len(items_to_delete))
             for item_to_delete in items_to_delete:

--- a/advanced_alchemy/cli.py
+++ b/advanced_alchemy/cli.py
@@ -1,7 +1,7 @@
 import sys
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from pathlib import Path
-from typing import TYPE_CHECKING, Optional, Union, cast
+from typing import TYPE_CHECKING, Any, Optional, Union, cast
 
 if TYPE_CHECKING:
     from alembic.migration import MigrationContext
@@ -11,6 +11,431 @@ if TYPE_CHECKING:
     from advanced_alchemy.config import SQLAlchemyAsyncConfig, SQLAlchemySyncConfig
 
 __all__ = ("add_migration_commands", "get_alchemy_group")
+
+from rich import get_console
+
+from advanced_alchemy.utils.cli_tools import click
+
+_console = get_console()
+
+bind_key_option = click.option(
+    "--bind-key",
+    help="Specify which SQLAlchemy config to use by bind key",
+    type=str,
+    default=None,
+)
+verbose_option = click.option(
+    "--verbose",
+    help="Enable verbose output.",
+    type=bool,
+    default=False,
+    is_flag=True,
+)
+no_prompt_option = click.option(
+    "--no-prompt",
+    help="Do not prompt for confirmation before executing the command.",
+    type=bool,
+    default=False,
+    required=False,
+    show_default=True,
+    is_flag=True,
+)
+
+
+def _get_config_by_bind_key(
+    ctx: "click.Context",
+    bind_key: Optional[str],
+) -> "Union[SQLAlchemyAsyncConfig, SQLAlchemySyncConfig]":
+    """Get the SQLAlchemy config for the specified bind key."""
+    configs = ctx.obj["configs"]
+    if bind_key is None:
+        return cast("Union[SQLAlchemyAsyncConfig, SQLAlchemySyncConfig]", configs[0])
+
+    for config in configs:
+        if config.bind_key == bind_key:
+            return cast("Union[SQLAlchemyAsyncConfig, SQLAlchemySyncConfig]", config)
+
+    _console.print(f"[red]No config found for bind key: {bind_key}[/]")
+    sys.exit(1)
+
+
+def _register_command(
+    group: "Group",
+    name: Optional[str],
+    help_text: str,
+    handler: Callable[..., Any],
+    *options: Callable[..., Any],
+) -> None:
+    """Register a Click command with its decorators."""
+    cmd = group.command(name=name, help=help_text)(handler)
+    for opt in options:
+        cmd = opt(cmd)
+
+
+# ── Command Handlers ────────────────────────────────────────────────
+
+
+def _show_database_revision(bind_key: Optional[str], verbose: bool) -> None:
+    """Show current database revision."""
+    from advanced_alchemy.alembic.commands import AlembicCommands
+
+    ctx = cast("click.Context", click.get_current_context())
+    _console.rule("[yellow]Listing current revision[/]", align="left")
+    sqlalchemy_config = _get_config_by_bind_key(ctx, bind_key)
+    alembic_commands = AlembicCommands(sqlalchemy_config=sqlalchemy_config)
+    alembic_commands.current(verbose=verbose)
+
+
+def _downgrade_database(
+    bind_key: Optional[str],
+    revision: str,
+    sql: bool,
+    tag: Optional[str],
+    no_prompt: bool,
+) -> None:
+    """Downgrade the database to the latest revision."""
+    from rich.prompt import Confirm
+
+    from advanced_alchemy.alembic.commands import AlembicCommands
+
+    ctx = cast("click.Context", click.get_current_context())
+    _console.rule("[yellow]Starting database downgrade process[/]", align="left")
+    input_confirmed = (
+        True
+        if no_prompt
+        else Confirm.ask(f"Are you sure you want to downgrade the database to the `{revision}` revision?")
+    )
+    if input_confirmed:
+        sqlalchemy_config = _get_config_by_bind_key(ctx, bind_key)
+        alembic_commands = AlembicCommands(sqlalchemy_config=sqlalchemy_config)
+        alembic_commands.downgrade(revision=revision, sql=sql, tag=tag)
+
+
+def _upgrade_database(
+    bind_key: Optional[str],
+    revision: str,
+    sql: bool,
+    tag: Optional[str],
+    no_prompt: bool,
+) -> None:
+    """Upgrade the database to the latest revision."""
+    from rich.prompt import Confirm
+
+    from advanced_alchemy.alembic.commands import AlembicCommands
+
+    ctx = cast("click.Context", click.get_current_context())
+    _console.rule("[yellow]Starting database upgrade process[/]", align="left")
+    input_confirmed = (
+        True
+        if no_prompt
+        else Confirm.ask(f"[bold]Are you sure you want migrate the database to the `{revision}` revision?[/]")
+    )
+    if input_confirmed:
+        sqlalchemy_config = _get_config_by_bind_key(ctx, bind_key)
+        alembic_commands = AlembicCommands(sqlalchemy_config=sqlalchemy_config)
+        alembic_commands.upgrade(revision=revision, sql=sql, tag=tag)
+
+
+def _stamp_database(
+    bind_key: Optional[str],
+    revision: str,
+    sql: bool,
+    tag: Optional[str],
+    purge: bool,
+) -> None:
+    """Stamp the revision table with the given revision."""
+    from advanced_alchemy.alembic.commands import AlembicCommands
+
+    ctx = cast("click.Context", click.get_current_context())
+    _console.rule("[yellow]Stamping revision table[/]", align="left")
+    sqlalchemy_config = _get_config_by_bind_key(ctx, bind_key)
+    alembic_commands = AlembicCommands(sqlalchemy_config=sqlalchemy_config)
+    alembic_commands.stamp(revision=revision, sql=sql, tag=tag, purge=purge)
+
+
+def _check_revision(bind_key: Optional[str]) -> None:
+    """Check for pending upgrade operations."""
+    from advanced_alchemy.alembic.commands import AlembicCommands
+
+    ctx = cast("click.Context", click.get_current_context())
+    _console.rule("[yellow]Checking for pending migrations[/]", align="left")
+    sqlalchemy_config = _get_config_by_bind_key(ctx, bind_key)
+    alembic_commands = AlembicCommands(sqlalchemy_config=sqlalchemy_config)
+    alembic_commands.check()
+
+
+def _edit_revision(bind_key: Optional[str], revision: str) -> None:
+    """Edit revision script with system editor."""
+    from advanced_alchemy.alembic.commands import AlembicCommands
+
+    ctx = cast("click.Context", click.get_current_context())
+    _console.rule(f"[yellow]Opening revision {revision} in editor[/]", align="left")
+    sqlalchemy_config = _get_config_by_bind_key(ctx, bind_key)
+    alembic_commands = AlembicCommands(sqlalchemy_config=sqlalchemy_config)
+    alembic_commands.edit(revision=revision)
+
+
+def _ensure_version_table(bind_key: Optional[str], sql: bool) -> None:
+    """Ensure alembic version table exists."""
+    from advanced_alchemy.alembic.commands import AlembicCommands
+
+    ctx = cast("click.Context", click.get_current_context())
+    _console.rule("[yellow]Ensuring version table exists[/]", align="left")
+    sqlalchemy_config = _get_config_by_bind_key(ctx, bind_key)
+    alembic_commands = AlembicCommands(sqlalchemy_config=sqlalchemy_config)
+    alembic_commands.ensure_version(sql=sql)
+
+
+def _show_heads(
+    bind_key: Optional[str],
+    verbose: bool,
+    resolve_dependencies: bool,
+) -> None:
+    """Show current heads."""
+    from advanced_alchemy.alembic.commands import AlembicCommands
+
+    ctx = cast("click.Context", click.get_current_context())
+    _console.rule("[yellow]Showing current heads[/]", align="left")
+    sqlalchemy_config = _get_config_by_bind_key(ctx, bind_key)
+    alembic_commands = AlembicCommands(sqlalchemy_config=sqlalchemy_config)
+    alembic_commands.heads(verbose=verbose, resolve_dependencies=resolve_dependencies)
+
+
+def _show_history(
+    bind_key: Optional[str],
+    verbose: bool,
+    rev_range: Optional[str],
+    indicate_current: bool,
+) -> None:
+    """Show revision history."""
+    from advanced_alchemy.alembic.commands import AlembicCommands
+
+    ctx = cast("click.Context", click.get_current_context())
+    _console.rule("[yellow]Showing revision history[/]", align="left")
+    sqlalchemy_config = _get_config_by_bind_key(ctx, bind_key)
+    alembic_commands = AlembicCommands(sqlalchemy_config=sqlalchemy_config)
+    alembic_commands.history(
+        rev_range=rev_range,
+        verbose=verbose,
+        indicate_current=indicate_current,
+    )
+
+
+def _merge_revisions(
+    bind_key: Optional[str],
+    revisions: str,
+    message: Optional[str],
+    branch_label: Optional[str],
+    rev_id: Optional[str],
+    no_prompt: bool,
+) -> None:
+    """Merge revisions (resolves multiple heads)."""
+    from rich.prompt import Prompt
+
+    from advanced_alchemy.alembic.commands import AlembicCommands
+
+    ctx = cast("click.Context", click.get_current_context())
+    _console.rule("[yellow]Merging revisions[/]", align="left")
+
+    if message is None:
+        message = "merge revisions" if no_prompt else Prompt.ask("Enter merge message")
+
+    sqlalchemy_config = _get_config_by_bind_key(ctx, bind_key)
+    alembic_commands = AlembicCommands(sqlalchemy_config=sqlalchemy_config)
+    alembic_commands.merge(
+        revisions=revisions,
+        message=message,
+        branch_label=branch_label,
+        rev_id=rev_id,
+    )
+
+
+def _show_revision(bind_key: Optional[str], revision: str) -> None:
+    """Show details of a specific revision."""
+    from advanced_alchemy.alembic.commands import AlembicCommands
+
+    ctx = cast("click.Context", click.get_current_context())
+    _console.rule(f"[yellow]Showing revision {revision}[/]", align="left")
+    sqlalchemy_config = _get_config_by_bind_key(ctx, bind_key)
+    alembic_commands = AlembicCommands(sqlalchemy_config=sqlalchemy_config)
+    alembic_commands.show(rev=revision)
+
+
+def _show_branches(bind_key: Optional[str], verbose: bool) -> None:
+    """Show branch points."""
+    from advanced_alchemy.alembic.commands import AlembicCommands
+
+    ctx = cast("click.Context", click.get_current_context())
+    _console.rule("[yellow]Showing branch points[/]", align="left")
+    sqlalchemy_config = _get_config_by_bind_key(ctx, bind_key)
+    alembic_commands = AlembicCommands(sqlalchemy_config=sqlalchemy_config)
+    alembic_commands.branches(verbose=verbose)
+
+
+def _list_init_templates(bind_key: Optional[str]) -> None:
+    """List available initialization templates."""
+    from advanced_alchemy.alembic.commands import AlembicCommands
+
+    ctx = cast("click.Context", click.get_current_context())
+    _console.rule("[yellow]Available templates[/]", align="left")
+    sqlalchemy_config = _get_config_by_bind_key(ctx, bind_key)
+    alembic_commands = AlembicCommands(sqlalchemy_config=sqlalchemy_config)
+    alembic_commands.list_templates()
+
+
+def _init_alembic(
+    bind_key: Optional[str],
+    directory: Optional[str],
+    multidb: bool,
+    package: bool,
+    no_prompt: bool,
+) -> None:
+    """Initialize the database migrations."""
+    from rich.prompt import Confirm
+
+    from advanced_alchemy.alembic.commands import AlembicCommands
+
+    ctx = cast("click.Context", click.get_current_context())
+    _console.rule("[yellow]Initializing database migrations.", align="left")
+    input_confirmed = (
+        True if no_prompt else Confirm.ask("[bold]Are you sure you want initialize migrations for the project?[/]")
+    )
+    if input_confirmed:
+        configs = [_get_config_by_bind_key(ctx, bind_key)] if bind_key is not None else ctx.obj["configs"]
+        for config in configs:
+            directory = config.alembic_config.script_location if directory is None else directory
+            alembic_commands = AlembicCommands(sqlalchemy_config=config)
+            alembic_commands.init(directory=cast("str", directory), multidb=multidb, package=package)
+
+
+def _create_revision(
+    bind_key: Optional[str],
+    message: Optional[str],
+    autogenerate: bool,
+    sql: bool,
+    head: str,
+    splice: bool,
+    branch_label: Optional[str],
+    version_path: Optional[str],
+    rev_id: Optional[str],
+    no_prompt: bool,
+) -> None:
+    """Create a new database revision."""
+    from rich.prompt import Prompt
+
+    from advanced_alchemy.alembic.commands import AlembicCommands
+
+    def process_revision_directives(
+        context: "MigrationContext",  # noqa: ARG001
+        revision: tuple[str],  # noqa: ARG001
+        directives: list["MigrationScript"],
+    ) -> None:
+        """Handle revision directives."""
+        if autogenerate and cast("UpgradeOps", directives[0].upgrade_ops).is_empty():
+            _console.rule(
+                "[magenta]The generation of a migration file is being skipped because it would result in an empty file.",
+                style="magenta",
+                align="left",
+            )
+            _console.rule(
+                "[magenta]More information can be found here. https://alembic.sqlalchemy.org/en/latest/autogenerate.html#what-does-autogenerate-detect-and-what-does-it-not-detect",
+                style="magenta",
+                align="left",
+            )
+            _console.rule(
+                "[magenta]If you intend to create an empty migration file, use the --no-autogenerate option.",
+                style="magenta",
+                align="left",
+            )
+            directives.clear()
+
+    ctx = cast("click.Context", click.get_current_context())
+    _console.rule("[yellow]Starting database upgrade process[/]", align="left")
+    if message is None:
+        message = "autogenerated" if no_prompt else Prompt.ask("Please enter a message describing this revision")
+
+    sqlalchemy_config = _get_config_by_bind_key(ctx, bind_key)
+    alembic_commands = AlembicCommands(sqlalchemy_config=sqlalchemy_config)
+    alembic_commands.revision(
+        message=message,
+        autogenerate=autogenerate,
+        sql=sql,
+        head=head,
+        splice=splice,
+        branch_label=branch_label,
+        version_path=version_path,
+        rev_id=rev_id,
+        process_revision_directives=process_revision_directives,  # type: ignore[arg-type]
+    )
+
+
+def _drop_all_tables(bind_key: Optional[str], no_prompt: bool) -> None:
+    """Drop all tables from the database."""
+    from anyio import run
+    from rich.prompt import Confirm
+
+    from advanced_alchemy.alembic.utils import drop_all
+    from advanced_alchemy.base import metadata_registry
+
+    ctx = cast("click.Context", click.get_current_context())
+    _console.rule("[yellow]Dropping all tables from the database[/]", align="left")
+    input_confirmed = no_prompt or Confirm.ask(
+        "[bold red]Are you sure you want to drop all tables from the database?",
+    )
+
+    async def _drop_all(
+        configs: "Sequence[Union[SQLAlchemyAsyncConfig, SQLAlchemySyncConfig]]",
+    ) -> None:
+        for config in configs:
+            engine = config.get_engine()
+            await drop_all(engine, config.alembic_config.version_table_name, metadata_registry.get(config.bind_key))
+
+    if input_confirmed:
+        configs = [_get_config_by_bind_key(ctx, bind_key)] if bind_key is not None else ctx.obj["configs"]
+        run(_drop_all, configs)
+
+
+def _dump_table_data(bind_key: Optional[str], table_names: tuple[str, ...], dump_dir: Path) -> None:
+    """Dump table data to JSON files."""
+    from anyio import run
+    from rich.prompt import Confirm
+
+    from advanced_alchemy.alembic.utils import dump_tables
+    from advanced_alchemy.base import metadata_registry, orm_registry
+
+    ctx = cast("click.Context", click.get_current_context())
+    all_tables = "*" in table_names
+
+    if all_tables and not Confirm.ask(
+        "[yellow bold]You have specified '*'. Are you sure you want to dump all tables from the database?",
+    ):
+        _console.rule("[red bold]No data was dumped.", style="red", align="left")
+        return None
+
+    async def _dump_tables() -> None:
+        configs = [_get_config_by_bind_key(ctx, bind_key)] if bind_key is not None else ctx.obj["configs"]
+        for config in configs:
+            target_tables = set(metadata_registry.get(config.bind_key).tables)
+
+            if not all_tables:
+                for table_name in set(table_names) - target_tables:
+                    _console.rule(
+                        f"[red bold]Skipping table '{table_name}' because it is not available in the default registry",
+                        style="red",
+                        align="left",
+                    )
+                target_tables.intersection_update(table_names)
+            else:
+                _console.rule("[yellow bold]Dumping all tables", style="yellow", align="left")
+
+            models = [mapper.class_ for mapper in orm_registry.mappers if mapper.class_.__table__.name in target_tables]
+            await dump_tables(dump_dir, config.get_session(), models)
+            _console.rule("[green bold]Data dump complete", align="left")
+
+    return run(_dump_tables)
+
+
+# ── Public API ──────────────────────────────────────────────────────
 
 
 def get_alchemy_group() -> "Group":
@@ -69,571 +494,244 @@ def get_alchemy_group() -> "Group":
     return alchemy_group
 
 
-def add_migration_commands(database_group: Optional["Group"] = None) -> "Group":  # noqa: C901, PLR0915
+def add_migration_commands(database_group: Optional["Group"] = None) -> "Group":
     """Add migration commands to the database group.
 
     Args:
         database_group: The database group to add the commands to.
 
-    Raises:
-        MissingDependencyError: If the `click` package is not installed.
-
     Returns:
         The database group with the migration commands added.
     """
-    from rich import get_console
-
-    from advanced_alchemy.utils.cli_tools import click
-
-    console = get_console()
-
     if database_group is None:
         database_group = get_alchemy_group()
 
-    bind_key_option = click.option(
-        "--bind-key",
-        help="Specify which SQLAlchemy config to use by bind key",
-        type=str,
-        default=None,
-    )
-    verbose_option = click.option(
-        "--verbose",
-        help="Enable verbose output.",
-        type=bool,
-        default=False,
-        is_flag=True,
-    )
-    no_prompt_option = click.option(
-        "--no-prompt",
-        help="Do not prompt for confirmation before executing the command.",
-        type=bool,
-        default=False,
-        required=False,
-        show_default=True,
-        is_flag=True,
+    _register_command(
+        database_group,
+        "show-current-revision",
+        "Shows the current revision for the database.",
+        _show_database_revision,
+        bind_key_option,
+        verbose_option,
     )
 
-    def get_config_by_bind_key(
-        ctx: "click.Context", bind_key: Optional[str]
-    ) -> "Union[SQLAlchemyAsyncConfig, SQLAlchemySyncConfig]":
-        """Get the SQLAlchemy config for the specified bind key.
-
-        Args:
-            ctx: The click context.
-            bind_key: The bind key to get the config for.
-
-        Returns:
-            The SQLAlchemy config for the specified bind key.
-        """
-        configs = ctx.obj["configs"]
-        if bind_key is None:
-            return cast("Union[SQLAlchemyAsyncConfig, SQLAlchemySyncConfig]", configs[0])
-
-        for config in configs:
-            if config.bind_key == bind_key:
-                return cast("Union[SQLAlchemyAsyncConfig, SQLAlchemySyncConfig]", config)
-
-        console.print(f"[red]No config found for bind key: {bind_key}[/]")
-        sys.exit(1)
-
-    @database_group.command(
-        name="show-current-revision",
-        help="Shows the current revision for the database.",
+    _register_command(
+        database_group,
+        "downgrade",
+        "Downgrade database to a specific revision.",
+        _downgrade_database,
+        click.argument("revision", type=str, default="-1"),
+        bind_key_option,
+        click.option(
+            "--sql", type=bool, help="Generate SQL output for offline migrations.", default=False, is_flag=True
+        ),
+        click.option(
+            "--tag",
+            help="an arbitrary 'tag' that can be intercepted by custom env.py scripts via the .EnvironmentContext.get_tag_argument method.",
+            type=str,
+            default=None,
+        ),
+        no_prompt_option,
     )
-    @bind_key_option
-    @verbose_option
-    def show_database_revision(bind_key: Optional[str], verbose: bool) -> None:  # pyright: ignore[reportUnusedFunction]
-        """Show current database revision."""
-        from advanced_alchemy.alembic.commands import AlembicCommands
 
-        ctx = cast("click.Context", click.get_current_context())
-        console.rule("[yellow]Listing current revision[/]", align="left")
-        sqlalchemy_config = get_config_by_bind_key(ctx, bind_key)
-        alembic_commands = AlembicCommands(sqlalchemy_config=sqlalchemy_config)
-        alembic_commands.current(verbose=verbose)
-
-    @database_group.command(
-        name="downgrade",
-        help="Downgrade database to a specific revision.",
+    _register_command(
+        database_group,
+        "upgrade",
+        "Upgrade database to a specific revision.",
+        _upgrade_database,
+        click.argument("revision", type=str, default="head"),
+        bind_key_option,
+        click.option(
+            "--sql", type=bool, help="Generate SQL output for offline migrations.", default=False, is_flag=True
+        ),
+        click.option(
+            "--tag",
+            help="an arbitrary 'tag' that can be intercepted by custom env.py scripts via the .EnvironmentContext.get_tag_argument method.",
+            type=str,
+            default=None,
+        ),
+        no_prompt_option,
     )
-    @bind_key_option
-    @click.option("--sql", type=bool, help="Generate SQL output for offline migrations.", default=False, is_flag=True)
-    @click.option(
-        "--tag",
-        help="an arbitrary 'tag' that can be intercepted by custom env.py scripts via the .EnvironmentContext.get_tag_argument method.",
-        type=str,
-        default=None,
+
+    _register_command(
+        database_group,
+        "stamp",
+        "Stamp the revision table with the given revision; don't run any migrations",
+        _stamp_database,
+        click.argument("revision", type=str),
+        bind_key_option,
+        click.option("--sql", is_flag=True, default=False, help="Generate SQL output for offline migrations"),
+        click.option(
+            "--tag",
+            type=str,
+            default=None,
+            help="Arbitrary 'tag' that can be intercepted by custom env.py scripts",
+        ),
+        click.option(
+            "--purge", is_flag=True, default=False, help="Delete all entries in version table before stamping"
+        ),
     )
-    @no_prompt_option
-    @click.argument(
-        "revision",
-        type=str,
-        default="-1",
+
+    _register_command(
+        database_group,
+        "check",
+        "Check if the target database is up to date",
+        _check_revision,
+        bind_key_option,
     )
-    def downgrade_database(  # pyright: ignore[reportUnusedFunction]
-        bind_key: Optional[str], revision: str, sql: bool, tag: Optional[str], no_prompt: bool
-    ) -> None:
-        """Downgrade the database to the latest revision."""
-        from rich.prompt import Confirm
 
-        from advanced_alchemy.alembic.commands import AlembicCommands
-
-        ctx = cast("click.Context", click.get_current_context())
-        console.rule("[yellow]Starting database downgrade process[/]", align="left")
-        input_confirmed = (
-            True
-            if no_prompt
-            else Confirm.ask(f"Are you sure you want to downgrade the database to the `{revision}` revision?")
-        )
-        if input_confirmed:
-            sqlalchemy_config = get_config_by_bind_key(ctx, bind_key)
-            alembic_commands = AlembicCommands(sqlalchemy_config=sqlalchemy_config)
-            alembic_commands.downgrade(revision=revision, sql=sql, tag=tag)
-
-    @database_group.command(
-        name="upgrade",
-        help="Upgrade database to a specific revision.",
+    _register_command(
+        database_group,
+        "edit",
+        "Edit a revision file using $EDITOR",
+        _edit_revision,
+        click.argument("revision", type=str),
+        bind_key_option,
     )
-    @bind_key_option
-    @click.option("--sql", type=bool, help="Generate SQL output for offline migrations.", default=False, is_flag=True)
-    @click.option(
-        "--tag",
-        help="an arbitrary 'tag' that can be intercepted by custom env.py scripts via the .EnvironmentContext.get_tag_argument method.",
-        type=str,
-        default=None,
+
+    _register_command(
+        database_group,
+        "ensure-version",
+        "Create the alembic version table if it doesn't exist",
+        _ensure_version_table,
+        bind_key_option,
+        click.option("--sql", is_flag=True, default=False, help="Generate SQL output instead of executing"),
     )
-    @no_prompt_option
-    @click.argument(
-        "revision",
-        type=str,
-        default="head",
+
+    _register_command(
+        database_group,
+        "heads",
+        "Show current available heads in the script directory",
+        _show_heads,
+        bind_key_option,
+        verbose_option,
+        click.option("--resolve-dependencies", is_flag=True, default=False, help="Resolve dependencies between heads"),
     )
-    def upgrade_database(  # pyright: ignore[reportUnusedFunction]
-        bind_key: Optional[str], revision: str, sql: bool, tag: Optional[str], no_prompt: bool
-    ) -> None:
-        """Upgrade the database to the latest revision."""
-        from rich.prompt import Confirm
 
-        from advanced_alchemy.alembic.commands import AlembicCommands
-
-        ctx = cast("click.Context", click.get_current_context())
-        console.rule("[yellow]Starting database upgrade process[/]", align="left")
-        input_confirmed = (
-            True
-            if no_prompt
-            else Confirm.ask(f"[bold]Are you sure you want migrate the database to the `{revision}` revision?[/]")
-        )
-        if input_confirmed:
-            sqlalchemy_config = get_config_by_bind_key(ctx, bind_key)
-            alembic_commands = AlembicCommands(sqlalchemy_config=sqlalchemy_config)
-            alembic_commands.upgrade(revision=revision, sql=sql, tag=tag)
-
-    @database_group.command(
-        help="Stamp the revision table with the given revision; don't run any migrations",
+    _register_command(
+        database_group,
+        "history",
+        "List changeset scripts in chronological order",
+        _show_history,
+        bind_key_option,
+        verbose_option,
+        click.option(
+            "--rev-range",
+            type=str,
+            default=None,
+            help="Revision range (e.g., 'base:head', 'abc:def')",
+        ),
+        click.option("--indicate-current", is_flag=True, default=False, help="Indicate the current revision"),
     )
-    @click.argument("revision", type=str)
-    @bind_key_option
-    @click.option("--sql", is_flag=True, default=False, help="Generate SQL output for offline migrations")
-    @click.option(
-        "--tag", type=str, default=None, help="Arbitrary 'tag' that can be intercepted by custom env.py scripts"
+
+    _register_command(
+        database_group,
+        "merge",
+        "Merge two revisions together, creating a new migration file",
+        _merge_revisions,
+        click.argument("revisions", type=str),
+        bind_key_option,
+        click.option("-m", "--message", type=str, default=None, help="Merge message"),
+        click.option("--branch-label", type=str, default=None, help="Branch label for merge revision"),
+        click.option("--rev-id", type=str, default=None, help="Specify custom revision ID"),
+        no_prompt_option,
     )
-    @click.option("--purge", is_flag=True, default=False, help="Delete all entries in version table before stamping")
-    def stamp(bind_key: Optional[str], revision: str, sql: bool, tag: Optional[str], purge: bool) -> None:  # pyright: ignore[reportUnusedFunction]
-        """Stamp the revision table with the given revision."""
-        from advanced_alchemy.alembic.commands import AlembicCommands
 
-        ctx = cast("click.Context", click.get_current_context())
-        console.rule("[yellow]Stamping revision table[/]", align="left")
-        sqlalchemy_config = get_config_by_bind_key(ctx, bind_key)
-        alembic_commands = AlembicCommands(sqlalchemy_config=sqlalchemy_config)
-        alembic_commands.stamp(revision=revision, sql=sql, tag=tag, purge=purge)
-
-    @database_group.command(
-        name="check",
-        help="Check if the target database is up to date",
+    _register_command(
+        database_group,
+        "show",
+        "Show the revision denoted by the given symbol",
+        _show_revision,
+        click.argument("revision", type=str),
+        bind_key_option,
     )
-    @bind_key_option
-    def check_revision(bind_key: Optional[str]) -> None:  # pyright: ignore[reportUnusedFunction]
-        """Check for pending upgrade operations."""
-        from advanced_alchemy.alembic.commands import AlembicCommands
 
-        ctx = cast("click.Context", click.get_current_context())
-        console.rule("[yellow]Checking for pending migrations[/]", align="left")
-        sqlalchemy_config = get_config_by_bind_key(ctx, bind_key)
-        alembic_commands = AlembicCommands(sqlalchemy_config=sqlalchemy_config)
-        alembic_commands.check()
-
-    @database_group.command(
-        name="edit",
-        help="Edit a revision file using $EDITOR",
+    _register_command(
+        database_group,
+        "branches",
+        "Show current branch points in the migration history",
+        _show_branches,
+        bind_key_option,
+        verbose_option,
     )
-    @click.argument("revision", type=str)
-    @bind_key_option
-    def edit_revision(bind_key: Optional[str], revision: str) -> None:  # pyright: ignore[reportUnusedFunction]
-        """Edit revision script with system editor."""
-        from advanced_alchemy.alembic.commands import AlembicCommands
 
-        ctx = cast("click.Context", click.get_current_context())
-        console.rule(f"[yellow]Opening revision {revision} in editor[/]", align="left")
-        sqlalchemy_config = get_config_by_bind_key(ctx, bind_key)
-        alembic_commands = AlembicCommands(sqlalchemy_config=sqlalchemy_config)
-        alembic_commands.edit(revision=revision)
-
-    @database_group.command(
-        name="ensure-version",
-        help="Create the alembic version table if it doesn't exist",
+    _register_command(
+        database_group,
+        "list-templates",
+        "List available Alembic migration templates",
+        _list_init_templates,
+        bind_key_option,
     )
-    @bind_key_option
-    @click.option("--sql", is_flag=True, default=False, help="Generate SQL output instead of executing")
-    def ensure_version_table(bind_key: Optional[str], sql: bool) -> None:  # pyright: ignore[reportUnusedFunction]
-        """Ensure alembic version table exists."""
-        from advanced_alchemy.alembic.commands import AlembicCommands
 
-        ctx = cast("click.Context", click.get_current_context())
-        console.rule("[yellow]Ensuring version table exists[/]", align="left")
-        sqlalchemy_config = get_config_by_bind_key(ctx, bind_key)
-        alembic_commands = AlembicCommands(sqlalchemy_config=sqlalchemy_config)
-        alembic_commands.ensure_version(sql=sql)
-
-    @database_group.command(
-        name="heads",
-        help="Show current available heads in the script directory",
+    _register_command(
+        database_group,
+        "init",
+        "Initialize migrations for the project.",
+        _init_alembic,
+        click.argument("directory", default=None, required=False),
+        bind_key_option,
+        click.option("--multidb", is_flag=True, default=False, help="Support multiple databases"),
+        click.option("--package", is_flag=True, default=True, help="Create `__init__.py` for created folder"),
+        no_prompt_option,
     )
-    @bind_key_option
-    @verbose_option
-    @click.option(
-        "--resolve-dependencies",
-        is_flag=True,
-        default=False,
-        help="Resolve dependencies between heads",
+
+    _register_command(
+        database_group,
+        "make-migrations",
+        "Create a new migration revision.",
+        _create_revision,
+        bind_key_option,
+        click.option("-m", "--message", default=None, help="Revision message"),
+        click.option(
+            "--autogenerate/--no-autogenerate",
+            default=True,
+            help="Automatically populate revision with detected changes",
+        ),
+        click.option("--sql", is_flag=True, default=False, help="Export to `.sql` instead of writing to the database."),
+        click.option("--head", default="head", help="Specify head revision to use as base for new revision."),
+        click.option(
+            "--splice",
+            is_flag=True,
+            default=False,
+            help='Allow a non-head revision as the "head" to splice onto',
+        ),
+        click.option("--branch-label", default=None, help="Specify a branch label to apply to the new revision"),
+        click.option("--version-path", default=None, help="Specify specific path from config for version file"),
+        click.option("--rev-id", default=None, help="Specify a ID to use for revision."),
+        no_prompt_option,
     )
-    def show_heads(bind_key: Optional[str], verbose: bool, resolve_dependencies: bool) -> None:  # pyright: ignore[reportUnusedFunction]
-        """Show current heads."""
-        from advanced_alchemy.alembic.commands import AlembicCommands
 
-        ctx = cast("click.Context", click.get_current_context())
-        console.rule("[yellow]Showing current heads[/]", align="left")
-        sqlalchemy_config = get_config_by_bind_key(ctx, bind_key)
-        alembic_commands = AlembicCommands(sqlalchemy_config=sqlalchemy_config)
-        alembic_commands.heads(verbose=verbose, resolve_dependencies=resolve_dependencies)
-
-    @database_group.command(
-        name="history",
-        help="List changeset scripts in chronological order",
+    _register_command(
+        database_group,
+        "drop-all",
+        "Drop all tables from the database.",
+        _drop_all_tables,
+        bind_key_option,
+        no_prompt_option,
     )
-    @bind_key_option
-    @verbose_option
-    @click.option(
-        "--rev-range",
-        type=str,
-        default=None,
-        help="Revision range (e.g., 'base:head', 'abc:def')",
+
+    _register_command(
+        database_group,
+        "dump-data",
+        "Dump specified tables from the database to JSON files.",
+        _dump_table_data,
+        bind_key_option,
+        click.option(
+            "--table",
+            "table_names",
+            help="Name of the table to dump. Multiple tables can be specified. Use '*' to dump all tables.",
+            type=str,
+            required=True,
+            multiple=True,
+        ),
+        click.option(
+            "--dir",
+            "dump_dir",
+            help="Directory to save the JSON files. Defaults to WORKDIR/fixtures",
+            type=click.Path(path_type=Path),
+            default=Path.cwd() / "fixtures",
+            required=False,
+        ),
     )
-    @click.option(
-        "--indicate-current",
-        is_flag=True,
-        default=False,
-        help="Indicate the current revision",
-    )
-    def show_history(  # pyright: ignore[reportUnusedFunction]
-        bind_key: Optional[str],
-        verbose: bool,
-        rev_range: Optional[str],
-        indicate_current: bool,
-    ) -> None:
-        """Show revision history."""
-        from advanced_alchemy.alembic.commands import AlembicCommands
-
-        ctx = cast("click.Context", click.get_current_context())
-        console.rule("[yellow]Showing revision history[/]", align="left")
-        sqlalchemy_config = get_config_by_bind_key(ctx, bind_key)
-        alembic_commands = AlembicCommands(sqlalchemy_config=sqlalchemy_config)
-        alembic_commands.history(
-            rev_range=rev_range,
-            verbose=verbose,
-            indicate_current=indicate_current,
-        )
-
-    @database_group.command(
-        name="merge",
-        help="Merge two revisions together, creating a new migration file",
-    )
-    @click.argument("revisions", type=str)
-    @bind_key_option
-    @click.option("-m", "--message", type=str, default=None, help="Merge message")
-    @click.option("--branch-label", type=str, default=None, help="Branch label for merge revision")
-    @click.option("--rev-id", type=str, default=None, help="Specify custom revision ID")
-    @no_prompt_option
-    def merge_revisions(  # pyright: ignore[reportUnusedFunction]
-        bind_key: Optional[str],
-        revisions: str,
-        message: Optional[str],
-        branch_label: Optional[str],
-        rev_id: Optional[str],
-        no_prompt: bool,
-    ) -> None:
-        """Merge revisions (resolves multiple heads)."""
-        from rich.prompt import Prompt
-
-        from advanced_alchemy.alembic.commands import AlembicCommands
-
-        ctx = cast("click.Context", click.get_current_context())
-        console.rule("[yellow]Merging revisions[/]", align="left")
-
-        if message is None:
-            message = "merge revisions" if no_prompt else Prompt.ask("Enter merge message")
-
-        sqlalchemy_config = get_config_by_bind_key(ctx, bind_key)
-        alembic_commands = AlembicCommands(sqlalchemy_config=sqlalchemy_config)
-        alembic_commands.merge(
-            revisions=revisions,
-            message=message,
-            branch_label=branch_label,
-            rev_id=rev_id,
-        )
-
-    @database_group.command(
-        name="show",
-        help="Show the revision denoted by the given symbol",
-    )
-    @click.argument("revision", type=str)
-    @bind_key_option
-    def show_revision(bind_key: Optional[str], revision: str) -> None:  # pyright: ignore[reportUnusedFunction]
-        """Show details of a specific revision."""
-        from advanced_alchemy.alembic.commands import AlembicCommands
-
-        ctx = cast("click.Context", click.get_current_context())
-        console.rule(f"[yellow]Showing revision {revision}[/]", align="left")
-        sqlalchemy_config = get_config_by_bind_key(ctx, bind_key)
-        alembic_commands = AlembicCommands(sqlalchemy_config=sqlalchemy_config)
-        alembic_commands.show(rev=revision)
-
-    @database_group.command(
-        name="branches",
-        help="Show current branch points in the migration history",
-    )
-    @bind_key_option
-    @verbose_option
-    def show_branches(bind_key: Optional[str], verbose: bool) -> None:  # pyright: ignore[reportUnusedFunction]
-        """Show branch points."""
-        from advanced_alchemy.alembic.commands import AlembicCommands
-
-        ctx = cast("click.Context", click.get_current_context())
-        console.rule("[yellow]Showing branch points[/]", align="left")
-        sqlalchemy_config = get_config_by_bind_key(ctx, bind_key)
-        alembic_commands = AlembicCommands(sqlalchemy_config=sqlalchemy_config)
-        alembic_commands.branches(verbose=verbose)
-
-    @database_group.command(
-        name="list-templates",
-        help="List available Alembic migration templates",
-    )
-    @bind_key_option
-    def list_init_templates(bind_key: Optional[str]) -> None:  # pyright: ignore[reportUnusedFunction]
-        """List available initialization templates."""
-        from advanced_alchemy.alembic.commands import AlembicCommands
-
-        ctx = cast("click.Context", click.get_current_context())
-        console.rule("[yellow]Available templates[/]", align="left")
-        sqlalchemy_config = get_config_by_bind_key(ctx, bind_key)
-        alembic_commands = AlembicCommands(sqlalchemy_config=sqlalchemy_config)
-        alembic_commands.list_templates()
-
-    @database_group.command(
-        name="init",
-        help="Initialize migrations for the project.",
-    )
-    @bind_key_option
-    @click.argument(
-        "directory",
-        default=None,
-        required=False,
-    )
-    @click.option("--multidb", is_flag=True, default=False, help="Support multiple databases")
-    @click.option("--package", is_flag=True, default=True, help="Create `__init__.py` for created folder")
-    @no_prompt_option
-    def init_alembic(  # pyright: ignore[reportUnusedFunction]
-        bind_key: Optional[str], directory: Optional[str], multidb: bool, package: bool, no_prompt: bool
-    ) -> None:
-        """Initialize the database migrations."""
-        from rich.prompt import Confirm
-
-        from advanced_alchemy.alembic.commands import AlembicCommands
-
-        ctx = cast("click.Context", click.get_current_context())
-        console.rule("[yellow]Initializing database migrations.", align="left")
-        input_confirmed = (
-            True if no_prompt else Confirm.ask("[bold]Are you sure you want initialize migrations for the project?[/]")
-        )
-        if input_confirmed:
-            configs = [get_config_by_bind_key(ctx, bind_key)] if bind_key is not None else ctx.obj["configs"]
-            for config in configs:
-                directory = config.alembic_config.script_location if directory is None else directory
-                alembic_commands = AlembicCommands(sqlalchemy_config=config)
-                alembic_commands.init(directory=cast("str", directory), multidb=multidb, package=package)
-
-    @database_group.command(
-        name="make-migrations",
-        help="Create a new migration revision.",
-    )
-    @bind_key_option
-    @click.option("-m", "--message", default=None, help="Revision message")
-    @click.option(
-        "--autogenerate/--no-autogenerate", default=True, help="Automatically populate revision with detected changes"
-    )
-    @click.option("--sql", is_flag=True, default=False, help="Export to `.sql` instead of writing to the database.")
-    @click.option("--head", default="head", help="Specify head revision to use as base for new revision.")
-    @click.option(
-        "--splice", is_flag=True, default=False, help='Allow a non-head revision as the "head" to splice onto'
-    )
-    @click.option("--branch-label", default=None, help="Specify a branch label to apply to the new revision")
-    @click.option("--version-path", default=None, help="Specify specific path from config for version file")
-    @click.option("--rev-id", default=None, help="Specify a ID to use for revision.")
-    @no_prompt_option
-    def create_revision(  # pyright: ignore[reportUnusedFunction]
-        bind_key: Optional[str],
-        message: Optional[str],
-        autogenerate: bool,
-        sql: bool,
-        head: str,
-        splice: bool,
-        branch_label: Optional[str],
-        version_path: Optional[str],
-        rev_id: Optional[str],
-        no_prompt: bool,
-    ) -> None:
-        """Create a new database revision."""
-        from rich.prompt import Prompt
-
-        from advanced_alchemy.alembic.commands import AlembicCommands
-
-        def process_revision_directives(
-            context: "MigrationContext",  # noqa: ARG001
-            revision: tuple[str],  # noqa: ARG001
-            directives: list["MigrationScript"],
-        ) -> None:
-            """Handle revision directives."""
-            if autogenerate and cast("UpgradeOps", directives[0].upgrade_ops).is_empty():
-                console.rule(
-                    "[magenta]The generation of a migration file is being skipped because it would result in an empty file.",
-                    style="magenta",
-                    align="left",
-                )
-                console.rule(
-                    "[magenta]More information can be found here. https://alembic.sqlalchemy.org/en/latest/autogenerate.html#what-does-autogenerate-detect-and-what-does-it-not-detect",
-                    style="magenta",
-                    align="left",
-                )
-                console.rule(
-                    "[magenta]If you intend to create an empty migration file, use the --no-autogenerate option.",
-                    style="magenta",
-                    align="left",
-                )
-                directives.clear()
-
-        ctx = cast("click.Context", click.get_current_context())
-        console.rule("[yellow]Starting database upgrade process[/]", align="left")
-        if message is None:
-            message = "autogenerated" if no_prompt else Prompt.ask("Please enter a message describing this revision")
-
-        sqlalchemy_config = get_config_by_bind_key(ctx, bind_key)
-        alembic_commands = AlembicCommands(sqlalchemy_config=sqlalchemy_config)
-        alembic_commands.revision(
-            message=message,
-            autogenerate=autogenerate,
-            sql=sql,
-            head=head,
-            splice=splice,
-            branch_label=branch_label,
-            version_path=version_path,
-            rev_id=rev_id,
-            process_revision_directives=process_revision_directives,  # type: ignore[arg-type]
-        )
-
-    @database_group.command(name="drop-all", help="Drop all tables from the database.")
-    @bind_key_option
-    @no_prompt_option
-    def drop_all(bind_key: Optional[str], no_prompt: bool) -> None:  # pyright: ignore[reportUnusedFunction]
-        """Drop all tables from the database."""
-        from anyio import run
-        from rich.prompt import Confirm
-
-        from advanced_alchemy.alembic.utils import drop_all
-        from advanced_alchemy.base import metadata_registry
-
-        ctx = cast("click.Context", click.get_current_context())
-        console.rule("[yellow]Dropping all tables from the database[/]", align="left")
-        input_confirmed = no_prompt or Confirm.ask(
-            "[bold red]Are you sure you want to drop all tables from the database?"
-        )
-
-        async def _drop_all(
-            configs: "Sequence[Union[SQLAlchemyAsyncConfig, SQLAlchemySyncConfig]]",
-        ) -> None:
-            for config in configs:
-                engine = config.get_engine()
-                await drop_all(engine, config.alembic_config.version_table_name, metadata_registry.get(config.bind_key))
-
-        if input_confirmed:
-            configs = [get_config_by_bind_key(ctx, bind_key)] if bind_key is not None else ctx.obj["configs"]
-            run(_drop_all, configs)
-
-    @database_group.command(name="dump-data", help="Dump specified tables from the database to JSON files.")
-    @bind_key_option
-    @click.option(
-        "--table",
-        "table_names",
-        help="Name of the table to dump. Multiple tables can be specified. Use '*' to dump all tables.",
-        type=str,
-        required=True,
-        multiple=True,
-    )
-    @click.option(
-        "--dir",
-        "dump_dir",
-        help="Directory to save the JSON files. Defaults to WORKDIR/fixtures",
-        type=click.Path(path_type=Path),
-        default=Path.cwd() / "fixtures",
-        required=False,
-    )
-    def dump_table_data(bind_key: Optional[str], table_names: tuple[str, ...], dump_dir: Path) -> None:  # pyright: ignore[reportUnusedFunction]
-        """Dump table data to JSON files."""
-        from anyio import run
-        from rich.prompt import Confirm
-
-        from advanced_alchemy.alembic.utils import dump_tables
-        from advanced_alchemy.base import metadata_registry, orm_registry
-
-        ctx = cast("click.Context", click.get_current_context())
-        all_tables = "*" in table_names
-
-        if all_tables and not Confirm.ask(
-            "[yellow bold]You have specified '*'. Are you sure you want to dump all tables from the database?",
-        ):
-            return console.rule("[red bold]No data was dumped.", style="red", align="left")
-
-        async def _dump_tables() -> None:
-            configs = [get_config_by_bind_key(ctx, bind_key)] if bind_key is not None else ctx.obj["configs"]
-            for config in configs:
-                target_tables = set(metadata_registry.get(config.bind_key).tables)
-
-                if not all_tables:
-                    for table_name in set(table_names) - target_tables:
-                        console.rule(
-                            f"[red bold]Skipping table '{table_name}' because it is not available in the default registry",
-                            style="red",
-                            align="left",
-                        )
-                    target_tables.intersection_update(table_names)
-                else:
-                    console.rule("[yellow bold]Dumping all tables", style="yellow", align="left")
-
-                models = [
-                    mapper.class_ for mapper in orm_registry.mappers if mapper.class_.__table__.name in target_tables
-                ]
-                await dump_tables(dump_dir, config.get_session(), models)
-                console.rule("[green bold]Data dump complete", align="left")
-
-        return run(_dump_tables)
 
     return database_group

--- a/advanced_alchemy/exceptions.py
+++ b/advanced_alchemy/exceptions.py
@@ -247,8 +247,74 @@ def _get_error_message(error_messages: ErrorMessages, key: str, exc: Exception) 
     return template  # pyright: ignore[reportUnknownVariableType]
 
 
+def _raise_from_error(
+    exc: Exception,
+    error_messages: Optional[ErrorMessages],
+    key: str,
+    default_message: str,
+    exception_cls: type[RepositoryError],
+) -> None:
+    if error_messages is not None:
+        msg = _get_error_message(error_messages=error_messages, key=key, exc=exc)
+    else:
+        msg = default_message
+    raise exception_cls(detail=msg) from exc
+
+
+def _handle_integrity_error(
+    exc: SQLAlchemyIntegrityError,
+    error_messages: Optional[ErrorMessages],
+    dialect_name: Optional[str],
+) -> None:
+    if error_messages is not None and dialect_name is not None:
+        keys_to_regex = {
+            "duplicate_key": (DUPLICATE_KEY_REGEXES.get(dialect_name, []), DuplicateKeyError),
+            "check_constraint": (CHECK_CONSTRAINT_REGEXES.get(dialect_name, []), IntegrityError),
+            "foreign_key": (FOREIGN_KEY_REGEXES.get(dialect_name, []), ForeignKeyError),
+        }
+        detail = " - ".join(str(exc_arg) for exc_arg in exc.orig.args) if exc.orig.args else ""  # type: ignore[union-attr] # pyright: ignore[reportArgumentType,reportOptionalMemberAccess]
+        for key, (regexes, exception) in keys_to_regex.items():
+            for regex in regexes:
+                if (match := regex.findall(detail)) and match[0]:
+                    raise exception(
+                        detail=_get_error_message(error_messages=error_messages, key=key, exc=exc),
+                    ) from exc
+
+        raise IntegrityError(
+            detail=_get_error_message(error_messages=error_messages, key="integrity", exc=exc),
+        ) from exc
+    raise IntegrityError(detail=f"An integrity error occurred: {exc}") from exc
+
+
+def _raise_wrapped_exception(
+    exc: Exception,
+    error_messages: Optional[ErrorMessages] = None,
+    dialect_name: Optional[str] = None,
+) -> None:
+    if isinstance(exc, NotFoundError):
+        _raise_from_error(exc, error_messages, "not_found", "No rows matched the specified data", NotFoundError)
+    if isinstance(exc, MultipleResultsFound):
+        _raise_from_error(
+            exc, error_messages, "multiple_rows", "Multiple rows matched the specified data", MultipleResultsFoundError
+        )
+    if isinstance(exc, SQLAlchemyIntegrityError):
+        _handle_integrity_error(exc, error_messages, dialect_name)
+    if isinstance(exc, SQLAlchemyInvalidRequestError):
+        raise InvalidRequestError(detail="An invalid request was made.") from exc
+    if isinstance(exc, StatementError):
+        raise IntegrityError(
+            detail=cast("str", getattr(exc.orig, "detail", "There was an issue processing the statement."))
+        ) from exc
+    if isinstance(exc, SQLAlchemyError):
+        _raise_from_error(exc, error_messages, "other", f"An exception occurred: {exc}", RepositoryError)
+    if isinstance(exc, AttributeError):
+        _raise_from_error(
+            exc, error_messages, "other", f"An attribute error occurred during processing: {exc}", RepositoryError
+        )
+
+
 @contextmanager
-def wrap_sqlalchemy_exception(  # noqa: C901, PLR0915
+def wrap_sqlalchemy_exception(
     error_messages: Optional[ErrorMessages] = None,
     dialect_name: Optional[str] = None,
     wrap_exceptions: bool = True,
@@ -285,66 +351,15 @@ def wrap_sqlalchemy_exception(  # noqa: C901, PLR0915
     try:
         yield
 
-    except NotFoundError as exc:
+    except (
+        NotFoundError,
+        MultipleResultsFound,
+        SQLAlchemyIntegrityError,
+        SQLAlchemyInvalidRequestError,
+        StatementError,
+        SQLAlchemyError,
+        AttributeError,
+    ) as exc:
         if wrap_exceptions is False:
             raise
-        if error_messages is not None:
-            msg = _get_error_message(error_messages=error_messages, key="not_found", exc=exc)
-        else:
-            msg = "No rows matched the specified data"
-        raise NotFoundError(detail=msg) from exc
-    except MultipleResultsFound as exc:
-        if wrap_exceptions is False:
-            raise
-        if error_messages is not None:
-            msg = _get_error_message(error_messages=error_messages, key="multiple_rows", exc=exc)
-        else:
-            msg = "Multiple rows matched the specified data"
-        raise MultipleResultsFoundError(detail=msg) from exc
-    except SQLAlchemyIntegrityError as exc:
-        if wrap_exceptions is False:
-            raise
-        if error_messages is not None and dialect_name is not None:
-            keys_to_regex = {
-                "duplicate_key": (DUPLICATE_KEY_REGEXES.get(dialect_name, []), DuplicateKeyError),
-                "check_constraint": (CHECK_CONSTRAINT_REGEXES.get(dialect_name, []), IntegrityError),
-                "foreign_key": (FOREIGN_KEY_REGEXES.get(dialect_name, []), ForeignKeyError),
-            }
-            detail = " - ".join(str(exc_arg) for exc_arg in exc.orig.args) if exc.orig.args else ""  # type: ignore[union-attr] # pyright: ignore[reportArgumentType,reportOptionalMemberAccess]
-            for key, (regexes, exception) in keys_to_regex.items():
-                for regex in regexes:
-                    if (match := regex.findall(detail)) and match[0]:
-                        raise exception(
-                            detail=_get_error_message(error_messages=error_messages, key=key, exc=exc),
-                        ) from exc
-
-            raise IntegrityError(
-                detail=_get_error_message(error_messages=error_messages, key="integrity", exc=exc),
-            ) from exc
-        raise IntegrityError(detail=f"An integrity error occurred: {exc}") from exc
-    except SQLAlchemyInvalidRequestError as exc:
-        if wrap_exceptions is False:
-            raise
-        raise InvalidRequestError(detail="An invalid request was made.") from exc
-    except StatementError as exc:
-        if wrap_exceptions is False:
-            raise
-        raise IntegrityError(
-            detail=cast("str", getattr(exc.orig, "detail", "There was an issue processing the statement."))
-        ) from exc
-    except SQLAlchemyError as exc:
-        if wrap_exceptions is False:
-            raise
-        if error_messages is not None:
-            msg = _get_error_message(error_messages=error_messages, key="other", exc=exc)
-        else:
-            msg = f"An exception occurred: {exc}"
-        raise RepositoryError(detail=msg) from exc
-    except AttributeError as exc:
-        if wrap_exceptions is False:
-            raise
-        if error_messages is not None:
-            msg = _get_error_message(error_messages=error_messages, key="other", exc=exc)
-        else:
-            msg = f"An attribute error occurred during processing: {exc}"
-        raise RepositoryError(detail=msg) from exc
+        _raise_wrapped_exception(exc, error_messages, dialect_name)

--- a/advanced_alchemy/extensions/fastapi/providers.py
+++ b/advanced_alchemy/extensions/fastapi/providers.py
@@ -137,6 +137,80 @@ def _should_commit_for_status(status_code: int, commit_mode: str) -> bool:
     return False
 
 
+async def _cleanup_async_session(
+    db_session: AsyncSession,
+    request: Request,
+    session_key: str,
+    exc_info: Optional[BaseException],
+    commit_mode: str,
+) -> None:
+    response_status = getattr(request.state, f"{session_key}_response_status", None)
+    should_commit = (
+        exc_info is None and response_status is not None and _should_commit_for_status(response_status, commit_mode)
+    )
+    try:
+        if should_commit:
+            await db_session.commit()
+        else:
+            await db_session.rollback()
+    except Exception:
+        if exc_info is not None:
+            logger.debug("Session commit/rollback failed during cleanup", exc_info=True)
+        else:
+            raise
+    try:
+        await db_session.close()
+    except Exception:
+        if exc_info is not None:
+            logger.debug("Session close failed during cleanup", exc_info=True)
+        else:
+            raise
+    for attr in [
+        session_key,
+        f"{session_key}_generator_managed",
+        f"{session_key}_response_status",
+    ]:
+        with contextlib.suppress(Exception):
+            delattr(request.state, attr)
+
+
+def _cleanup_sync_session(
+    db_session: Session,
+    request: Request,
+    session_key: str,
+    exc_info: Optional[BaseException],
+    commit_mode: str,
+) -> None:
+    response_status = getattr(request.state, f"{session_key}_response_status", None)
+    should_commit = (
+        exc_info is None and response_status is not None and _should_commit_for_status(response_status, commit_mode)
+    )
+    try:
+        if should_commit:
+            db_session.commit()
+        else:
+            db_session.rollback()
+    except Exception:
+        if exc_info is not None:
+            logger.debug("Session commit/rollback failed during cleanup", exc_info=True)
+        else:
+            raise
+    try:
+        db_session.close()
+    except Exception:
+        if exc_info is not None:
+            logger.debug("Session close failed during cleanup", exc_info=True)
+        else:
+            raise
+    for attr in [
+        session_key,
+        f"{session_key}_generator_managed",
+        f"{session_key}_response_status",
+    ]:
+        with contextlib.suppress(Exception):
+            delattr(request.state, attr)
+
+
 @overload
 def provide_service(
     service_class: type["AsyncServiceT_co"],
@@ -167,7 +241,7 @@ def provide_service(
 ) -> Callable[..., Generator[SyncServiceT_co, None, None]]: ...
 
 
-def provide_service(  # noqa: C901, PLR0915
+def provide_service(
     service_class: type[Union["AsyncServiceT_co", "SyncServiceT_co"]],
     /,
     extension: AdvancedAlchemy,
@@ -218,45 +292,8 @@ def provide_service(  # noqa: C901, PLR0915
                 exc_info = e
                 raise
             finally:
-                # Get response status stored by middleware
-                response_status = getattr(request.state, f"{session_key}_response_status", None)
                 commit_mode = async_config.commit_mode if async_config else "manual"
-
-                should_commit = (
-                    exc_info is None
-                    and response_status is not None
-                    and _should_commit_for_status(response_status, commit_mode)
-                )
-
-                # Each cleanup operation is individually protected so that failures
-                # in one step do not prevent subsequent steps or mask the original exception.
-                try:
-                    if should_commit:
-                        await db_session.commit()
-                    else:
-                        await db_session.rollback()
-                except Exception:
-                    if exc_info is not None:
-                        logger.debug("Session commit/rollback failed during cleanup", exc_info=True)
-                    else:
-                        raise
-
-                try:
-                    await db_session.close()
-                except Exception:
-                    if exc_info is not None:
-                        logger.debug("Session close failed during cleanup", exc_info=True)
-                    else:
-                        raise
-
-                # Clean up request state
-                for attr in [
-                    session_key,
-                    f"{session_key}_generator_managed",
-                    f"{session_key}_response_status",
-                ]:
-                    with contextlib.suppress(Exception):
-                        delattr(request.state, attr)
+                await _cleanup_async_session(db_session, request, session_key, exc_info, commit_mode)
 
         return provide_async_service
 
@@ -288,45 +325,8 @@ def provide_service(  # noqa: C901, PLR0915
             exc_info = e
             raise
         finally:
-            # Get response status stored by middleware
-            response_status = getattr(request.state, f"{session_key}_response_status", None)
             commit_mode = sync_config.commit_mode if sync_config else "manual"
-
-            should_commit = (
-                exc_info is None
-                and response_status is not None
-                and _should_commit_for_status(response_status, commit_mode)
-            )
-
-            # Each cleanup operation is individually protected so that failures
-            # in one step do not prevent subsequent steps or mask the original exception.
-            try:
-                if should_commit:
-                    db_session.commit()
-                else:
-                    db_session.rollback()
-            except Exception:
-                if exc_info is not None:
-                    logger.debug("Session commit/rollback failed during cleanup", exc_info=True)
-                else:
-                    raise
-
-            try:
-                db_session.close()
-            except Exception:
-                if exc_info is not None:
-                    logger.debug("Session close failed during cleanup", exc_info=True)
-                else:
-                    raise
-
-            # Clean up request state
-            for attr in [
-                session_key,
-                f"{session_key}_generator_managed",
-                f"{session_key}_response_status",
-            ]:
-                with contextlib.suppress(Exception):
-                    delattr(request.state, attr)
+            _cleanup_sync_session(db_session, request, session_key, exc_info, commit_mode)
 
     return provide_sync_service
 
@@ -377,388 +377,462 @@ def provide_filters(
     return dep
 
 
-def _create_filter_aggregate_function_fastapi(  # noqa: C901, PLR0915
+def _create_id_filter_provider_fastapi(
+    config: FilterConfig,
+    dep_defaults: DependencyDefaults = DEPENDENCY_DEFAULTS,
+) -> Optional[tuple[str, inspect.Parameter, Any]]:
+    id_filter = config.get("id_filter", False)
+    if id_filter is False:
+        return None
+
+    def provide_id_filter(  # pyright: ignore[reportUnknownParameterType]
+        ids: Annotated[  # type: ignore
+            Optional[list[id_filter]],  # pyright: ignore
+            Query(
+                alias="ids",
+                required=False,
+                description="IDs to filter by.",
+            ),
+        ] = None,
+    ) -> Optional[CollectionFilter[id_filter]]:  # type: ignore
+        return CollectionFilter[id_filter](field_name=config.get("id_field", "id"), values=ids) if ids else None  # type: ignore
+
+    param_name = dep_defaults.ID_FILTER_DEPENDENCY_KEY
+    annotation: Any = Annotated[
+        Optional[CollectionFilter[id_filter]], Depends(provide_id_filter)  # type: ignore
+    ]
+    param = inspect.Parameter(
+        name=param_name,
+        kind=inspect.Parameter.KEYWORD_ONLY,
+        annotation=annotation,
+    )
+    return param_name, param, annotation
+
+
+def _create_created_at_filter_provider_fastapi(
+    config: FilterConfig,
+    dep_defaults: DependencyDefaults = DEPENDENCY_DEFAULTS,
+) -> Optional[tuple[str, inspect.Parameter, Any]]:
+    if not config.get("created_at", False):
+        return None
+
+    def provide_created_at_filter(
+        before: Annotated[
+            Optional[str],
+            Query(
+                alias="createdBefore",
+                description="Filter by created date before this timestamp.",
+                json_schema_extra={"format": "date-time"},
+            ),
+        ] = None,
+        after: Annotated[
+            Optional[str],
+            Query(
+                alias="createdAfter",
+                description="Filter by created date after this timestamp.",
+                json_schema_extra={"format": "date-time"},
+            ),
+        ] = None,
+    ) -> Optional[BeforeAfter]:
+        before_dt = None
+        after_dt = None
+
+        if before is not None:
+            try:
+                before_dt = datetime.datetime.fromisoformat(before.replace("Z", "+00:00"))
+            except (ValueError, TypeError, AttributeError) as e:
+                raise RequestValidationError(
+                    errors=[{"loc": ["query", "createdBefore"], "msg": "Invalid date format"}]
+                ) from e
+
+        if after is not None:
+            try:
+                after_dt = datetime.datetime.fromisoformat(after.replace("Z", "+00:00"))
+            except (ValueError, TypeError, AttributeError) as e:
+                raise RequestValidationError(
+                    errors=[{"loc": ["query", "createdAfter"], "msg": "Invalid date format"}]
+                ) from e
+
+        return (
+            BeforeAfter(field_name="created_at", before=before_dt, after=after_dt) if before_dt or after_dt else None  # pyright: ignore
+        )
+
+    param_name = dep_defaults.CREATED_FILTER_DEPENDENCY_KEY
+    annotation: Any = Annotated[Optional[BeforeAfter], Depends(provide_created_at_filter)]
+    param = inspect.Parameter(
+        name=param_name,
+        kind=inspect.Parameter.KEYWORD_ONLY,
+        annotation=annotation,
+    )
+    return param_name, param, annotation
+
+
+def _create_updated_at_filter_provider_fastapi(
+    config: FilterConfig,
+    dep_defaults: DependencyDefaults = DEPENDENCY_DEFAULTS,
+) -> Optional[tuple[str, inspect.Parameter, Any]]:
+    if not config.get("updated_at", False):
+        return None
+
+    def provide_updated_at_filter(
+        before: Annotated[
+            Optional[str],
+            Query(
+                alias="updatedBefore",
+                description="Filter by updated date before this timestamp.",
+                json_schema_extra={"format": "date-time"},
+            ),
+        ] = None,
+        after: Annotated[
+            Optional[str],
+            Query(
+                alias="updatedAfter",
+                description="Filter by updated date after this timestamp.",
+                json_schema_extra={"format": "date-time"},
+            ),
+        ] = None,
+    ) -> Optional[BeforeAfter]:
+        before_dt = None
+        after_dt = None
+
+        if before is not None:
+            try:
+                before_dt = datetime.datetime.fromisoformat(before.replace("Z", "+00:00"))
+            except (ValueError, TypeError, AttributeError) as e:
+                raise RequestValidationError(
+                    errors=[{"loc": ["query", "updatedBefore"], "msg": "Invalid date format"}]
+                ) from e
+
+        if after is not None:
+            try:
+                after_dt = datetime.datetime.fromisoformat(after.replace("Z", "+00:00"))
+            except (ValueError, TypeError, AttributeError) as e:
+                raise RequestValidationError(
+                    errors=[{"loc": ["query", "updatedAfter"], "msg": "Invalid date format"}]
+                ) from e
+
+        return (
+            BeforeAfter(field_name="updated_at", before=before_dt, after=after_dt) if before_dt or after_dt else None  # pyright: ignore
+        )
+
+    param_name = dep_defaults.UPDATED_FILTER_DEPENDENCY_KEY
+    annotation: Any = Annotated[Optional[BeforeAfter], Depends(provide_updated_at_filter)]
+    param = inspect.Parameter(
+        name=param_name,
+        kind=inspect.Parameter.KEYWORD_ONLY,
+        annotation=annotation,
+    )
+    return param_name, param, annotation
+
+
+def _create_limit_offset_pagination_provider_fastapi(
+    config: FilterConfig,
+    dep_defaults: DependencyDefaults = DEPENDENCY_DEFAULTS,
+) -> Optional[tuple[str, inspect.Parameter, Any]]:
+    if config.get("pagination_type") != "limit_offset":
+        return None
+
+    def provide_limit_offset_pagination(
+        current_page: Annotated[
+            int,
+            Query(
+                ge=1,
+                alias="currentPage",
+                description="Page number for pagination.",
+            ),
+        ] = 1,
+        page_size: Annotated[
+            int,
+            Query(
+                ge=1,
+                alias="pageSize",
+                description="Number of items per page.",
+            ),
+        ] = config.get("pagination_size", dep_defaults.DEFAULT_PAGINATION_SIZE),
+    ) -> LimitOffset:
+        return LimitOffset(limit=page_size, offset=page_size * (current_page - 1))
+
+    param_name = dep_defaults.LIMIT_OFFSET_FILTER_DEPENDENCY_KEY
+    annotation: Any = Annotated[LimitOffset, Depends(provide_limit_offset_pagination)]
+    param = inspect.Parameter(
+        name=param_name,
+        kind=inspect.Parameter.KEYWORD_ONLY,
+        annotation=annotation,
+    )
+    return param_name, param, annotation
+
+
+def _create_search_filter_provider_fastapi(
+    config: FilterConfig,
+    dep_defaults: DependencyDefaults = DEPENDENCY_DEFAULTS,
+) -> Optional[tuple[str, inspect.Parameter, Any]]:
+    search_fields = config.get("search")
+    if not search_fields:
+        return None
+
+    def provide_search_filter(
+        search_string: Annotated[
+            Optional[str],
+            Query(
+                required=False,
+                alias="searchString",
+                description="Search term.",
+            ),
+        ] = None,
+        ignore_case: Annotated[
+            Optional[bool],
+            Query(
+                required=False,
+                alias="searchIgnoreCase",
+                description="Whether search should be case-insensitive.",
+            ),
+        ] = config.get("search_ignore_case", False),
+    ) -> SearchFilter:
+        field_names = set(search_fields.split(",")) if isinstance(search_fields, str) else set(search_fields)
+
+        return SearchFilter(
+            field_name=field_names,
+            value=search_string,  # type: ignore[arg-type]
+            ignore_case=ignore_case or False,
+        )
+
+    param_name = dep_defaults.SEARCH_FILTER_DEPENDENCY_KEY
+    annotation: Any = Annotated[Optional[SearchFilter], Depends(provide_search_filter)]
+    param = inspect.Parameter(
+        name=param_name,
+        kind=inspect.Parameter.KEYWORD_ONLY,
+        annotation=annotation,
+    )
+    return param_name, param, annotation
+
+
+def _create_order_by_filter_provider_fastapi(
+    config: FilterConfig,
+    dep_defaults: DependencyDefaults = DEPENDENCY_DEFAULTS,
+) -> Optional[tuple[str, inspect.Parameter, Any]]:
+    sort_field = config.get("sort_field")
+    if not sort_field:
+        return None
+
+    sort_field_default = normalize_sort_field(sort_field)
+    sort_order_default = config.get("sort_order", "desc")
+
+    def provide_order_by(
+        field_name: Annotated[
+            str,
+            Query(
+                alias="orderBy",
+                description="Field to order by.",
+                required=False,
+            ),
+        ] = sort_field_default,
+        sort_order: Annotated[
+            Optional[SortOrder],
+            Query(
+                alias="sortOrder",
+                description="Sort order ('asc' or 'desc').",
+                required=False,
+            ),
+        ] = sort_order_default,
+    ) -> OrderBy:
+        return OrderBy(field_name=field_name, sort_order=sort_order or sort_order_default)
+
+    param_name = dep_defaults.ORDER_BY_FILTER_DEPENDENCY_KEY
+    annotation: Any = Annotated[OrderBy, Depends(provide_order_by)]
+    param = inspect.Parameter(
+        name=param_name,
+        kind=inspect.Parameter.KEYWORD_ONLY,
+        annotation=annotation,
+    )
+    return param_name, param, annotation
+
+
+def _create_not_in_filter_providers_fastapi(
+    config: FilterConfig,
+) -> list[tuple[str, inspect.Parameter, Any]]:
+    results: list[tuple[str, inspect.Parameter, Any]] = []
+    not_in_fields = config.get("not_in_fields")
+    if not not_in_fields:
+        return results
+
+    for field_def in normalize_field_name_types(not_in_fields):
+
+        def create_not_in_filter_provider(  # pyright: ignore
+            field_name: FieldNameType = field_def,
+        ) -> Callable[..., Optional[NotInCollectionFilter[Any]]]:
+            def provide_not_in_filter(  # pyright: ignore
+                values: Annotated[  # type: ignore
+                    Optional[set[field_name.type_hint]],  # pyright: ignore
+                    Query(
+                        alias=camelize(f"{field_name.name}_not_in"),
+                        description=f"Filter {field_name.name} not in values",
+                    ),
+                ] = None,
+            ) -> Optional[NotInCollectionFilter[field_name.type_hint]]:  # type: ignore
+                return NotInCollectionFilter(field_name=field_name.name, values=values) if values else None  # pyright: ignore
+
+            return provide_not_in_filter  # pyright: ignore
+
+        provider = create_not_in_filter_provider()  # pyright: ignore
+        param_name = f"{field_def.name}_not_in_filter"
+        annotation: Any = Annotated[Optional[NotInCollectionFilter[field_def.type_hint]], Depends(provider)]  # type: ignore
+        param = inspect.Parameter(
+            name=param_name,
+            kind=inspect.Parameter.KEYWORD_ONLY,
+            annotation=annotation,
+        )
+        results.append((param_name, param, annotation))
+
+    return results
+
+
+def _create_in_filter_providers_fastapi(
+    config: FilterConfig,
+) -> list[tuple[str, inspect.Parameter, Any]]:
+    results: list[tuple[str, inspect.Parameter, Any]] = []
+    in_fields = config.get("in_fields")
+    if not in_fields:
+        return results
+
+    for field_def in normalize_field_name_types(in_fields):
+
+        def create_in_filter_provider(  # pyright: ignore
+            field_name: FieldNameType = field_def,
+        ) -> Callable[..., Optional[CollectionFilter[Any]]]:
+            def provide_in_filter(  # pyright: ignore
+                values: Annotated[  # type: ignore
+                    Optional[set[field_name.type_hint]],  # pyright: ignore
+                    Query(
+                        alias=camelize(f"{field_name.name}_in"),
+                        description=f"Filter {field_name.name} in values",
+                    ),
+                ] = None,
+            ) -> Optional[CollectionFilter[field_name.type_hint]]:  # type: ignore
+                return CollectionFilter(field_name=field_name.name, values=values) if values else None  # pyright: ignore
+
+            return provide_in_filter  # pyright: ignore
+
+        provider = create_in_filter_provider()
+        param_name = f"{field_def.name}_in_filter"
+        annotation: Any = Annotated[Optional[CollectionFilter[field_def.type_hint]], Depends(provider)]  # type: ignore
+        param = inspect.Parameter(
+            name=param_name,
+            kind=inspect.Parameter.KEYWORD_ONLY,
+            annotation=annotation,
+        )
+        results.append((param_name, param, annotation))
+
+    return results
+
+
+def _create_boolean_filter_providers_fastapi(
+    config: FilterConfig,
+) -> list[tuple[str, inspect.Parameter, Any]]:
+    results: list[tuple[str, inspect.Parameter, Any]] = []
+    boolean_fields = config.get("boolean_fields")
+    if not boolean_fields:
+        return results
+
+    for boolean_field_def in normalize_field_name_types(boolean_fields):
+
+        def create_boolean_filter_provider(
+            field_name: FieldNameType = boolean_field_def,
+        ) -> Callable[..., Optional[BooleanFilter]]:
+            def provide_boolean_filter(
+                value: Annotated[
+                    Optional[bool],
+                    Query(
+                        alias=camelize(field_name.name),
+                        description=f"Filter {field_name.name} by boolean value",
+                    ),
+                ] = None,
+            ) -> Optional[BooleanFilter]:
+                return BooleanFilter(field_name=field_name.name, value=value) if value is not None else None
+
+            return provide_boolean_filter
+
+        boolean_provider = create_boolean_filter_provider()
+        param_name = f"{boolean_field_def.name}_boolean_filter"
+        annotation: Any = Annotated[Optional[BooleanFilter], Depends(boolean_provider)]
+        param = inspect.Parameter(
+            name=param_name,
+            kind=inspect.Parameter.KEYWORD_ONLY,
+            annotation=annotation,
+        )
+        results.append((param_name, param, annotation))
+
+    return results
+
+
+def _create_choices_filter_providers_fastapi(
+    config: FilterConfig,
+) -> list[tuple[str, inspect.Parameter, Any]]:
+    results: list[tuple[str, inspect.Parameter, Any]] = []
+    choice_fields = config.get("choice_fields")
+    if not choice_fields:
+        return results
+
+    for choice_field_def in normalize_choice_field_types(choice_fields):
+
+        def create_choices_filter_provider(  # pyright: ignore
+            field_name: FieldNameType = choice_field_def,
+        ) -> Callable[..., Optional[ChoicesFilter[Any]]]:
+            def provide_choices_filter(  # pyright: ignore
+                values: Annotated[  # type: ignore
+                    Optional[list[field_name.type_hint]],  # pyright: ignore
+                    Query(
+                        alias=camelize(field_name.name),
+                        description=f"Filter {field_name.name} by allowed choices",
+                    ),
+                ] = None,
+            ) -> Optional[ChoicesFilter[field_name.type_hint]]:  # type: ignore
+                return ChoicesFilter(field_name=field_name.name, values=values) if values else None  # pyright: ignore
+
+            return provide_choices_filter  # pyright: ignore
+
+        choices_provider = create_choices_filter_provider()  # pyright: ignore
+        param_name = f"{choice_field_def.name}_choices_filter"
+        annotation: Any = Annotated[Optional[ChoicesFilter[Any]], Depends(choices_provider)]
+        param = inspect.Parameter(
+            name=param_name,
+            kind=inspect.Parameter.KEYWORD_ONLY,
+            annotation=annotation,
+        )
+        results.append((param_name, param, annotation))
+
+    return results
+
+
+def _create_filter_aggregate_function_fastapi(
     config: FilterConfig,
     dep_defaults: DependencyDefaults = DEPENDENCY_DEFAULTS,
 ) -> Callable[..., list[FilterTypes]]:
-    """Create a FastAPI dependency provider function that aggregates multiple filter dependencies.
-
-    Returns:
-        A FastAPI dependency provider function that aggregates multiple filter dependencies.
-    """
     params: list[inspect.Parameter] = []
     annotations: dict[str, Any] = {}
 
-    # Add id filter providers
-    if (id_filter := config.get("id_filter", False)) is not False:
+    for factory in (
+        _create_id_filter_provider_fastapi,
+        _create_created_at_filter_provider_fastapi,
+        _create_updated_at_filter_provider_fastapi,
+        _create_limit_offset_pagination_provider_fastapi,
+        _create_search_filter_provider_fastapi,
+        _create_order_by_filter_provider_fastapi,
+    ):
+        result = factory(config, dep_defaults)
+        if result is not None:
+            param_name, param, annotation = result
+            params.append(param)
+            annotations[param_name] = annotation
 
-        def provide_id_filter(  # pyright: ignore[reportUnknownParameterType]
-            ids: Annotated[  # type: ignore
-                Optional[list[id_filter]],  # pyright: ignore
-                Query(
-                    alias="ids",
-                    required=False,
-                    description="IDs to filter by.",
-                ),
-            ] = None,
-        ) -> Optional[CollectionFilter[id_filter]]:  # type: ignore
-            return CollectionFilter[id_filter](field_name=config.get("id_field", "id"), values=ids) if ids else None  # type: ignore
-
-        params.append(
-            inspect.Parameter(
-                name=dep_defaults.ID_FILTER_DEPENDENCY_KEY,
-                kind=inspect.Parameter.KEYWORD_ONLY,
-                annotation=Annotated[Optional[CollectionFilter[id_filter]], Depends(provide_id_filter)],  # type: ignore
-            )
-        )
-        annotations[dep_defaults.ID_FILTER_DEPENDENCY_KEY] = Annotated[
-            Optional[CollectionFilter[id_filter]], Depends(provide_id_filter)  # type: ignore
-        ]
-
-    # Add created_at filter providers
-    if config.get("created_at", False):
-
-        def provide_created_at_filter(
-            before: Annotated[
-                Optional[str],
-                Query(
-                    alias="createdBefore",
-                    description="Filter by created date before this timestamp.",
-                    json_schema_extra={"format": "date-time"},
-                ),
-            ] = None,
-            after: Annotated[
-                Optional[str],
-                Query(
-                    alias="createdAfter",
-                    description="Filter by created date after this timestamp.",
-                    json_schema_extra={"format": "date-time"},
-                ),
-            ] = None,
-        ) -> Optional[BeforeAfter]:
-            before_dt = None
-            after_dt = None
-
-            # Validate both parameters regardless of endpoint path
-            if before is not None:
-                try:
-                    before_dt = datetime.datetime.fromisoformat(before.replace("Z", "+00:00"))
-                except (ValueError, TypeError, AttributeError) as e:
-                    raise RequestValidationError(
-                        errors=[{"loc": ["query", "createdBefore"], "msg": "Invalid date format"}]
-                    ) from e
-
-            if after is not None:
-                try:
-                    after_dt = datetime.datetime.fromisoformat(after.replace("Z", "+00:00"))
-                except (ValueError, TypeError, AttributeError) as e:
-                    raise RequestValidationError(
-                        errors=[{"loc": ["query", "createdAfter"], "msg": "Invalid date format"}]
-                    ) from e
-
-            return (
-                BeforeAfter(field_name="created_at", before=before_dt, after=after_dt)
-                if before_dt or after_dt
-                else None  # pyright: ignore
-            )
-
-        param_name = dep_defaults.CREATED_FILTER_DEPENDENCY_KEY
-        params.append(
-            inspect.Parameter(
-                name=param_name,
-                kind=inspect.Parameter.KEYWORD_ONLY,
-                annotation=Annotated[Optional[BeforeAfter], Depends(provide_created_at_filter)],
-            )
-        )
-        annotations[param_name] = Annotated[Optional[BeforeAfter], Depends(provide_created_at_filter)]
-
-    # Add updated_at filter providers
-    if config.get("updated_at", False):
-
-        def provide_updated_at_filter(
-            before: Annotated[
-                Optional[str],
-                Query(
-                    alias="updatedBefore",
-                    description="Filter by updated date before this timestamp.",
-                    json_schema_extra={"format": "date-time"},
-                ),
-            ] = None,
-            after: Annotated[
-                Optional[str],
-                Query(
-                    alias="updatedAfter",
-                    description="Filter by updated date after this timestamp.",
-                    json_schema_extra={"format": "date-time"},
-                ),
-            ] = None,
-        ) -> Optional[BeforeAfter]:
-            before_dt = None
-            after_dt = None
-
-            # Validate both parameters regardless of endpoint path
-            if before is not None:
-                try:
-                    before_dt = datetime.datetime.fromisoformat(before.replace("Z", "+00:00"))
-                except (ValueError, TypeError, AttributeError) as e:
-                    raise RequestValidationError(
-                        errors=[{"loc": ["query", "updatedBefore"], "msg": "Invalid date format"}]
-                    ) from e
-
-            if after is not None:
-                try:
-                    after_dt = datetime.datetime.fromisoformat(after.replace("Z", "+00:00"))
-                except (ValueError, TypeError, AttributeError) as e:
-                    raise RequestValidationError(
-                        errors=[{"loc": ["query", "updatedAfter"], "msg": "Invalid date format"}]
-                    ) from e
-
-            return (
-                BeforeAfter(field_name="updated_at", before=before_dt, after=after_dt)
-                if before_dt or after_dt
-                else None  # pyright: ignore
-            )
-
-        param_name = dep_defaults.UPDATED_FILTER_DEPENDENCY_KEY
-        params.append(
-            inspect.Parameter(
-                name=param_name,
-                kind=inspect.Parameter.KEYWORD_ONLY,
-                annotation=Annotated[Optional[BeforeAfter], Depends(provide_updated_at_filter)],
-            )
-        )
-        annotations[param_name] = Annotated[Optional[BeforeAfter], Depends(provide_updated_at_filter)]
-
-    # Add pagination filter providers
-    if config.get("pagination_type") == "limit_offset":
-
-        def provide_limit_offset_pagination(
-            current_page: Annotated[
-                int,
-                Query(
-                    ge=1,
-                    alias="currentPage",
-                    description="Page number for pagination.",
-                ),
-            ] = 1,
-            page_size: Annotated[
-                int,
-                Query(
-                    ge=1,
-                    alias="pageSize",
-                    description="Number of items per page.",
-                ),
-            ] = config.get("pagination_size", dep_defaults.DEFAULT_PAGINATION_SIZE),
-        ) -> LimitOffset:
-            return LimitOffset(limit=page_size, offset=page_size * (current_page - 1))
-
-        param_name = dep_defaults.LIMIT_OFFSET_FILTER_DEPENDENCY_KEY
-        params.append(
-            inspect.Parameter(
-                name=param_name,
-                kind=inspect.Parameter.KEYWORD_ONLY,
-                annotation=Annotated[LimitOffset, Depends(provide_limit_offset_pagination)],
-            )
-        )
-        annotations[param_name] = Annotated[LimitOffset, Depends(provide_limit_offset_pagination)]
-
-    # Add search filter providers
-    if search_fields := config.get("search"):
-
-        def provide_search_filter(
-            search_string: Annotated[
-                Optional[str],
-                Query(
-                    required=False,
-                    alias="searchString",
-                    description="Search term.",
-                ),
-            ] = None,
-            ignore_case: Annotated[
-                Optional[bool],
-                Query(
-                    required=False,
-                    alias="searchIgnoreCase",
-                    description="Whether search should be case-insensitive.",
-                ),
-            ] = config.get("search_ignore_case", False),
-        ) -> SearchFilter:
-            field_names = set(search_fields.split(",")) if isinstance(search_fields, str) else set(search_fields)
-
-            return SearchFilter(
-                field_name=field_names,
-                value=search_string,  # type: ignore[arg-type]
-                ignore_case=ignore_case or False,
-            )
-
-        param_name = dep_defaults.SEARCH_FILTER_DEPENDENCY_KEY
-        params.append(
-            inspect.Parameter(
-                name=param_name,
-                kind=inspect.Parameter.KEYWORD_ONLY,
-                annotation=Annotated[Optional[SearchFilter], Depends(provide_search_filter)],
-            )
-        )
-        annotations[param_name] = Annotated[Optional[SearchFilter], Depends(provide_search_filter)]
-
-    # Add sort filter providers
-    if sort_field := config.get("sort_field"):
-        sort_field_default = normalize_sort_field(sort_field)
-        sort_order_default = config.get("sort_order", "desc")
-
-        def provide_order_by(
-            field_name: Annotated[
-                str,
-                Query(
-                    alias="orderBy",
-                    description="Field to order by.",
-                    required=False,
-                ),
-            ] = sort_field_default,
-            sort_order: Annotated[
-                Optional[SortOrder],
-                Query(
-                    alias="sortOrder",
-                    description="Sort order ('asc' or 'desc').",
-                    required=False,
-                ),
-            ] = sort_order_default,
-        ) -> OrderBy:
-            return OrderBy(field_name=field_name, sort_order=sort_order or sort_order_default)
-
-        param_name = dep_defaults.ORDER_BY_FILTER_DEPENDENCY_KEY
-        params.append(
-            inspect.Parameter(
-                name=param_name,
-                kind=inspect.Parameter.KEYWORD_ONLY,
-                annotation=Annotated[OrderBy, Depends(provide_order_by)],
-            )
-        )
-        annotations[param_name] = Annotated[OrderBy, Depends(provide_order_by)]
-
-    # Add not_in filter providers
-    if not_in_fields := config.get("not_in_fields"):
-        for field_def in normalize_field_name_types(not_in_fields):
-            # Capture field_def by value to avoid Python closure late binding gotcha
-            # Without default parameter, all closures would reference the loop variable's final value
-            def create_not_in_filter_provider(  # pyright: ignore
-                field_name: FieldNameType = field_def,
-            ) -> Callable[..., Optional[NotInCollectionFilter[Any]]]:
-                def provide_not_in_filter(  # pyright: ignore
-                    values: Annotated[  # type: ignore
-                        Optional[set[field_name.type_hint]],  # pyright: ignore
-                        Query(
-                            alias=camelize(f"{field_name.name}_not_in"),
-                            description=f"Filter {field_name.name} not in values",
-                        ),
-                    ] = None,
-                ) -> Optional[NotInCollectionFilter[field_name.type_hint]]:  # type: ignore
-                    return NotInCollectionFilter(field_name=field_name.name, values=values) if values else None  # pyright: ignore
-
-                return provide_not_in_filter  # pyright: ignore
-
-            provider = create_not_in_filter_provider()  # pyright: ignore
-            param_name = f"{field_def.name}_not_in_filter"
-            params.append(
-                inspect.Parameter(
-                    name=param_name,
-                    kind=inspect.Parameter.KEYWORD_ONLY,
-                    annotation=Annotated[Optional[NotInCollectionFilter[field_def.type_hint]], Depends(provider)],  # type: ignore
-                )
-            )
-            annotations[param_name] = Annotated[Optional[NotInCollectionFilter[field_def.type_hint]], Depends(provider)]  # type: ignore
-
-    # Add in filter providers
-    if in_fields := config.get("in_fields"):
-        for field_def in normalize_field_name_types(in_fields):
-            # Capture field_def by value to avoid Python closure late binding gotcha
-            # Without default parameter, all closures would reference the loop variable's final value
-            def create_in_filter_provider(  # pyright: ignore
-                field_name: FieldNameType = field_def,
-            ) -> Callable[..., Optional[CollectionFilter[Any]]]:
-                def provide_in_filter(  # pyright: ignore
-                    values: Annotated[  # type: ignore
-                        Optional[set[field_name.type_hint]],  # pyright: ignore
-                        Query(
-                            alias=camelize(f"{field_name.name}_in"),
-                            description=f"Filter {field_name.name} in values",
-                        ),
-                    ] = None,
-                ) -> Optional[CollectionFilter[field_name.type_hint]]:  # type: ignore
-                    return CollectionFilter(field_name=field_name.name, values=values) if values else None  # pyright: ignore
-
-                return provide_in_filter  # pyright: ignore
-
-            provider = create_in_filter_provider()  # type: ignore
-            param_name = f"{field_def.name}_in_filter"
-            params.append(
-                inspect.Parameter(
-                    name=param_name,
-                    kind=inspect.Parameter.KEYWORD_ONLY,
-                    annotation=Annotated[Optional[CollectionFilter[field_def.type_hint]], Depends(provider)],  # type: ignore
-                )
-            )
-            annotations[param_name] = Annotated[Optional[CollectionFilter[field_def.type_hint]], Depends(provider)]  # type: ignore
-
-    if boolean_fields := config.get("boolean_fields"):
-        for boolean_field_def in normalize_field_name_types(boolean_fields):
-
-            def create_boolean_filter_provider(
-                field_name: FieldNameType = boolean_field_def,
-            ) -> Callable[..., Optional[BooleanFilter]]:
-                def provide_boolean_filter(
-                    value: Annotated[
-                        Optional[bool],
-                        Query(
-                            alias=camelize(field_name.name),
-                            description=f"Filter {field_name.name} by boolean value",
-                        ),
-                    ] = None,
-                ) -> Optional[BooleanFilter]:
-                    return BooleanFilter(field_name=field_name.name, value=value) if value is not None else None
-
-                return provide_boolean_filter
-
-            boolean_provider = create_boolean_filter_provider()
-            param_name = f"{boolean_field_def.name}_boolean_filter"
-            params.append(
-                inspect.Parameter(
-                    name=param_name,
-                    kind=inspect.Parameter.KEYWORD_ONLY,
-                    annotation=Annotated[Optional[BooleanFilter], Depends(boolean_provider)],
-                )
-            )
-            annotations[param_name] = Annotated[Optional[BooleanFilter], Depends(boolean_provider)]
-
-    if choice_fields := config.get("choice_fields"):
-        for choice_field_def in normalize_choice_field_types(choice_fields):
-
-            def create_choices_filter_provider(  # pyright: ignore
-                field_name: FieldNameType = choice_field_def,
-            ) -> Callable[..., Optional[ChoicesFilter[Any]]]:
-                def provide_choices_filter(  # pyright: ignore
-                    values: Annotated[  # type: ignore
-                        Optional[list[field_name.type_hint]],  # pyright: ignore
-                        Query(
-                            alias=camelize(field_name.name),
-                            description=f"Filter {field_name.name} by allowed choices",
-                        ),
-                    ] = None,
-                ) -> Optional[ChoicesFilter[field_name.type_hint]]:  # type: ignore
-                    return ChoicesFilter(field_name=field_name.name, values=values) if values else None  # pyright: ignore
-
-                return provide_choices_filter  # pyright: ignore
-
-            choices_provider = create_choices_filter_provider()  # pyright: ignore
-            param_name = f"{choice_field_def.name}_choices_filter"
-            params.append(
-                inspect.Parameter(
-                    name=param_name,
-                    kind=inspect.Parameter.KEYWORD_ONLY,
-                    annotation=Annotated[Optional[ChoicesFilter[Any]], Depends(choices_provider)],
-                )
-            )
-            annotations[param_name] = Annotated[Optional[ChoicesFilter[Any]], Depends(choices_provider)]
+    for providers_factory in (
+        _create_not_in_filter_providers_fastapi,
+        _create_in_filter_providers_fastapi,
+        _create_boolean_filter_providers_fastapi,
+        _create_choices_filter_providers_fastapi,
+    ):
+        for param_name, param, annotation in providers_factory(config):
+            params.append(param)
+            annotations[param_name] = annotation
 
     _aggregate_filter_function.__signature__ = inspect.Signature(  # type: ignore
         parameters=params,

--- a/advanced_alchemy/extensions/litestar/providers.py
+++ b/advanced_alchemy/extensions/litestar/providers.py
@@ -355,7 +355,213 @@ def _create_order_by_filter_provider(
     return provide_order_by
 
 
-def _create_statement_filters(  # noqa: C901, PLR0915
+def _create_not_in_filter_providers(
+    config: FilterConfig,
+) -> dict[str, Provide]:
+    """Create not-in filter providers based on configuration."""
+    filters: dict[str, Provide] = {}
+    if not_in_fields := config.get("not_in_fields"):
+        # Get all field names, handling both strings and FieldNameType objects
+        not_in_fields = {not_in_fields} if isinstance(not_in_fields, (str, FieldNameType)) else not_in_fields
+
+        for field_def in not_in_fields:
+            field_def = FieldNameType(name=field_def, type_hint=str) if isinstance(field_def, str) else field_def
+
+            # Capture field_def by value to avoid Python closure late binding gotcha
+            # Without default parameter, all closures would reference the loop variable's final value
+            def create_not_in_filter_provider(  # pyright: ignore
+                field_name: FieldNameType = field_def,  # type: ignore[assignment]
+            ) -> Callable[..., Optional[NotInCollectionFilter[Any]]]:
+                param_name = f"{field_name.name}_not_in"
+
+                def provide_not_in_filter(  # pyright: ignore
+                    **kwargs: Any,
+                ) -> Optional[NotInCollectionFilter[field_name.type_hint]]:  # type: ignore
+                    values = kwargs.get(param_name)
+                    return (
+                        NotInCollectionFilter[field_name.type_hint](field_name=field_name.name, values=values)  # type: ignore
+                        if values
+                        else None
+                    )
+
+                annotation = Annotated[
+                    Optional[list[field_name.type_hint]],  # type: ignore
+                    QueryParameter(name=camelize(param_name)),
+                ]
+                provide_not_in_filter.__name__ = f"provide_not_in_filter_{field_name.name}"
+                provide_not_in_filter.__signature__ = inspect.Signature(  # type: ignore[attr-defined]
+                    parameters=[
+                        inspect.Parameter(
+                            name=param_name,
+                            kind=inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                            default=None,
+                            annotation=annotation,
+                        )
+                    ],
+                    return_annotation=Optional[NotInCollectionFilter[field_name.type_hint]],  # type: ignore
+                )
+                provide_not_in_filter.__annotations__ = {
+                    param_name: annotation,
+                    "return": Optional[NotInCollectionFilter[field_name.type_hint]],  # type: ignore
+                }
+                return provide_not_in_filter  # pyright: ignore
+
+            provider = create_not_in_filter_provider(field_def)  # pyright: ignore
+            filters[f"{field_def.name}_not_in_filter"] = Provide(provider, sync_to_thread=False)  # pyright: ignore
+    return filters
+
+
+def _create_in_filter_providers(
+    config: FilterConfig,
+) -> dict[str, Provide]:
+    """Create in-filter providers based on configuration."""
+    filters: dict[str, Provide] = {}
+    if in_fields := config.get("in_fields"):
+        # Get all field names, handling both strings and FieldNameType objects
+        in_fields = {in_fields} if isinstance(in_fields, (str, FieldNameType)) else in_fields
+
+        for field_def in in_fields:
+            field_def = FieldNameType(name=field_def, type_hint=str) if isinstance(field_def, str) else field_def
+
+            # Capture field_def by value to avoid Python closure late binding gotcha
+            # Without default parameter, all closures would reference the loop variable's final value
+            def create_in_filter_provider(  # pyright: ignore
+                field_name: FieldNameType = field_def,  # type: ignore[assignment]
+            ) -> Callable[..., Optional[CollectionFilter[Any]]]:
+                param_name = f"{field_name.name}_in"
+
+                def provide_in_filter(  # pyright: ignore
+                    **kwargs: Any,
+                ) -> Optional[CollectionFilter[field_name.type_hint]]:  # type: ignore # pyright: ignore
+                    values = kwargs.get(param_name)
+                    return (
+                        CollectionFilter[field_name.type_hint](field_name=field_name.name, values=values)  # type: ignore  # pyright: ignore
+                        if values
+                        else None
+                    )
+
+                provide_in_filter.__name__ = f"provide_in_filter_{field_name.name}"
+                annotation = Annotated[
+                    Optional[list[field_name.type_hint]],  # type: ignore
+                    QueryParameter(
+                        name=camelize(param_name),
+                    ),
+                ]
+                provide_in_filter.__signature__ = inspect.Signature(  # type: ignore[attr-defined]
+                    parameters=[
+                        inspect.Parameter(
+                            name=param_name,
+                            kind=inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                            default=None,
+                            annotation=annotation,
+                        )
+                    ],
+                    return_annotation=Optional[CollectionFilter[field_name.type_hint]],  # type: ignore
+                )
+                provide_in_filter.__annotations__ = {
+                    param_name: annotation,
+                    "return": Optional[CollectionFilter[field_name.type_hint]],  # type: ignore
+                }
+                return provide_in_filter  # pyright: ignore
+
+            provider = create_in_filter_provider(field_def)
+            filters[f"{field_def.name}_in_filter"] = Provide(provider, sync_to_thread=False)  # pyright: ignore
+    return filters
+
+
+def _create_boolean_filter_providers(
+    config: FilterConfig,
+) -> dict[str, Provide]:
+    """Create boolean filter providers based on configuration."""
+    filters: dict[str, Provide] = {}
+    if boolean_fields := config.get("boolean_fields"):
+        for boolean_field_def in normalize_field_name_types(boolean_fields):
+
+            def create_boolean_filter_provider(
+                field_name: FieldNameType = boolean_field_def,
+            ) -> Callable[..., Optional[BooleanFilter]]:
+                param_name = f"{field_name.name}_boolean"
+
+                def provide_boolean_filter(**kwargs: Any) -> Optional[BooleanFilter]:
+                    value = kwargs.get(param_name)
+                    return BooleanFilter(field_name=field_name.name, value=value) if value is not None else None
+
+                annotation = Annotated[
+                    BooleanOrNone,
+                    QueryParameter(name=camelize(field_name.name)),
+                ]
+                provide_boolean_filter.__name__ = f"provide_boolean_filter_{field_name.name}"
+                provide_boolean_filter.__signature__ = inspect.Signature(  # type: ignore[attr-defined]
+                    parameters=[
+                        inspect.Parameter(
+                            name=param_name,
+                            kind=inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                            default=None,
+                            annotation=annotation,
+                        )
+                    ],
+                    return_annotation=Optional[BooleanFilter],
+                )
+                provide_boolean_filter.__annotations__ = {
+                    param_name: annotation,
+                    "return": Optional[BooleanFilter],
+                }
+                return provide_boolean_filter
+
+            boolean_provider = create_boolean_filter_provider(boolean_field_def)
+            filters[f"{boolean_field_def.name}_boolean_filter"] = Provide(boolean_provider, sync_to_thread=False)
+    return filters
+
+
+def _create_choices_filter_providers(
+    config: FilterConfig,
+) -> dict[str, Provide]:
+    """Create choices filter providers based on configuration."""
+    filters: dict[str, Provide] = {}
+    if choice_fields := config.get("choice_fields"):
+        for choice_field_def in normalize_choice_field_types(choice_fields):
+
+            def create_choices_filter_provider(
+                field_name: FieldNameType = choice_field_def,
+            ) -> Callable[..., Optional[ChoicesFilter[Any]]]:
+                param_name = f"{field_name.name}_choices"
+
+                def provide_choices_filter(**kwargs: Any) -> Optional[ChoicesFilter[Any]]:
+                    values = kwargs.get(param_name)
+                    return (
+                        ChoicesFilter[field_name.type_hint](field_name=field_name.name, values=values)  # type: ignore
+                        if values
+                        else None
+                    )
+
+                annotation = Annotated[
+                    Optional[list[field_name.type_hint]],  # type: ignore
+                    QueryParameter(name=camelize(field_name.name)),
+                ]
+                provide_choices_filter.__name__ = f"provide_choices_filter_{field_name.name}"
+                provide_choices_filter.__signature__ = inspect.Signature(  # type: ignore[attr-defined]
+                    parameters=[
+                        inspect.Parameter(
+                            name=param_name,
+                            kind=inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                            default=None,
+                            annotation=annotation,
+                        )
+                    ],
+                    return_annotation=Optional[ChoicesFilter[Any]],
+                )
+                provide_choices_filter.__annotations__ = {
+                    param_name: annotation,
+                    "return": Optional[ChoicesFilter[Any]],
+                }
+                return provide_choices_filter
+
+            choices_provider = create_choices_filter_provider(choice_field_def)
+            filters[f"{choice_field_def.name}_choices_filter"] = Provide(choices_provider, sync_to_thread=False)
+    return filters
+
+
+def _create_statement_filters(
     config: FilterConfig, dep_defaults: DependencyDefaults = DEPENDENCY_DEFAULTS
 ) -> dict[str, Provide]:
     """Create filter dependencies based on configuration.
@@ -451,185 +657,10 @@ def _create_statement_filters(  # noqa: C901, PLR0915
             sync_to_thread=False,
         )
 
-    # Add not_in filter providers
-    if not_in_fields := config.get("not_in_fields"):
-        # Get all field names, handling both strings and FieldNameType objects
-        not_in_fields = {not_in_fields} if isinstance(not_in_fields, (str, FieldNameType)) else not_in_fields
-
-        for field_def in not_in_fields:
-            field_def = FieldNameType(name=field_def, type_hint=str) if isinstance(field_def, str) else field_def
-
-            # Capture field_def by value to avoid Python closure late binding gotcha
-            # Without default parameter, all closures would reference the loop variable's final value
-            def create_not_in_filter_provider(  # pyright: ignore
-                field_name: FieldNameType = field_def,  # type: ignore[assignment]
-            ) -> Callable[..., Optional[NotInCollectionFilter[Any]]]:
-                param_name = f"{field_name.name}_not_in"
-
-                def provide_not_in_filter(  # pyright: ignore
-                    **kwargs: Any,
-                ) -> Optional[NotInCollectionFilter[field_name.type_hint]]:  # type: ignore
-                    values = kwargs.get(param_name)
-                    return (
-                        NotInCollectionFilter[field_name.type_hint](field_name=field_name.name, values=values)  # type: ignore
-                        if values
-                        else None
-                    )
-
-                annotation = Annotated[
-                    Optional[list[field_name.type_hint]],  # type: ignore
-                    QueryParameter(name=camelize(param_name)),
-                ]
-                provide_not_in_filter.__name__ = f"provide_not_in_filter_{field_name.name}"
-                provide_not_in_filter.__signature__ = inspect.Signature(  # type: ignore[attr-defined]
-                    parameters=[
-                        inspect.Parameter(
-                            name=param_name,
-                            kind=inspect.Parameter.POSITIONAL_OR_KEYWORD,
-                            default=None,
-                            annotation=annotation,
-                        )
-                    ],
-                    return_annotation=Optional[NotInCollectionFilter[field_name.type_hint]],  # type: ignore
-                )
-                provide_not_in_filter.__annotations__ = {
-                    param_name: annotation,
-                    "return": Optional[NotInCollectionFilter[field_name.type_hint]],  # type: ignore
-                }
-                return provide_not_in_filter  # pyright: ignore
-
-            provider = create_not_in_filter_provider(field_def)  # pyright: ignore
-            filters[f"{field_def.name}_not_in_filter"] = Provide(provider, sync_to_thread=False)  # pyright: ignore
-
-    # Add in filter providers
-    if in_fields := config.get("in_fields"):
-        # Get all field names, handling both strings and FieldNameType objects
-        in_fields = {in_fields} if isinstance(in_fields, (str, FieldNameType)) else in_fields
-
-        for field_def in in_fields:
-            field_def = FieldNameType(name=field_def, type_hint=str) if isinstance(field_def, str) else field_def
-
-            # Capture field_def by value to avoid Python closure late binding gotcha
-            # Without default parameter, all closures would reference the loop variable's final value
-            def create_in_filter_provider(  # pyright: ignore
-                field_name: FieldNameType = field_def,  # type: ignore[assignment]
-            ) -> Callable[..., Optional[CollectionFilter[Any]]]:
-                param_name = f"{field_name.name}_in"
-
-                def provide_in_filter(  # pyright: ignore
-                    **kwargs: Any,
-                ) -> Optional[CollectionFilter[field_name.type_hint]]:  # type: ignore # pyright: ignore
-                    values = kwargs.get(param_name)
-                    return (
-                        CollectionFilter[field_name.type_hint](field_name=field_name.name, values=values)  # type: ignore  # pyright: ignore
-                        if values
-                        else None
-                    )
-
-                provide_in_filter.__name__ = f"provide_in_filter_{field_name.name}"
-                annotation = Annotated[
-                    Optional[list[field_name.type_hint]],  # type: ignore
-                    QueryParameter(
-                        name=camelize(param_name),
-                    ),
-                ]
-                provide_in_filter.__signature__ = inspect.Signature(  # type: ignore[attr-defined]
-                    parameters=[
-                        inspect.Parameter(
-                            name=param_name,
-                            kind=inspect.Parameter.POSITIONAL_OR_KEYWORD,
-                            default=None,
-                            annotation=annotation,
-                        )
-                    ],
-                    return_annotation=Optional[CollectionFilter[field_name.type_hint]],  # type: ignore
-                )
-                provide_in_filter.__annotations__ = {
-                    param_name: annotation,
-                    "return": Optional[CollectionFilter[field_name.type_hint]],  # type: ignore
-                }
-                return provide_in_filter  # pyright: ignore
-
-            provider = create_in_filter_provider(field_def)  # type: ignore
-            filters[f"{field_def.name}_in_filter"] = Provide(provider, sync_to_thread=False)  # pyright: ignore
-
-    if boolean_fields := config.get("boolean_fields"):
-        for boolean_field_def in normalize_field_name_types(boolean_fields):
-
-            def create_boolean_filter_provider(
-                field_name: FieldNameType = boolean_field_def,
-            ) -> Callable[..., Optional[BooleanFilter]]:
-                param_name = f"{field_name.name}_boolean"
-
-                def provide_boolean_filter(**kwargs: Any) -> Optional[BooleanFilter]:
-                    value = kwargs.get(param_name)
-                    return BooleanFilter(field_name=field_name.name, value=value) if value is not None else None
-
-                annotation = Annotated[
-                    BooleanOrNone,
-                    QueryParameter(name=camelize(field_name.name)),
-                ]
-                provide_boolean_filter.__name__ = f"provide_boolean_filter_{field_name.name}"
-                provide_boolean_filter.__signature__ = inspect.Signature(  # type: ignore[attr-defined]
-                    parameters=[
-                        inspect.Parameter(
-                            name=param_name,
-                            kind=inspect.Parameter.POSITIONAL_OR_KEYWORD,
-                            default=None,
-                            annotation=annotation,
-                        )
-                    ],
-                    return_annotation=Optional[BooleanFilter],
-                )
-                provide_boolean_filter.__annotations__ = {
-                    param_name: annotation,
-                    "return": Optional[BooleanFilter],
-                }
-                return provide_boolean_filter
-
-            boolean_provider = create_boolean_filter_provider(boolean_field_def)
-            filters[f"{boolean_field_def.name}_boolean_filter"] = Provide(boolean_provider, sync_to_thread=False)
-
-    if choice_fields := config.get("choice_fields"):
-        for choice_field_def in normalize_choice_field_types(choice_fields):
-
-            def create_choices_filter_provider(
-                field_name: FieldNameType = choice_field_def,
-            ) -> Callable[..., Optional[ChoicesFilter[Any]]]:
-                param_name = f"{field_name.name}_choices"
-
-                def provide_choices_filter(**kwargs: Any) -> Optional[ChoicesFilter[Any]]:
-                    values = kwargs.get(param_name)
-                    return (
-                        ChoicesFilter[field_name.type_hint](field_name=field_name.name, values=values)  # type: ignore
-                        if values
-                        else None
-                    )
-
-                annotation = Annotated[
-                    Optional[list[field_name.type_hint]],  # type: ignore
-                    QueryParameter(name=camelize(field_name.name)),
-                ]
-                provide_choices_filter.__name__ = f"provide_choices_filter_{field_name.name}"
-                provide_choices_filter.__signature__ = inspect.Signature(  # type: ignore[attr-defined]
-                    parameters=[
-                        inspect.Parameter(
-                            name=param_name,
-                            kind=inspect.Parameter.POSITIONAL_OR_KEYWORD,
-                            default=None,
-                            annotation=annotation,
-                        )
-                    ],
-                    return_annotation=Optional[ChoicesFilter[Any]],
-                )
-                provide_choices_filter.__annotations__ = {
-                    param_name: annotation,
-                    "return": Optional[ChoicesFilter[Any]],
-                }
-                return provide_choices_filter
-
-            choices_provider = create_choices_filter_provider(choice_field_def)
-            filters[f"{choice_field_def.name}_choices_filter"] = Provide(choices_provider, sync_to_thread=False)
+    filters.update(_create_not_in_filter_providers(config))
+    filters.update(_create_in_filter_providers(config))
+    filters.update(_create_boolean_filter_providers(config))
+    filters.update(_create_choices_filter_providers(config))
 
     if filters:
         filters[dep_defaults.FILTERS_DEPENDENCY_KEY] = Provide(
@@ -639,7 +670,149 @@ def _create_statement_filters(  # noqa: C901, PLR0915
     return filters
 
 
-def _create_filter_aggregate_function(config: FilterConfig) -> Callable[..., list[FilterTypes]]:  # noqa: C901, PLR0915
+def _build_parameter(
+    parameters: dict[str, inspect.Parameter],
+    annotations: dict[str, Any],
+    name: str,
+    annotation_type: Any,
+    *,
+    use_named_dependency: bool = True,
+) -> None:
+    annotation: Any = (
+        NamedDependency[SkipValidation[annotation_type]]  # type: ignore[misc]
+        if use_named_dependency
+        else annotation_type
+    )
+    parameters[name] = inspect.Parameter(
+        name=name,
+        kind=inspect.Parameter.POSITIONAL_OR_KEYWORD,
+        annotation=annotation,
+    )
+    annotations[name] = annotation_type
+
+
+def _collect_builtin_filters(kwargs: dict[str, FilterTypes]) -> list[FilterTypes]:
+    filters: list[FilterTypes] = []
+    if id_filter := kwargs.get("id_filter"):
+        filters.append(id_filter)
+    if created_filter := kwargs.get("created_filter"):
+        filters.append(created_filter)
+    if limit_offset := kwargs.get("limit_offset_filter"):
+        filters.append(limit_offset)
+    if updated_filter := kwargs.get("updated_filter"):
+        filters.append(updated_filter)
+    if (
+        (search_filter := cast("Optional[SearchFilter]", kwargs.get("search_filter")))
+        and search_filter is not None  # pyright: ignore[reportUnnecessaryComparison]
+        and search_filter.field_name is not None  # pyright: ignore[reportUnnecessaryComparison]
+        and search_filter.value is not None  # pyright: ignore[reportUnnecessaryComparison]
+    ):
+        filters.append(search_filter)
+    if (
+        (order_by := cast("Optional[OrderBy]", kwargs.get("order_by_filter")))
+        and order_by is not None  # pyright: ignore[reportUnnecessaryComparison]
+        and order_by.field_name is not None  # pyright: ignore[reportUnnecessaryComparison]
+    ):
+        filters.append(order_by)
+    return filters
+
+
+def _collect_field_filters(config: FilterConfig, kwargs: dict[str, FilterTypes]) -> list[FilterTypes]:
+    filters: list[FilterTypes] = []
+    if not_in_fields := config.get("not_in_fields"):
+        filters.extend(
+            filter_
+            for field_def in normalize_field_name_types(not_in_fields)
+            if (filter_ := kwargs.get(f"{field_def.name}_not_in_filter")) is not None
+        )
+    if in_fields := config.get("in_fields"):
+        filters.extend(
+            filter_
+            for field_def in normalize_field_name_types(in_fields)
+            if (filter_ := kwargs.get(f"{field_def.name}_in_filter")) is not None
+        )
+    if boolean_fields := config.get("boolean_fields"):
+        filters.extend(
+            filter_
+            for field_def in normalize_field_name_types(boolean_fields)
+            if (filter_ := kwargs.get(f"{field_def.name}_boolean_filter")) is not None
+        )
+    if choice_fields := config.get("choice_fields"):
+        filters.extend(
+            filter_
+            for field_def in normalize_choice_field_types(choice_fields)
+            if (filter_ := kwargs.get(f"{field_def.name}_choices_filter")) is not None
+        )
+    return filters
+
+
+def _collect_filters(config: FilterConfig, **kwargs: FilterTypes) -> list[FilterTypes]:
+    return _collect_builtin_filters(kwargs) + _collect_field_filters(config, kwargs)
+
+
+def _build_builtin_parameters(
+    config: FilterConfig,
+    parameters: dict[str, inspect.Parameter],
+    annotations: dict[str, Any],
+) -> None:
+    if cls := config.get("id_filter"):
+        _build_parameter(parameters, annotations, "id_filter", CollectionFilter[cls])  # type: ignore[valid-type]
+
+    if config.get("created_at"):
+        _build_parameter(parameters, annotations, "created_filter", BeforeAfter)
+
+    if config.get("updated_at"):
+        _build_parameter(parameters, annotations, "updated_filter", BeforeAfter)
+
+    if config.get("search"):
+        _build_parameter(parameters, annotations, "search_filter", SearchFilter)
+
+    if config.get("pagination_type") == "limit_offset":
+        _build_parameter(parameters, annotations, "limit_offset_filter", LimitOffset)
+
+    if config.get("sort_field"):
+        _build_parameter(parameters, annotations, "order_by_filter", OrderBy)
+
+
+def _build_field_parameters(
+    config: FilterConfig,
+    parameters: dict[str, inspect.Parameter],
+    annotations: dict[str, Any],
+) -> None:
+    if not_in_fields := config.get("not_in_fields"):
+        for field_def in normalize_field_name_types(not_in_fields):
+            _build_parameter(
+                parameters,
+                annotations,
+                f"{field_def.name}_not_in_filter",
+                NotInCollectionFilter[field_def.type_hint],  # type: ignore[name-defined]
+            )
+
+    if in_fields := config.get("in_fields"):
+        for field_def in normalize_field_name_types(in_fields):
+            _build_parameter(
+                parameters,
+                annotations,
+                f"{field_def.name}_in_filter",
+                CollectionFilter[field_def.type_hint],  # type: ignore[name-defined]
+                use_named_dependency=False,
+            )
+
+    if boolean_fields := config.get("boolean_fields"):
+        for boolean_field_def in normalize_field_name_types(boolean_fields):
+            _build_parameter(parameters, annotations, f"{boolean_field_def.name}_boolean_filter", BooleanFilter)
+
+    if choice_fields := config.get("choice_fields"):
+        for choice_field_def in normalize_choice_field_types(choice_fields):
+            _build_parameter(
+                parameters,
+                annotations,
+                f"{choice_field_def.name}_choices_filter",
+                ChoicesFilter[choice_field_def.type_hint],  # type: ignore[name-defined]
+            )
+
+
+def _create_filter_aggregate_function(config: FilterConfig) -> Callable[..., list[FilterTypes]]:
     """Create a filter function based on the provided configuration.
 
     Args:
@@ -652,152 +825,11 @@ def _create_filter_aggregate_function(config: FilterConfig) -> Callable[..., lis
     parameters: dict[str, inspect.Parameter] = {}
     annotations: dict[str, Any] = {}
 
-    # Build parameters based on config
-    if cls := config.get("id_filter"):
-        parameters["id_filter"] = inspect.Parameter(
-            name="id_filter",
-            kind=inspect.Parameter.POSITIONAL_OR_KEYWORD,
-            annotation=NamedDependency[SkipValidation[CollectionFilter[cls]]],  # type: ignore[valid-type]
-        )
-        annotations["id_filter"] = CollectionFilter[cls]  # type: ignore[valid-type]
+    _build_builtin_parameters(config, parameters, annotations)
+    _build_field_parameters(config, parameters, annotations)
 
-    if config.get("created_at"):
-        parameters["created_filter"] = inspect.Parameter(
-            name="created_filter",
-            kind=inspect.Parameter.POSITIONAL_OR_KEYWORD,
-            annotation=NamedDependency[SkipValidation[BeforeAfter]],
-        )
-        annotations["created_filter"] = BeforeAfter
-
-    if config.get("updated_at"):
-        parameters["updated_filter"] = inspect.Parameter(
-            name="updated_filter",
-            kind=inspect.Parameter.POSITIONAL_OR_KEYWORD,
-            annotation=NamedDependency[SkipValidation[BeforeAfter]],
-        )
-        annotations["updated_filter"] = BeforeAfter
-
-    if config.get("search"):
-        parameters["search_filter"] = inspect.Parameter(
-            name="search_filter",
-            kind=inspect.Parameter.POSITIONAL_OR_KEYWORD,
-            annotation=NamedDependency[SkipValidation[SearchFilter]],
-        )
-        annotations["search_filter"] = SearchFilter
-
-    if config.get("pagination_type") == "limit_offset":
-        parameters["limit_offset_filter"] = inspect.Parameter(
-            name="limit_offset_filter",
-            kind=inspect.Parameter.POSITIONAL_OR_KEYWORD,
-            annotation=NamedDependency[SkipValidation[LimitOffset]],
-        )
-        annotations["limit_offset_filter"] = LimitOffset
-
-    if config.get("sort_field"):
-        parameters["order_by_filter"] = inspect.Parameter(
-            name="order_by_filter",
-            kind=inspect.Parameter.POSITIONAL_OR_KEYWORD,
-            annotation=NamedDependency[SkipValidation[OrderBy,]],
-        )
-        annotations["order_by_filter"] = OrderBy
-
-    # Add parameters for not_in filters
-    if not_in_fields := config.get("not_in_fields"):
-        for field_def in normalize_field_name_types(not_in_fields):
-            annotation = NamedDependency[SkipValidation[NotInCollectionFilter[field_def.type_hint]]]  # type: ignore[name-defined]
-            parameters[f"{field_def.name}_not_in_filter"] = inspect.Parameter(
-                name=f"{field_def.name}_not_in_filter",
-                kind=inspect.Parameter.POSITIONAL_OR_KEYWORD,
-                annotation=annotation,
-            )
-            annotations[f"{field_def.name}_not_in_filter"] = annotation
-
-    # Add parameters for in filters
-    if in_fields := config.get("in_fields"):
-        for field_def in normalize_field_name_types(in_fields):
-            annotation = CollectionFilter[field_def.type_hint]  # type: ignore
-
-            parameters[f"{field_def.name}_in_filter"] = inspect.Parameter(
-                name=f"{field_def.name}_in_filter", kind=inspect.Parameter.POSITIONAL_OR_KEYWORD, annotation=annotation
-            )
-            annotations[f"{field_def.name}_in_filter"] = annotation
-
-    if boolean_fields := config.get("boolean_fields"):
-        for boolean_field_def in normalize_field_name_types(boolean_fields):
-            boolean_annotation = NamedDependency[SkipValidation[BooleanFilter]]
-            parameters[f"{boolean_field_def.name}_boolean_filter"] = inspect.Parameter(
-                name=f"{boolean_field_def.name}_boolean_filter",
-                kind=inspect.Parameter.POSITIONAL_OR_KEYWORD,
-                annotation=boolean_annotation,
-            )
-            annotations[f"{boolean_field_def.name}_boolean_filter"] = boolean_annotation
-
-    if choice_fields := config.get("choice_fields"):
-        for choice_field_def in normalize_choice_field_types(choice_fields):
-            choices_annotation = NamedDependency[SkipValidation[ChoicesFilter[choice_field_def.type_hint]]]  # type: ignore[name-defined]
-            parameters[f"{choice_field_def.name}_choices_filter"] = inspect.Parameter(
-                name=f"{choice_field_def.name}_choices_filter",
-                kind=inspect.Parameter.POSITIONAL_OR_KEYWORD,
-                annotation=choices_annotation,
-            )
-            annotations[f"{choice_field_def.name}_choices_filter"] = choices_annotation
-
-    def provide_filters(**kwargs: FilterTypes) -> list[FilterTypes]:  # noqa: C901
-        """Provide filter dependencies based on configuration.
-
-        Args:
-            **kwargs: Filter parameters dynamically provided based on configuration.
-
-        Returns:
-            list[FilterTypes]: List of configured filters.
-        """
-        filters: list[FilterTypes] = []
-        if id_filter := kwargs.get("id_filter"):
-            filters.append(id_filter)
-        if created_filter := kwargs.get("created_filter"):
-            filters.append(created_filter)
-        if limit_offset := kwargs.get("limit_offset_filter"):
-            filters.append(limit_offset)
-        if updated_filter := kwargs.get("updated_filter"):
-            filters.append(updated_filter)
-        if (
-            (search_filter := cast("Optional[SearchFilter]", kwargs.get("search_filter")))
-            and search_filter is not None  # pyright: ignore[reportUnnecessaryComparison]
-            and search_filter.field_name is not None  # pyright: ignore[reportUnnecessaryComparison]
-            and search_filter.value is not None  # pyright: ignore[reportUnnecessaryComparison]
-        ):
-            filters.append(search_filter)
-        if (
-            (order_by := cast("Optional[OrderBy]", kwargs.get("order_by_filter")))
-            and order_by is not None  # pyright: ignore[reportUnnecessaryComparison]
-            and order_by.field_name is not None  # pyright: ignore[reportUnnecessaryComparison]
-        ):
-            filters.append(order_by)
-
-        # Add not_in filters
-        if not_in_fields := config.get("not_in_fields"):
-            for field_def in normalize_field_name_types(not_in_fields):
-                filter_ = kwargs.get(f"{field_def.name}_not_in_filter")
-                if filter_ is not None:
-                    filters.append(filter_)
-
-        # Add in filters
-        if in_fields := config.get("in_fields"):
-            for field_def in normalize_field_name_types(in_fields):
-                filter_ = kwargs.get(f"{field_def.name}_in_filter")
-                if filter_ is not None:
-                    filters.append(filter_)
-        if boolean_fields := config.get("boolean_fields"):
-            for field_def in normalize_field_name_types(boolean_fields):
-                filter_ = kwargs.get(f"{field_def.name}_boolean_filter")
-                if filter_ is not None:
-                    filters.append(filter_)
-        if choice_fields := config.get("choice_fields"):
-            for field_def in normalize_choice_field_types(choice_fields):
-                filter_ = kwargs.get(f"{field_def.name}_choices_filter")
-                if filter_ is not None:
-                    filters.append(filter_)
-        return filters
+    def provide_filters(**kwargs: FilterTypes) -> list[FilterTypes]:
+        return _collect_filters(config, **kwargs)
 
     # Set both signature and annotations
     provide_filters.__signature__ = inspect.Signature(  # type: ignore

--- a/advanced_alchemy/operations.py
+++ b/advanced_alchemy/operations.py
@@ -47,7 +47,6 @@ from sqlalchemy.sql.expression import Executable
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
     from sqlalchemy.sql.compiler import SQLCompiler
-    from sqlalchemy.sql.elements import ColumnElement
 
 __all__ = ("MergeStatement", "OnConflictUpsert", "validate_identifier")
 
@@ -346,7 +345,110 @@ class OnConflictUpsert:
         raise NotImplementedError(msg)
 
     @staticmethod
-    def create_merge_upsert(  # noqa: C901, PLR0915
+    def _validate_upsert_identifiers(
+        conflict_columns: list[str],
+        update_columns: Optional[list[str]],
+        values: dict[str, Any],
+    ) -> None:
+        for col in conflict_columns:
+            validate_identifier(col, "conflict column")
+        if update_columns:
+            for col in update_columns:
+                validate_identifier(col, "update column")
+        for col in values:
+            validate_identifier(col, "column")
+
+    @staticmethod
+    def _build_oracle_merge_source(
+        table: Table,
+        values: dict[str, Any],
+    ) -> tuple[ClauseElement, list[str], dict[str, Any], dict[str, Any]]:
+        additional_params: dict[str, Any] = {}
+        labeled_columns: list[Any] = []
+        for key, value in values.items():
+            column = table.c[key]
+            labeled_columns.append(bindparam(key, value=value, type_=column.type).label(key))
+
+        pk_col_with_seq = None
+        for pk_column in table.primary_key.columns:
+            if pk_column.name in values or pk_column.default is None:
+                continue
+            if callable(getattr(pk_column.default, "arg", None)):
+                try:
+                    default_value = pk_column.default.arg(None)  # type: ignore[attr-defined]
+                    if isinstance(default_value, UUID):
+                        default_value = default_value.hex
+                    additional_params[pk_column.name] = default_value
+                    labeled_columns.append(
+                        bindparam(pk_column.name, value=default_value, type_=pk_column.type).label(pk_column.name)
+                    )
+                except (TypeError, AttributeError, ValueError):
+                    continue
+            elif hasattr(pk_column.default, "next_value"):
+                pk_col_with_seq = pk_column
+
+        source_query = select(*labeled_columns)
+        source_query = source_query.select_from(text("DUAL"))
+        source = source_query.subquery("src")
+        insert_columns = [label_col.name for label_col in labeled_columns]
+        when_not_matched_insert: dict[str, Any] = {
+            col_name: literal_column(f"src.{col_name}") for col_name in insert_columns
+        }
+        if pk_col_with_seq is not None:
+            insert_columns.append(pk_col_with_seq.name)
+            when_not_matched_insert[pk_col_with_seq.name] = cast("Any", pk_col_with_seq.default).next_value()
+
+        return source, insert_columns, when_not_matched_insert, additional_params
+
+    @staticmethod
+    def _build_postgresql_merge_source(
+        table: Table,
+        values: dict[str, Any],
+    ) -> tuple[ClauseElement, list[str], dict[str, Any]]:
+        labeled_columns: list[Any] = []
+        for key, value in values.items():
+            column = table.c[key]
+            bp = bindparam(f"src_{key}", value=value, type_=column.type)
+            labeled_columns.append(bp.label(key))
+        source = select(*labeled_columns).subquery("src")
+        insert_columns = list(values.keys())
+        when_not_matched_insert: dict[str, Any] = {col: literal_column(f"src.{col}") for col in insert_columns}
+        return source, insert_columns, when_not_matched_insert
+
+    @staticmethod
+    def _build_generic_merge_source(
+        values: dict[str, Any],
+    ) -> tuple[str, list[str], dict[str, Any]]:
+        placeholders = ", ".join([f"%({key})s" for key in values])
+        col_names = ", ".join(values.keys())
+        source = f"(SELECT * FROM (VALUES ({placeholders})) AS src({col_names}))"  # noqa: S608
+        insert_columns = list(values.keys())
+        when_not_matched_insert: dict[str, Any] = {col: bindparam(col) for col in insert_columns}
+        return source, insert_columns, when_not_matched_insert
+
+    @staticmethod
+    def _build_when_matched_update(
+        dialect_name: Optional[str],
+        update_columns: list[str],
+        values: dict[str, Any],
+    ) -> dict[str, Any]:
+        if dialect_name in {"postgresql", "cockroachdb", "oracle"}:
+            return {col: literal_column(f"src.{col}") for col in update_columns if col in values}
+        return {col: bindparam(col) for col in update_columns if col in values}
+
+    @staticmethod
+    def _reorder_oracle_insert_mapping(
+        insert_columns: list[str],
+        when_not_matched_insert: dict[str, Any],
+    ) -> dict[str, Any]:
+        final_insert_mapping: dict[str, Any] = {}
+        for col_name in insert_columns:
+            if col_name in when_not_matched_insert:
+                final_insert_mapping[col_name] = when_not_matched_insert[col_name]
+        return final_insert_mapping
+
+    @staticmethod
+    def create_merge_upsert(
         table: Table,
         values: dict[str, Any],
         conflict_columns: list[str],
@@ -377,13 +479,7 @@ class OnConflictUpsert:
             ValueError: If validate_identifiers is True and invalid identifiers are found
         """
         if validate_identifiers:
-            for col in conflict_columns:
-                validate_identifier(col, "conflict column")
-            if update_columns:
-                for col in update_columns:
-                    validate_identifier(col, "update column")
-            for col in values:
-                validate_identifier(col, "column")
+            OnConflictUpsert._validate_upsert_identifiers(conflict_columns, update_columns, values)
 
         if update_columns is None:
             update_columns = [col for col in values if col not in conflict_columns]
@@ -394,73 +490,25 @@ class OnConflictUpsert:
         when_not_matched_insert: dict[str, Any]
 
         if dialect_name == "oracle":
-            labeled_columns: list[ColumnElement[Any]] = []
-            for key, value in values.items():
-                column = table.c[key]
-                labeled_columns.append(bindparam(key, value=value, type_=column.type).label(key))
-
-            pk_col_with_seq = None
-            for pk_column in table.primary_key.columns:
-                if pk_column.name in values or pk_column.default is None:
-                    continue
-                if callable(getattr(pk_column.default, "arg", None)):
-                    try:
-                        default_value = pk_column.default.arg(None)  # type: ignore[attr-defined]
-                        if isinstance(default_value, UUID):
-                            default_value = default_value.hex
-                        additional_params[pk_column.name] = default_value
-                        labeled_columns.append(
-                            bindparam(pk_column.name, value=default_value, type_=pk_column.type).label(pk_column.name)
-                        )
-                    except (TypeError, AttributeError, ValueError):
-                        continue
-                elif hasattr(pk_column.default, "next_value"):
-                    pk_col_with_seq = pk_column
-
-            # Oracle requires FROM DUAL for SELECT statements without tables
-            source_query = select(*labeled_columns)
-            # Add FROM DUAL for Oracle
-            source_query = source_query.select_from(text("DUAL"))
-            source = source_query.subquery("src")
-            insert_columns = [label_col.name for label_col in labeled_columns]
-            when_not_matched_insert = {col_name: literal_column(f"src.{col_name}") for col_name in insert_columns}
-            if pk_col_with_seq is not None:
-                insert_columns.append(pk_col_with_seq.name)
-                when_not_matched_insert[pk_col_with_seq.name] = cast("Any", pk_col_with_seq.default).next_value()
-
+            source, insert_columns, when_not_matched_insert, additional_params = (
+                OnConflictUpsert._build_oracle_merge_source(table, values)
+            )
         elif dialect_name in {"postgresql", "cockroachdb"}:
-            labeled_columns = []
-            for key, value in values.items():
-                column = table.c[key]
-                bp = bindparam(f"src_{key}", value=value, type_=column.type)
-                labeled_columns.append(bp.label(key))
-            source = select(*labeled_columns).subquery("src")
-            insert_columns = list(values.keys())
-            when_not_matched_insert = {col: literal_column(f"src.{col}") for col in insert_columns}
+            source, insert_columns, when_not_matched_insert = OnConflictUpsert._build_postgresql_merge_source(
+                table, values
+            )
         else:
-            placeholders = ", ".join([f"%({key})s" for key in values])
-            col_names = ", ".join(values.keys())
-            source = f"(SELECT * FROM (VALUES ({placeholders})) AS src({col_names}))"  # noqa: S608
-            insert_columns = list(values.keys())
-            when_not_matched_insert = {col: bindparam(col) for col in insert_columns}
+            source, insert_columns, when_not_matched_insert = OnConflictUpsert._build_generic_merge_source(values)
 
         on_conditions = [f"tgt.{col} = src.{col}" for col in conflict_columns]
         on_condition = text(" AND ".join(on_conditions))
 
-        if dialect_name in {"postgresql", "cockroachdb", "oracle"}:
-            when_matched_update: dict[str, Any] = {
-                col: literal_column(f"src.{col}") for col in update_columns if col in values
-            }
-        else:
-            when_matched_update = {col: bindparam(col) for col in update_columns if col in values}
+        when_matched_update = OnConflictUpsert._build_when_matched_update(dialect_name, update_columns, values)
 
-        # For Oracle, we need to ensure the keys in when_not_matched_insert match the insert_columns
         if dialect_name == "oracle":
-            final_insert_mapping = {}
-            for col_name in insert_columns:
-                if col_name in when_not_matched_insert:
-                    final_insert_mapping[col_name] = when_not_matched_insert[col_name]
-            when_not_matched_insert = final_insert_mapping
+            when_not_matched_insert = OnConflictUpsert._reorder_oracle_insert_mapping(
+                insert_columns, when_not_matched_insert
+            )
 
         merge_stmt = MergeStatement(
             table=table,
@@ -471,6 +519,3 @@ class OnConflictUpsert:
         )
 
         return merge_stmt, additional_params  # pyright: ignore[reportUnknownVariableType]
-
-
-# Note: Oracle-specific helper removed; inline logic now handles defaults


### PR DESCRIPTION
## Description

This PR addresses and resolves all **8 occurrences** of the `too-many-statements` (R0915) code smell identified by Pylint across the `advanced_alchemy` core and extension modules. Complex functions and methods that coupled multiple responsibilities were refactored using the **Extract Function** technique, introducing focused private helpers to improve maintainability and readability without altering external behavior.

### Refactoring Breakdown

| Module | Object / Function | Original Statement Count (Limit: 50) | Refactoring Action Taken |
| :--- | :--- | :---: | :--- |
| `advanced_alchemy._listeners` | `FileObjectInspector.handle_multiple_attribute` | 55 / 50 | Extracted complex operational attribute mapping logic into smaller private helpers. |
| `advanced_alchemy.cli` | `add_migration_commands` | 154 / 50 | Decoupled multiple command initializations, shared options, and sub-commands into independent setup functions. |
| `advanced_alchemy.exceptions` | `wrap_sqlalchemy_exception` | 59 / 50 | Eliminated repetitive `except` block logic by introducing structural exception-mapping helper functions. |
| `advanced_alchemy.operations` | `OnConflictUpsert.create_merge_upsert` | 64 / 50 | Isolated deep conditional merge block logic into dedicated internal class methods. |
| `advanced_alchemy.extensions.fastapi.providers` | `provide_service` | 68 / 50 | Unified and extracted duplicated session cleanup routines into a dedicated lifecycle helper. |
| `advanced_alchemy.extensions.fastapi.providers` | `_create_filter_aggregate_function_fastapi` | 74 / 50 | Delegated sub-provider generation steps into targeted functional components. |
| `advanced_alchemy.extensions.litestar.providers` | `_create_statement_filters` | 57 / 50 | Split out large filter creation blocks into specialized statements factory sub-routines. |
| `advanced_alchemy.extensions.litestar.providers` | `_create_filter_aggregate_function` | 69 / 50 | Reduced complexity by moving repetitive provider construction branches into dedicated helpers. |

### Why is this change necessary?
Functions that exceed the maximum statement threshold accumulate too many concurrent responsibilities. This high coupling increases cognitive load, makes targeted unit testing difficult, and elevates regression risks during updates. Breaking these blocks down enforces the Single Responsibility Principle (SRP) and ensures long-term codebase sustainability.

### How was this tested?
- Validated via local verification rules (`make lint` / static typing check).
- The repository test suite (`pytest`) was fully executed locally to guarantee strict behavior preservation and ensure that no regressions were introduced.