### PR TITLE
feat(types): opt-in fractional-second precision for DateTimeUTC

### DIFF
--- a/advanced_alchemy/types/datetime.py
+++ b/advanced_alchemy/types/datetime.py
@@ -1,7 +1,8 @@
 import datetime
-from typing import Optional
+from typing import Any, Optional
 
 from sqlalchemy import DateTime
+from sqlalchemy.dialects import mysql, oracle
 from sqlalchemy.engine import Dialect
 from sqlalchemy.types import TypeDecorator
 
@@ -12,14 +13,33 @@ class DateTimeUTC(TypeDecorator[datetime.datetime]):
     """Timezone Aware DateTime.
 
     Ensure UTC is stored in the database and that TZ aware dates are returned for all dialects.
+
+    Args:
+        fsp: Optional fractional seconds precision. When omitted the DDL is unchanged, which on
+            MySQL and Oracle means whole-second resolution. Pass a precision to compile a type
+            that retains sub-second values, which matters for expiry and lease comparisons.
     """
 
     impl = DateTime(timezone=True)
     cache_ok = True
 
+    def __init__(self, timezone: bool = True, fsp: Optional[int] = None) -> None:
+        super().__init__(timezone=timezone)
+        self.timezone = timezone
+        self.fsp = fsp
+
     @property
     def python_type(self) -> type[datetime.datetime]:
         return datetime.datetime
+
+    def load_dialect_impl(self, dialect: Dialect) -> Any:
+        if self.fsp is None:
+            return dialect.type_descriptor(DateTime(timezone=True))
+        if dialect.name in {"mysql", "mariadb"}:
+            return dialect.type_descriptor(mysql.DATETIME(timezone=True, fsp=self.fsp))
+        if dialect.name == "oracle":
+            return dialect.type_descriptor(oracle.TIMESTAMP(timezone=True))
+        return dialect.type_descriptor(DateTime(timezone=True))
 
     def process_bind_param(self, value: Optional[datetime.datetime], dialect: Dialect) -> Optional[datetime.datetime]:
         if value is None:

--- a/tests/unit/test_types/test_datetime.py
+++ b/tests/unit/test_types/test_datetime.py
@@ -1,0 +1,47 @@
+import pytest
+from sqlalchemy.dialects import mysql, oracle, postgresql, sqlite
+from sqlalchemy.engine import Dialect
+
+from advanced_alchemy.types import DateTimeUTC
+
+
+@pytest.mark.parametrize(
+    ("dialect", "expected"),
+    [
+        (mysql.dialect(), "DATETIME"),
+        (oracle.dialect(), "DATE"),
+        (postgresql.dialect(), "TIMESTAMP WITH TIME ZONE"),
+        (sqlite.dialect(), "DATETIME"),
+    ],
+)
+def test_default_ddl_is_unchanged(dialect: Dialect, expected: str) -> None:
+    """Omitting fsp must keep the DDL emitted before fractional precision was available."""
+    assert DateTimeUTC().compile(dialect=dialect) == expected
+
+
+@pytest.mark.parametrize(
+    ("dialect", "expected"),
+    [
+        (mysql.dialect(), "DATETIME(6)"),
+        (oracle.dialect(), "TIMESTAMP WITH TIME ZONE"),
+    ],
+)
+def test_fsp_retains_fractional_seconds(dialect: Dialect, expected: str) -> None:
+    """The dialects that truncate to whole seconds compile to a sub-second type when fsp is set."""
+    assert DateTimeUTC(fsp=6).compile(dialect=dialect) == expected
+
+
+@pytest.mark.parametrize("dialect", [postgresql.dialect(), sqlite.dialect()])
+def test_fsp_leaves_other_dialects_alone(dialect: Dialect) -> None:
+    """Dialects that already keep microseconds are not rewritten."""
+    assert DateTimeUTC(fsp=6).compile(dialect=dialect) == DateTimeUTC().compile(dialect=dialect)
+
+
+def test_fsp_participates_in_the_cache_key() -> None:
+    """cache_ok is True, so two precisions must not share a compiled statement."""
+    assert DateTimeUTC()._static_cache_key != DateTimeUTC(fsp=6)._static_cache_key
+
+
+def test_timezone_argument_is_still_accepted() -> None:
+    """AuditColumns constructs DateTimeUTC(timezone=True), which must keep working."""
+    assert DateTimeUTC(timezone=True).compile(dialect=postgresql.dialect()) == "TIMESTAMP WITH TIME ZONE"


### PR DESCRIPTION
### Description

`DateTimeUTC` wraps `DateTime(timezone=True)`, which compiles to `DATETIME` on MySQL and `DATE` on Oracle. Neither retains fractional seconds, so a value like `now + timedelta(milliseconds=50)` is quantized to a whole second and expiry or lease comparisons fire early or stay live hundreds of milliseconds too long.

Confirmed against the MCVE from the issue:

```
mysql        -> DATETIME
oracle       -> DATE
postgresql   -> TIMESTAMP WITH TIME ZONE
sqlite       -> DATETIME
```

### Change

Adds the opt-in `fsp` argument suggested in the issue via `load_dialect_impl`, selecting `mysql.DATETIME(fsp=...)` and `oracle.TIMESTAMP`. **Omitting `fsp` leaves today's DDL byte-for-byte unchanged on every dialect**, so this is not a breaking change.

With `fsp=6`:

```
mysql        -> DATETIME(6)
mariadb      -> DATETIME(6)
oracle       -> TIMESTAMP WITH TIME ZONE
postgresql   -> TIMESTAMP WITH TIME ZONE   (unchanged, already microsecond)
sqlite       -> DATETIME                   (unchanged)
```

Two details worth flagging for review:

- `AuditColumns` constructs `DateTimeUTC(timezone=True)`, so `timezone` is kept as an explicit parameter rather than dropped. An earlier `*args/**kwargs` spelling broke that import and is not what is proposed here.
- `cache_ok = True`, so `fsp` has to participate in the compiled-statement cache key. Declaring both parameters explicitly rather than through `**kwargs` keeps SQLAlchemy's introspection working; otherwise `DateTimeUTC()` and `DateTimeUTC(fsp=6)` share a cache key and can be served the wrong compiled SQL. There is a test pinning this.

### Tests

New `tests/unit/test_types/test_datetime.py`, 10 cases covering: default DDL unchanged on four dialects, `fsp=6` producing a sub-second type on MySQL and Oracle, `fsp` leaving Postgres and SQLite alone, the cache-key requirement above, and `timezone=True` still being accepted.

All 10 pass. `ruff check` and `ruff format --check` pass on both files. Run with `--noconftest` locally because the repo `conftest.py` imports `google.cloud.spanner`, which is unrelated to this change.

Closes #777
