### PR TITLE
fix(base): remove unreachable `msgspec.Struct` annotation mapping

### DIFF
--- a/advanced_alchemy/base.py
+++ b/advanced_alchemy/base.py
@@ -421,10 +421,6 @@ def create_registry(
                 IPvAnyNetwork: String,
             }
         )
-    with contextlib.suppress(ImportError):
-        from msgspec import Struct
-
-        type_annotation_map[Struct] = JsonB
     if custom_annotation_map is not None:
         type_annotation_map.update(custom_annotation_map)
     return SQLAlchemyRegistry(metadata=meta, type_annotation_map=type_annotation_map)

--- a/tests/unit/test_base.py
+++ b/tests/unit/test_base.py
@@ -319,3 +319,51 @@ def test_dataclass_column_resolves_via_custom_annotation_map() -> None:
 
     resolved = registry._resolve_type(ExtraData)  # pyright: ignore[reportPrivateUsage]
     assert resolved is not None
+
+
+def test_registry_type_annotation_map_has_no_msgspec_struct_key() -> None:
+    """Regression test for https://github.com/litestar-org/advanced-alchemy/issues/772.
+
+    ``type_annotation_map`` is resolved by SQLAlchemy through an exact/``__mro__``
+    dictionary lookup that rejects supertype matches (``_resolve_for_python_type``
+    returns ``None`` unless ``python_type is matched_on_flattened``). A base ``Struct``
+    key is therefore found in a concrete struct's ``__mro__`` but rejected, so it only
+    ever matched the literal ``Mapped[Struct]`` annotation and never a user-defined
+    subclass -- the realistic case. Like the removed ``DataclassProtocol`` entry, it
+    was misleading dead configuration. Guard against reintroducing it.
+    """
+    from advanced_alchemy._typing import MSGSPEC_INSTALLED
+    from advanced_alchemy.base import orm_registry
+
+    if not MSGSPEC_INSTALLED:
+        pytest.skip("msgspec not installed")
+
+    from msgspec import Struct
+
+    assert Struct not in orm_registry.type_annotation_map
+
+
+def test_struct_column_resolves_via_custom_annotation_map() -> None:
+    """A concrete msgspec struct resolves only when registered explicitly.
+
+    This is the supported replacement for the removed ``Struct`` entry: users map
+    their own concrete struct type, which lands in the registry as an exact key and
+    therefore resolves.
+    """
+    from advanced_alchemy._typing import MSGSPEC_INSTALLED
+
+    if not MSGSPEC_INSTALLED:
+        pytest.skip("msgspec not installed")
+
+    from msgspec import Struct
+
+    from advanced_alchemy.base import create_registry
+    from advanced_alchemy.types import JsonB
+
+    class MyStruct(Struct):
+        a: int
+
+    registry = create_registry(custom_annotation_map={MyStruct: JsonB})
+
+    resolved = registry._resolve_type(MyStruct)  # pyright: ignore[reportPrivateUsage]
+    assert resolved is not None


### PR DESCRIPTION
## Summary

Closes #772. Follow-up to #477 / #771.

`create_registry()` seeds `type_annotation_map` with `Struct: JsonB` (msgspec) so struct-typed columns are stored as `JsonB`. Like the `DataclassProtocol` entry removed in #771, this entry only ever matches an **exact** `Mapped[Struct]` annotation — never a concrete subclass, which is the only realistic usage.

**Root cause** — SQLAlchemy resolves `type_annotation_map` by walking the concrete type's `__mro__`, then rejecting supertype matches in `TypeEngine._resolve_for_python_type`:

```python
if python_type is not matched_on_flattened:
    return None
```

`MyStruct.__mro__` contains `Struct`, so the key is *found*, but because `MyStruct is not Struct` the match is rejected. So `Struct: JsonB` is effectively dead for the common case of user-defined structs.

### MCVE (before this change)

```python
from advanced_alchemy.base import orm_registry
import msgspec

class MyStruct(msgspec.Struct):
    a: int

orm_registry._resolve_type(msgspec.Struct)  # JSON  (exact base — rare)
orm_registry._resolve_type(MyStruct)         # None  (subclass — the real case)
```

## Changes

- Remove the default `Struct: JsonB` entry and its now-unused msgspec import from `advanced_alchemy/base.py`.
- Add regression coverage: a guard against reintroducing the `Struct` key, and a test of the supported concrete-registration path.

## Compatibility

This changes the narrow case where a model is annotated literally as `Mapped[Struct]` (the msgspec base class); that exact annotation previously selected `JsonB`. Concrete annotations such as `Mapped[MyStruct]` did not resolve through this entry before this change and continue to require an explicit concrete mapping.

## Supported replacement

```python
from advanced_alchemy.base import create_registry
from advanced_alchemy.types import JsonB
from msgspec import Struct


class MyStruct(Struct):
    a: int


registry = create_registry(custom_annotation_map={MyStruct: JsonB})
```

## Notes

This mirrors the direction taken for `DataclassProtocol` in #771, whose PR body explicitly flagged the identical `Struct` limitation as out of scope. The regression test uses a direct `Struct not in type_annotation_map` assertion rather than #771's `_is_protocol` guard, since `msgspec.Struct` is a concrete base class, not a Protocol.

## Testing

- `uv run pytest tests/unit/test_base.py` — all pass
- `uv run ruff check` — clean
- `uv run mypy advanced_alchemy/base.py` — clean

<!-- docs-preview -->

<hr>
📚 Documentation preview: <a href="https://litestar-org.github.io/advanced-alchemy-docs-preview/775">https://litestar-org.github.io/advanced-alchemy-docs-preview/775</a> 
