### PR TITLE
fix(typing): declare ModelProtocol attributes as ClassVar so plain declarative models satisfy it

### DIFF
--- a/advanced_alchemy/_typing.py
+++ b/advanced_alchemy/_typing.py
@@ -73,9 +73,9 @@ class SQLModelBaseLike:
     """
 
     if TYPE_CHECKING:
-        __table__: "FromClause"
-        __mapper__: "Mapper[Any]"
-        __name__: str
+        __table__: "ClassVar[FromClause]"
+        __mapper__: "ClassVar[Mapper[Any]]"
+        __name__: ClassVar[str]
 
     model_fields: ClassVar[dict[str, Any]] = {}
 

--- a/advanced_alchemy/base.py
+++ b/advanced_alchemy/base.py
@@ -4,7 +4,7 @@ import contextlib
 import datetime
 import re
 from collections.abc import Iterator, Mapping
-from typing import TYPE_CHECKING, Any, Optional, Protocol, Union, cast, runtime_checkable
+from typing import TYPE_CHECKING, Any, ClassVar, Optional, Protocol, Union, cast, runtime_checkable
 from uuid import UUID
 
 from sqlalchemy import Date, MetaData, String
@@ -155,9 +155,9 @@ class ModelProtocol(Protocol):
     """
 
     if TYPE_CHECKING:
-        __table__: FromClause
-        __mapper__: Mapper[Any]
-        __name__: str
+        __table__: ClassVar[FromClause]
+        __mapper__: ClassVar[Mapper[Any]]
+        __name__: ClassVar[str]
 
 
 def model_to_dict(instance: "ModelProtocol", exclude: Optional[set[str]] = None) -> dict[str, Any]:
@@ -202,9 +202,9 @@ class BasicAttributes:
     """
 
     if TYPE_CHECKING:
-        __name__: str
-        __table__: FromClause
-        __mapper__: Mapper[Any]
+        __name__: ClassVar[str]
+        __table__: ClassVar[FromClause]
+        __mapper__: ClassVar[Mapper[Any]]
 
     def to_dict(self, exclude: Optional[set[str]] = None) -> dict[str, Any]:
         """Convert model to dictionary.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -57,7 +57,7 @@ extensions = [
 
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
-    "msgspec": ("https://jcristharif.com/msgspec/", None),
+    "msgspec": ("https://msgspec.dev/", None),
     "sqlalchemy": ("https://docs.sqlalchemy.org/en/20/", None),
     "alembic": ("https://alembic.sqlalchemy.org/en/latest/", None),
     "litestar": ("https://docs.litestar.dev/latest/", None),

--- a/tests/unit/test_model_protocol_typing.py
+++ b/tests/unit/test_model_protocol_typing.py
@@ -1,0 +1,52 @@
+"""Regression tests: plain SQLAlchemy declarative models satisfy ``ModelProtocol``.
+
+``sqlalchemy.orm.DeclarativeBase`` declares ``__table__``/``__mapper__``/``__name__``
+as ``ClassVar``, so ``ModelProtocol`` must declare them as ``ClassVar`` too — a plain
+instance-variable declaration makes mypy reject every model not built on Advanced
+Alchemy's own bases ("expected instance variable, got class variable"), which breaks
+``SQLAlchemySyncRepository[PlainModel]`` and the service classes for external models.
+
+The ``ModelProtocol``-annotated assignments below are the actual assertions: this
+module is type-checked by mypy in CI, so a variance regression fails the build.
+(``type-var`` is disabled for ``tests.*``, so the repository subclass documents the
+downstream failure mode but the assignments are what fail CI.)
+"""
+
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
+
+from advanced_alchemy.base import ModelProtocol, UUIDBase
+from advanced_alchemy.repository import SQLAlchemySyncRepository
+
+
+class PlainBase(DeclarativeBase):
+    """A declarative base with no Advanced Alchemy mixins."""
+
+
+class PlainModel(PlainBase):
+    """A model built directly on ``sqlalchemy.orm.DeclarativeBase``."""
+
+    __tablename__ = "test_model_protocol_plain"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+
+
+class AAModel(UUIDBase):
+    """A model built on Advanced Alchemy's own base."""
+
+    __tablename__ = "test_model_protocol_aa"
+
+
+class PlainModelRepository(SQLAlchemySyncRepository[PlainModel]):
+    """The ``ModelT`` bound must accept plain declarative models."""
+
+    model_type = PlainModel
+
+
+def test_plain_declarative_model_satisfies_protocol_statically() -> None:
+    instance: ModelProtocol = PlainModel(id=1)
+    assert isinstance(instance, ModelProtocol)
+
+
+def test_advanced_alchemy_model_satisfies_protocol_statically() -> None:
+    instance: ModelProtocol = AAModel()
+    assert isinstance(instance, ModelProtocol)


### PR DESCRIPTION
### Summary

Fixes #768. `ModelProtocol` declares `__table__`/`__mapper__`/`__name__` as instance variables, while `sqlalchemy.orm.DeclarativeBase` declares them as `ClassVar` — so under mypy, no model built on plain `DeclarativeBase` has ever satisfied the protocol, and every repository/service parameterized with an external model fails the `ModelT` bound. Advanced Alchemy's own bases pass only because `UUIDBase`'s MRO happens to list `CommonTableAttributes` before `AdvancedDeclarativeBase`.

### Structure

Two commits, test-first:

1. **`test(typing): plain declarative models must satisfy ModelProtocol`** — adds `tests/unit/test_model_protocol_typing.py`, which reproduces the bug: at this commit the module **fails mypy** (`[assignment]` on the `ModelProtocol`-annotated assignments, with the "expected instance variable, got class variable" notes). The pytest cases pass throughout since runtime was never broken — the static assignments are the assertions, and the module is type-checked by mypy in CI. (Note: `type-var` is disabled for `tests.*` in the mypy config, so the repository subclass in the test documents the downstream failure mode while the assignments are what guard CI.)
2. **`fix(typing): declare ModelProtocol attributes as ClassVar so plain declarative models satisfy it`** — declares the members as `ClassVar` in `ModelProtocol` and `BasicAttributes` (`base.py`) and the `SQLModelBaseLike` placeholder (`_typing.py`), matching SQLAlchemy's own declarations. All three sites are `TYPE_CHECKING`-only; no runtime change.

### Verification

- `make mypy`: clean (133 files, strict) — and fails as expected on the test-only commit
- `make pyright`: 0 errors
- ruff check + format: clean
- `tests/unit`: passes (one pre-existing failure on macOS, `test_case_insensitive_support`, fails identically on `main`)
- Validated downstream on a 775-file FastAPI codebase with ~55 `SQLAlchemyAsyncRepositoryService` subclasses over plain declarative models: 110 `must be a subtype of "ModelProtocol"` `[type-var]` errors → 0


<!-- docs-preview -->

<hr>
📚 Documentation preview: <a href="https://litestar-org.github.io/advanced-alchemy-docs-preview/769">https://litestar-org.github.io/advanced-alchemy-docs-preview/769</a> 
