### PR TITLE
fix: get binding of a routed session.

### DIFF
--- a/advanced_alchemy/routing/session.py
+++ b/advanced_alchemy/routing/session.py
@@ -72,6 +72,7 @@ class RoutingSyncSession(Session):
         """
         kwargs.pop("bind", None)
         kwargs.pop("binds", None)
+        self.bind = None
         super().__init__(**kwargs)
         self._default_engine = default_engine
         self._selectors = selectors
@@ -213,6 +214,7 @@ class RoutingAsyncSession(AsyncSession):
 
         # Convert async selectors to sync selectors for the wrapped session
         sync_selectors = {name: _SyncEngineSelectorWrapper(selector) for name, selector in selectors.items()}
+        self.bind = None  # type: ignore
 
         super().__init__(
             sync_session_class=RoutingSyncSession,

--- a/advanced_alchemy/routing/session.py
+++ b/advanced_alchemy/routing/session.py
@@ -20,7 +20,7 @@ from advanced_alchemy.routing.context import (
 
 if TYPE_CHECKING:
     from sqlalchemy import Engine
-    from sqlalchemy.ext.asyncio import AsyncEngine
+    from sqlalchemy.ext.asyncio import AsyncConnection, AsyncEngine
     from sqlalchemy.orm import Mapper
 
     from advanced_alchemy.config.routing import RoutingConfig
@@ -214,7 +214,9 @@ class RoutingAsyncSession(AsyncSession):
 
         # Convert async selectors to sync selectors for the wrapped session
         sync_selectors = {name: _SyncEngineSelectorWrapper(selector) for name, selector in selectors.items()}
-        self.bind = None  # type: ignore
+        # In SQLAlchemy this type is either Unbound or AsyncEngine | AsyncConnection.
+        # This type ignore guarantees that bind is going to be defined in any case.
+        self.bind: Optional[Union[AsyncEngine, AsyncConnection]] = None  # type: ignore[assignment]
 
         super().__init__(
             sync_session_class=RoutingSyncSession,

--- a/tests/unit/test_routing/test_routing_repository_bind.py
+++ b/tests/unit/test_routing/test_routing_repository_bind.py
@@ -1,8 +1,11 @@
 """
 Regression tests: repositories constructed on top of routing sessions.
 
