### PR TITLE
fix: pyright errors for ModelProtocol

### DIFF
--- a/advanced_alchemy/base.py
+++ b/advanced_alchemy/base.py
@@ -156,7 +156,6 @@ class ModelProtocol(Protocol):
     if TYPE_CHECKING:
         __table__: ClassVar[FromClause]
         __mapper__: ClassVar[Mapper[Any]]
-        __name__: ClassVar[str]
 
 
 def model_to_dict(instance: "ModelProtocol", exclude: Optional[set[str]] = None) -> dict[str, Any]:


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow [Litestar's AI Policy](https://github.com/litestar-org/.github/blob/main/AI_POLICY.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

This PR is intended to fix #768 regression. 

Since `__name__` is a special attribute defined for all `Type[T]` there is no need to declare it explicitly. And declaring it as a ClassVar breaks pyright and all LSP suggestions. 

I could come up with an MRE for this issue on pyright. 


```python
from typing import TYPE_CHECKING, ClassVar, Generic, Protocol, TypeVar


class DeclarativeMeta(type):
    # stands in for sqlalchemy.orm.decl_api.DeclarativeAttributeIntercept
    pass


class Base(metaclass=DeclarativeMeta):
    # stands in for sqlalchemy.orm.DeclarativeBase, which declares these
    if TYPE_CHECKING:
        __name__: ClassVar[str]


class Author(Base): ...


class ModelProtocol(Protocol):
    # stands in for advanced_alchemy.base.ModelProtocol
    if TYPE_CHECKING:
        __name__: ClassVar[str]


ModelT = TypeVar("ModelT", bound=ModelProtocol)


class Repository(Generic[ModelT]):
    # stands in for advanced_alchemy.repository.SQLAlchemySyncRepository
    ...


class AuthorRepo(Repository[Author]): ...
```

This script gives errors for pyright and passes with mypy.

```bash
# mypy --strict mre.py
Success: no issues found in 1 source file

# pyright mre.py 
/home/s3rius/projects/github/advanced-alchemy/mre.py
  /home/s3rius/projects/github/advanced-alchemy/mre.py:32:29 - error: Type "Author" cannot be assigned to type variable "ModelT@Repository"
    Type "Author" is not assignable to upper bound "ModelProtocol" for type variable "ModelT@Repository"
      "Author" is incompatible with protocol "ModelProtocol"
        "__name__" is defined as a ClassVar in protocol (reportInvalidTypeArguments)
1 error, 0 warnings, 0 informations
```

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->


<!-- docs-preview -->

<hr>
📚 Documentation preview: <a href="https://litestar-org.github.io/advanced-alchemy-docs-preview/796">https://litestar-org.github.io/advanced-alchemy-docs-preview/796</a> 
