### PR TITLE
docs(cli): fix incorrect config class and parameter in example

### DIFF
--- a/docs/usage/cli.rst
+++ b/docs/usage/cli.rst
@@ -71,7 +71,7 @@ The following options are available for all commands:
    * - Option
      - Explanation
    * - ``--config`` TEXT
-     - **Required**. Dotted path to SQLAlchemy config(s), it's an instance of ``SQLAlchemyConfig`` (sync or async). Example: ``--config path.to.alchemy-config.config``
+     - **Required**. Dotted path to SQLAlchemy config(s), it's an instance of ``SQLAlchemySyncConfig`` or ``SQLAlchemyAsyncConfig``. Example: ``--config path.to.alchemy-config.config``
    * - ``--bind-key`` TEXT
      - Optional. Specify which SQLAlchemy config to use
    * - ``--no-prompt``

--- a/docs/usage/cli.rst
+++ b/docs/usage/cli.rst
@@ -90,12 +90,11 @@ If the file is named ``alchemy-config.py``, you would need to use it like this `
 .. code-block:: python
     :caption: alchemy-config.py
 
-    from sqlalchemy import create_engine
-    from advanced_alchemy.config import SQLAlchemyConfig
+    from advanced_alchemy.config import SQLAlchemySyncConfig
 
     # Create a test config using SQLite
-    config = SQLAlchemyConfig(
-        connection_url="sqlite:///test.db"
+    config = SQLAlchemySyncConfig(
+        connection_string="sqlite:///test.db"
     )
 
 


### PR DESCRIPTION
## Summary

The CLI documentation example in `docs/usage/cli.rst` would fail if copy-pasted:

- `SQLAlchemyConfig` is not a real export — replaced with `SQLAlchemySyncConfig`
- `connection_url` is not a valid parameter — replaced with `connection_string`
- Removed an unused `from sqlalchemy import create_engine` import

Also fixed the matching prose in the **Global Options** table, which described `--config` as "an instance of `SQLAlchemyConfig` (sync or async)" — replaced with the real exported types `SQLAlchemySyncConfig` or `SQLAlchemyAsyncConfig` so the whole page is consistent.

Verified against source: `advanced_alchemy/config/__init__.py` exports only `SQLAlchemySyncConfig` / `SQLAlchemyAsyncConfig`, and the field is defined as `connection_string` in `advanced_alchemy/config/common.py`.

Closes #728

<!-- docs-preview -->

<hr>
📚 Documentation preview: <a href="https://litestar-org.github.io/advanced-alchemy-docs-preview/776">https://litestar-org.github.io/advanced-alchemy-docs-preview/776</a> 