-Issue #793: ``RoutingSession`` / ``RoutingAsyncSession`` did not expose a
-``bind`` attribute, so the repository ``__init__`` line::
+Issue: https://github.com/litestar-org/advanced-alchemy/issues/793
+
+Description:
+
+``RoutingAsyncSession`` did not expose a ``bind`` attribute, so the repository ``__init__`` line::
 
     self._dialect = (
         self.session.bind.dialect

--- a/tests/unit/test_routing/test_routing_repository_bind.py
+++ b/tests/unit/test_routing/test_routing_repository_bind.py
@@ -1,0 +1,130 @@
+"""
+Regression tests: repositories constructed on top of routing sessions.
+
+Issue #793: ``RoutingSession`` / ``RoutingAsyncSession`` did not expose a
+``bind`` attribute, so the repository ``__init__`` line::
+
+    self._dialect = (
+        self.session.bind.dialect
+        if self.session.bind is not None
+        else self.session.get_bind().dialect
+    )
+
+raised ``AttributeError: ...Session object has no attribute 'bind'`` as soon as a
+repository was created around a routing session (e.g. inside a FastAPI/Starlette
+dependency). These tests reproduce that scenario and verify the fix: routing
+sessions must expose ``bind`` as ``None`` so the repository falls back to
+``get_bind()`` and resolves the dialect correctly.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator, Iterator
+
+import pytest
+from sqlalchemy import String
+from sqlalchemy.orm import Mapped, mapped_column
+
+from advanced_alchemy.base import UUIDAuditBase
+from advanced_alchemy.config.routing import RoutingConfig
+from advanced_alchemy.repository import SQLAlchemyAsyncRepository, SQLAlchemySyncRepository
+from advanced_alchemy.routing import (
+    RoutingAsyncSession,
+    RoutingAsyncSessionMaker,
+    RoutingSyncSession,
+    RoutingSyncSessionMaker,
+)
+
+
+class User(UUIDAuditBase):
+    """Minimal model for routing bind regression tests (mirrors issue #793)."""
+
+    __tablename__ = "routing_bind_users"
+
+    name: Mapped[str] = mapped_column(String(length=100))  # pyright: ignore[reportUninitializedInstanceVariable]
+
+
+class UserSyncRepository(SQLAlchemySyncRepository[User]):
+    """Sync repository for ``User``."""
+
+    model_type = User
+
+
+class UserAsyncRepository(SQLAlchemyAsyncRepository[User]):
+    """Async repository for ``User``."""
+
+    model_type = User
+
+
+@pytest.fixture()
+def sync_routing_session() -> Iterator[RoutingSyncSession]:
+    """Create a sync routing session backed by real (in-memory) SQLite engines."""
+    maker = RoutingSyncSessionMaker(
+        RoutingConfig(
+            primary_connection_string="sqlite://",
+            read_replicas=["sqlite://"],
+        )
+    )
+    session = maker()
+    try:
+        yield session
+    finally:
+        session.close()
+        maker.close_all()
+
+
+@pytest.fixture()
+async def async_routing_session() -> AsyncIterator[RoutingAsyncSession]:
+    """Create an async routing session backed by real (in-memory) SQLite engines."""
+    maker = RoutingAsyncSessionMaker(
+        RoutingConfig(
+            primary_connection_string="sqlite+aiosqlite://",
+            read_replicas=["sqlite+aiosqlite://"],
+        )
+    )
+    session = maker()
+    try:
+        yield session
+    finally:
+        await session.close()
+        await maker.close_all()
+
+
+def test_sync_routing_session_exposes_none_bind(sync_routing_session: RoutingSyncSession) -> None:
+    """A sync routing session must expose ``bind`` as ``None`` (not be missing)."""
+    assert sync_routing_session.bind is None
+
+
+async def test_async_routing_session_exposes_none_bind(async_routing_session: RoutingAsyncSession) -> None:
+    """A routing async session must expose ``bind`` as ``None`` (issue #793)."""
+    assert async_routing_session.bind is None
+
+
+def test_sync_repository_constructs_with_routing_session(sync_routing_session: RoutingSyncSession) -> None:
+    """Constructing a sync repository on a routing session must not raise (issue #793)."""
+    repo = UserSyncRepository(session=sync_routing_session)
+
+    assert repo.session is sync_routing_session
+    assert repo._dialect.name == "sqlite"
+
+
+async def test_async_repository_constructs_with_routing_session(async_routing_session: RoutingAsyncSession) -> None:
+    """Constructing an async repository on a routing session must not raise (issue #793)."""
+    repo = UserAsyncRepository(session=async_routing_session)
+
+    assert repo.session is async_routing_session
+    assert repo._dialect.name == "sqlite"
+
+
+def test_sync_repository_resolves_replica_dialect(sync_routing_session: RoutingSyncSession) -> None:
+    """The resolved dialect must come from the routed engine, not a bound engine."""
+    repo = UserSyncRepository(session=sync_routing_session)
+
+    assert repo._dialect is sync_routing_session.get_bind().dialect
+
+
+async def test_async_repository_resolves_replica_dialect(async_routing_session: RoutingAsyncSession) -> None:
+    """The resolved dialect must come from the routed engine, not a bound engine."""
+    repo = UserAsyncRepository(session=async_routing_session)
+
+    assert repo._dialect is async_routing_session.get_bind().dialect


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow [Litestar's AI Policy](https://github.com/litestar-org/.github/blob/main/AI_POLICY.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

This is a fix for #793. 

The fix was tested locally and I could get my setup to work with the following change. This seems to be an okay fix, becuase original repository logic was build with bind attribute being available in mind. 

```
self._dialect = self.session.bind.dialect if self.session.bind is not None else self.session.get_bind().dialect
```


Also, I tested my solution locally, now my AllDAOs seem to work correctly. 


As of my discovery it seems like an SQLAlcemy issue, because in their `AsyncSession`, they don't set attribute `bind` if it's not present as the argument.


```py
# AsyncSession.__init__ code:

        if bind:
            self.bind = bind
            sync_bind = engine._get_sync_engine_or_connection(bind)

        if binds:
            self.binds = binds
            sync_binds = {
                key: engine._get_sync_engine_or_connection(b)
                for key, b in binds.items()
            }

```

Which was causing this bug to happen. 

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->


<!-- docs-preview -->

<hr>
📚 Documentation preview: <a href="https://litestar-org.github.io/advanced-alchemy-docs-preview/794">https://litestar-org.github.io/advanced-alchemy-docs-preview/794</a> 
