### PR TITLE
fix: unify filter provider naming and isolation

### DIFF
--- a/advanced_alchemy/extensions/fastapi/providers.py
+++ b/advanced_alchemy/extensions/fastapi/providers.py
@@ -10,6 +10,7 @@ import datetime
 import inspect
 import logging
 from collections.abc import AsyncGenerator, Generator
+from functools import partial
 from typing import (
     TYPE_CHECKING,
     Annotated,
@@ -55,12 +56,12 @@ from advanced_alchemy.utils.dependencies import (
     DependencyCache,
     FieldNameType,
     FilterConfig,
-    make_hashable,
+    filter_cache_key,
     normalize_choice_field_types,
     normalize_field_name_types,
     normalize_sort_field,
+    resolve_filter_aliases,
 )
-from advanced_alchemy.utils.text import camelize
 
 logger = logging.getLogger("advanced_alchemy.extensions.fastapi")
 
@@ -364,15 +365,15 @@ def provide_filters(
     if not has_filters:
         return list
 
-    # Calculate cache key using hashable version of config
-    cache_key = hash((_CACHE_NAMESPACE, make_hashable(config)))
+    aliases = resolve_filter_aliases(config)
+    cache_key = filter_cache_key(_CACHE_NAMESPACE, config, dep_defaults, aliases)
 
     # Check cache first
     cached_dep = cast("Optional[Callable[..., list[FilterTypes]]]", dep_cache.get_dependencies(cache_key))
     if cached_dep is not None:
         return cached_dep
 
-    dep = _create_filter_aggregate_function_fastapi(config, dep_defaults)
+    dep = _create_filter_aggregate_function_fastapi(config, dep_defaults, aliases=aliases)
     dep_cache.add_dependencies(cache_key, dep)
     return dep
 
@@ -380,6 +381,8 @@ def provide_filters(
 def _create_filter_aggregate_function_fastapi(  # noqa: C901, PLR0915
     config: FilterConfig,
     dep_defaults: DependencyDefaults = DEPENDENCY_DEFAULTS,
+    *,
+    aliases: Optional[dict[str, str]] = None,
 ) -> Callable[..., list[FilterTypes]]:
     """Create a FastAPI dependency provider function that aggregates multiple filter dependencies.
 
@@ -388,6 +391,7 @@ def _create_filter_aggregate_function_fastapi(  # noqa: C901, PLR0915
     """
     params: list[inspect.Parameter] = []
     annotations: dict[str, Any] = {}
+    alias_for = (resolve_filter_aliases(config) if aliases is None else aliases).__getitem__
 
     # Add id filter providers
     if (id_filter := config.get("id_filter", False)) is not False:
@@ -396,7 +400,7 @@ def _create_filter_aggregate_function_fastapi(  # noqa: C901, PLR0915
             ids: Annotated[  # type: ignore
                 Optional[list[id_filter]],  # pyright: ignore
                 Query(
-                    alias="ids",
+                    alias=alias_for("ids"),
                     required=False,
                     description="IDs to filter by.",
                 ),
@@ -417,12 +421,14 @@ def _create_filter_aggregate_function_fastapi(  # noqa: C901, PLR0915
 
     # Add created_at filter providers
     if config.get("created_at", False):
+        created_before_alias = alias_for("created_before")
+        created_after_alias = alias_for("created_after")
 
         def provide_created_at_filter(
             before: Annotated[
                 Optional[str],
                 Query(
-                    alias="createdBefore",
+                    alias=created_before_alias,
                     description="Filter by created date before this timestamp.",
                     json_schema_extra={"format": "date-time"},
                 ),
@@ -430,7 +436,7 @@ def _create_filter_aggregate_function_fastapi(  # noqa: C901, PLR0915
             after: Annotated[
                 Optional[str],
                 Query(
-                    alias="createdAfter",
+                    alias=created_after_alias,
                     description="Filter by created date after this timestamp.",
                     json_schema_extra={"format": "date-time"},
                 ),
@@ -445,7 +451,7 @@ def _create_filter_aggregate_function_fastapi(  # noqa: C901, PLR0915
                     before_dt = datetime.datetime.fromisoformat(before.replace("Z", "+00:00"))
                 except (ValueError, TypeError, AttributeError) as e:
                     raise RequestValidationError(
-                        errors=[{"loc": ["query", "createdBefore"], "msg": "Invalid date format"}]
+                        errors=[{"loc": ["query", created_before_alias], "msg": "Invalid date format"}]
                     ) from e
 
             if after is not None:
@@ -453,7 +459,7 @@ def _create_filter_aggregate_function_fastapi(  # noqa: C901, PLR0915
                     after_dt = datetime.datetime.fromisoformat(after.replace("Z", "+00:00"))
                 except (ValueError, TypeError, AttributeError) as e:
                     raise RequestValidationError(
-                        errors=[{"loc": ["query", "createdAfter"], "msg": "Invalid date format"}]
+                        errors=[{"loc": ["query", created_after_alias], "msg": "Invalid date format"}]
                     ) from e
 
             return (
@@ -474,12 +480,14 @@ def _create_filter_aggregate_function_fastapi(  # noqa: C901, PLR0915
 
     # Add updated_at filter providers
     if config.get("updated_at", False):
+        updated_before_alias = alias_for("updated_before")
+        updated_after_alias = alias_for("updated_after")
 
         def provide_updated_at_filter(
             before: Annotated[
                 Optional[str],
                 Query(
-                    alias="updatedBefore",
+                    alias=updated_before_alias,
                     description="Filter by updated date before this timestamp.",
                     json_schema_extra={"format": "date-time"},
                 ),
@@ -487,7 +495,7 @@ def _create_filter_aggregate_function_fastapi(  # noqa: C901, PLR0915
             after: Annotated[
                 Optional[str],
                 Query(
-                    alias="updatedAfter",
+                    alias=updated_after_alias,
                     description="Filter by updated date after this timestamp.",
                     json_schema_extra={"format": "date-time"},
                 ),
@@ -502,7 +510,7 @@ def _create_filter_aggregate_function_fastapi(  # noqa: C901, PLR0915
                     before_dt = datetime.datetime.fromisoformat(before.replace("Z", "+00:00"))
                 except (ValueError, TypeError, AttributeError) as e:
                     raise RequestValidationError(
-                        errors=[{"loc": ["query", "updatedBefore"], "msg": "Invalid date format"}]
+                        errors=[{"loc": ["query", updated_before_alias], "msg": "Invalid date format"}]
                     ) from e
 
             if after is not None:
@@ -510,7 +518,7 @@ def _create_filter_aggregate_function_fastapi(  # noqa: C901, PLR0915
                     after_dt = datetime.datetime.fromisoformat(after.replace("Z", "+00:00"))
                 except (ValueError, TypeError, AttributeError) as e:
                     raise RequestValidationError(
-                        errors=[{"loc": ["query", "updatedAfter"], "msg": "Invalid date format"}]
+                        errors=[{"loc": ["query", updated_after_alias], "msg": "Invalid date format"}]
                     ) from e
 
             return (
@@ -537,7 +545,7 @@ def _create_filter_aggregate_function_fastapi(  # noqa: C901, PLR0915
                 int,
                 Query(
                     ge=1,
-                    alias="currentPage",
+                    alias=alias_for("current_page"),
                     description="Page number for pagination.",
                 ),
             ] = 1,
@@ -545,7 +553,7 @@ def _create_filter_aggregate_function_fastapi(  # noqa: C901, PLR0915
                 int,
                 Query(
                     ge=1,
-                    alias="pageSize",
+                    alias=alias_for("page_size"),
                     description="Number of items per page.",
                 ),
             ] = config.get("pagination_size", dep_defaults.DEFAULT_PAGINATION_SIZE),
@@ -570,7 +578,7 @@ def _create_filter_aggregate_function_fastapi(  # noqa: C901, PLR0915
                 Optional[str],
                 Query(
                     required=False,
-                    alias="searchString",
+                    alias=alias_for("search_string"),
                     description="Search term.",
                 ),
             ] = None,
@@ -578,7 +586,7 @@ def _create_filter_aggregate_function_fastapi(  # noqa: C901, PLR0915
                 Optional[bool],
                 Query(
                     required=False,
-                    alias="searchIgnoreCase",
+                    alias=alias_for("search_ignore_case"),
                     description="Whether search should be case-insensitive.",
                 ),
             ] = config.get("search_ignore_case", False),
@@ -610,7 +618,7 @@ def _create_filter_aggregate_function_fastapi(  # noqa: C901, PLR0915
             field_name: Annotated[
                 str,
                 Query(
-                    alias="orderBy",
+                    alias=alias_for("order_by"),
                     description="Field to order by.",
                     required=False,
                 ),
@@ -618,7 +626,7 @@ def _create_filter_aggregate_function_fastapi(  # noqa: C901, PLR0915
             sort_order: Annotated[
                 Optional[SortOrder],
                 Query(
-                    alias="sortOrder",
+                    alias=alias_for("sort_order"),
                     description="Sort order ('asc' or 'desc').",
                     required=False,
                 ),
@@ -648,7 +656,7 @@ def _create_filter_aggregate_function_fastapi(  # noqa: C901, PLR0915
                     values: Annotated[  # type: ignore
                         Optional[set[field_name.type_hint]],  # pyright: ignore
                         Query(
-                            alias=camelize(f"{field_name.name}_not_in"),
+                            alias=alias_for(f"{field_name.name}_not_in"),
                             description=f"Filter {field_name.name} not in values",
                         ),
                     ] = None,
@@ -680,7 +688,7 @@ def _create_filter_aggregate_function_fastapi(  # noqa: C901, PLR0915
                     values: Annotated[  # type: ignore
                         Optional[set[field_name.type_hint]],  # pyright: ignore
                         Query(
-                            alias=camelize(f"{field_name.name}_in"),
+                            alias=alias_for(f"{field_name.name}_in"),
                             description=f"Filter {field_name.name} in values",
                         ),
                     ] = None,
@@ -710,7 +718,7 @@ def _create_filter_aggregate_function_fastapi(  # noqa: C901, PLR0915
                     value: Annotated[
                         Optional[bool],
                         Query(
-                            alias=camelize(field_name.name),
+                            alias=alias_for(field_name.name),
                             description=f"Filter {field_name.name} by boolean value",
                         ),
                     ] = None,
@@ -740,7 +748,7 @@ def _create_filter_aggregate_function_fastapi(  # noqa: C901, PLR0915
                     values: Annotated[  # type: ignore
                         Optional[list[field_name.type_hint]],  # pyright: ignore
                         Query(
-                            alias=camelize(field_name.name),
+                            alias=alias_for(field_name.name),
                             description=f"Filter {field_name.name} by allowed choices",
                         ),
                     ] = None,
@@ -760,12 +768,19 @@ def _create_filter_aggregate_function_fastapi(  # noqa: C901, PLR0915
             )
             annotations[param_name] = Annotated[Optional[ChoicesFilter[Any]], Depends(choices_provider)]
 
-    _aggregate_filter_function.__signature__ = inspect.Signature(  # type: ignore
+    # A fresh function per config. Assigning `__signature__` to the shared module-level
+    # `_aggregate_filter_function` would make every call to `provide_filters` overwrite the
+    # parameters of every dependency built before it, so two routers with different configs would
+    # both end up serving whichever config was built last.
+    aggregate_filters = partial(_aggregate_filter_function)
+
+    aggregate_filters.__signature__ = inspect.Signature(  # type: ignore[attr-defined]
         parameters=params,
-        return_annotation=Annotated[list[FilterTypes], Depends(_aggregate_filter_function)],
+        return_annotation=list[FilterTypes],
     )
 
-    return _aggregate_filter_function
+    aggregate_filters.__annotations__ = {**annotations, "return": list[FilterTypes]}
+    return aggregate_filters
 
 
 def _aggregate_filter_function(**kwargs: Any) -> list[FilterTypes]:

--- a/advanced_alchemy/extensions/litestar/providers.py
+++ b/advanced_alchemy/extensions/litestar/providers.py
@@ -9,6 +9,7 @@ You should not have modify this module very often and should only be invoked und
 import datetime
 import inspect
 from collections.abc import AsyncGenerator, Callable, Generator
+from functools import partial
 from typing import (
     TYPE_CHECKING,
     Annotated,
@@ -23,7 +24,8 @@ from typing import (
 from uuid import UUID
 
 from litestar.di import NamedDependency, Provide
-from litestar.params import FromQuery, QueryParameter, SkipValidation
+from litestar.params import QueryParameter, SkipValidation
+from litestar.utils.signature import ParsedSignature
 
 from advanced_alchemy.filters import (
     BeforeAfter,
@@ -50,10 +52,11 @@ from advanced_alchemy.utils.dependencies import (
     DependencyCache,
     FieldNameType,
     FilterConfig,
-    make_hashable,
+    filter_cache_key,
     normalize_choice_field_types,
     normalize_field_name_types,
     normalize_sort_field,
+    resolve_filter_aliases,
 )
 from advanced_alchemy.utils.singleton import SingletonMeta
 from advanced_alchemy.utils.text import camelize
@@ -319,11 +322,12 @@ def create_filter_dependencies(
     Returns:
         A dependency provider function for the combined filter function.
     """
-    cache_key = hash((_CACHE_NAMESPACE, make_hashable(config)))
+    aliases = resolve_filter_aliases(config)
+    cache_key = filter_cache_key(_CACHE_NAMESPACE, config, dep_defaults, aliases)
     deps = cast("Optional[dict[str, Provide]]", dep_cache.get_dependencies(cache_key))
     if deps is not None:
         return deps
-    deps = _create_statement_filters(config, dep_defaults)
+    deps = _create_statement_filters(config, dep_defaults, aliases=aliases)
     dep_cache.add_dependencies(cache_key, deps)
     return deps
 
@@ -331,6 +335,7 @@ def create_filter_dependencies(
 def _create_order_by_filter_provider(
     sort_field: Union[str, set[str], list[str]],
     sort_order_default: SortOrder = "desc",
+    alias_for: Callable[[str], str] = camelize,
 ) -> Callable[..., OrderBy]:
     sort_field_default = normalize_sort_field(sort_field)
 
@@ -339,14 +344,14 @@ def _create_order_by_filter_provider(
             StringOrNone,
             QueryParameter(
                 title="Order by field",
-                name="orderBy",
+                name=alias_for("order_by"),
             ),
         ] = sort_field_default,
         sort_order: Annotated[
             SortOrderOrNone,
             QueryParameter(
                 title="Field to search",
-                name="sortOrder",
+                name=alias_for("sort_order"),
             ),
         ] = sort_order_default,
     ) -> OrderBy:
@@ -356,23 +361,30 @@ def _create_order_by_filter_provider(
 
 
 def _create_statement_filters(  # noqa: C901, PLR0915
-    config: FilterConfig, dep_defaults: DependencyDefaults = DEPENDENCY_DEFAULTS
+    config: FilterConfig,
+    dep_defaults: DependencyDefaults = DEPENDENCY_DEFAULTS,
+    *,
+    include_aggregate: bool = True,
+    aliases: Optional[dict[str, str]] = None,
 ) -> dict[str, Provide]:
     """Create filter dependencies based on configuration.
 
     Args:
         config (FilterConfig): Configuration dictionary specifying which filters to enable
         dep_defaults (DependencyDefaults): Dependency defaults to use for the filter dependencies
+        include_aggregate: Include the combined dependency in the result.
+        aliases: Previously resolved public query names.
 
     Returns:
         dict[str, Provide]: Dictionary of filter provider functions
     """
     filters: dict[str, Provide] = {}
+    alias_for = (resolve_filter_aliases(config) if aliases is None else aliases).__getitem__
 
     if config.get("id_filter", False):
 
         def provide_id_filter(  # pyright: ignore[reportUnknownParameterType]
-            ids: FromQuery[Optional[list[str]]] = None,
+            ids: Annotated[Optional[list[str]], QueryParameter(name=alias_for("ids"))] = None,
         ) -> CollectionFilter:  # pyright: ignore[reportMissingTypeArgument]
             return CollectionFilter(field_name=config.get("id_field", "id"), values=ids)
 
@@ -381,8 +393,8 @@ def _create_statement_filters(  # noqa: C901, PLR0915
     if config.get("created_at", False):
 
         def provide_created_filter(
-            before: Annotated[DTorNone, QueryParameter(name="createdBefore")] = None,
-            after: Annotated[DTorNone, QueryParameter(name="createdAfter")] = None,
+            before: Annotated[DTorNone, QueryParameter(name=alias_for("created_before"))] = None,
+            after: Annotated[DTorNone, QueryParameter(name=alias_for("created_after"))] = None,
         ) -> BeforeAfter:
             return BeforeAfter("created_at", before, after)
 
@@ -391,8 +403,8 @@ def _create_statement_filters(  # noqa: C901, PLR0915
     if config.get("updated_at", False):
 
         def provide_updated_filter(
-            before: Annotated[DTorNone, QueryParameter(name="updatedBefore")] = None,
-            after: Annotated[DTorNone, QueryParameter(name="updatedAfter")] = None,
+            before: Annotated[DTorNone, QueryParameter(name=alias_for("updated_before"))] = None,
+            after: Annotated[DTorNone, QueryParameter(name=alias_for("updated_after"))] = None,
         ) -> BeforeAfter:
             return BeforeAfter("updated_at", before, after)
 
@@ -401,11 +413,11 @@ def _create_statement_filters(  # noqa: C901, PLR0915
     if config.get("pagination_type") == "limit_offset":
 
         def provide_limit_offset_pagination(
-            current_page: Annotated[int, QueryParameter(ge=1, name="currentPage")] = 1,
+            current_page: Annotated[int, QueryParameter(ge=1, name=alias_for("current_page"))] = 1,
             page_size: Annotated[
                 int,
                 QueryParameter(
-                    name="pageSize",
+                    name=alias_for("page_size"),
                     ge=1,
                 ),
             ] = config.get("pagination_size", dep_defaults.DEFAULT_PAGINATION_SIZE),
@@ -422,14 +434,14 @@ def _create_statement_filters(  # noqa: C901, PLR0915
             search_string: Annotated[
                 StringOrNone,
                 QueryParameter(
-                    name="searchString",
+                    name=alias_for("search_string"),
                     title="Field to search",
                 ),
             ] = None,
             ignore_case: Annotated[
                 BooleanOrNone,
                 QueryParameter(
-                    name="searchIgnoreCase",
+                    name=alias_for("search_ignore_case"),
                     title="Search should be case sensitive",
                 ),
             ] = config.get("search_ignore_case", False),
@@ -447,7 +459,7 @@ def _create_statement_filters(  # noqa: C901, PLR0915
 
     if sort_field := config.get("sort_field"):
         filters[dep_defaults.ORDER_BY_FILTER_DEPENDENCY_KEY] = Provide(
-            _create_order_by_filter_provider(sort_field, config.get("sort_order", "desc")),
+            _create_order_by_filter_provider(sort_field, config.get("sort_order", "desc"), alias_for),
             sync_to_thread=False,
         )
 
@@ -478,7 +490,7 @@ def _create_statement_filters(  # noqa: C901, PLR0915
 
                 annotation = Annotated[
                     Optional[list[field_name.type_hint]],  # type: ignore
-                    QueryParameter(name=camelize(param_name)),
+                    QueryParameter(name=alias_for(param_name)),
                 ]
                 provide_not_in_filter.__name__ = f"provide_not_in_filter_{field_name.name}"
                 provide_not_in_filter.__signature__ = inspect.Signature(  # type: ignore[attr-defined]
@@ -530,7 +542,7 @@ def _create_statement_filters(  # noqa: C901, PLR0915
                 annotation = Annotated[
                     Optional[list[field_name.type_hint]],  # type: ignore
                     QueryParameter(
-                        name=camelize(param_name),
+                        name=alias_for(param_name),
                     ),
                 ]
                 provide_in_filter.__signature__ = inspect.Signature(  # type: ignore[attr-defined]
@@ -567,7 +579,7 @@ def _create_statement_filters(  # noqa: C901, PLR0915
 
                 annotation = Annotated[
                     BooleanOrNone,
-                    QueryParameter(name=camelize(field_name.name)),
+                    QueryParameter(name=alias_for(field_name.name)),
                 ]
                 provide_boolean_filter.__name__ = f"provide_boolean_filter_{field_name.name}"
                 provide_boolean_filter.__signature__ = inspect.Signature(  # type: ignore[attr-defined]
@@ -608,7 +620,7 @@ def _create_statement_filters(  # noqa: C901, PLR0915
 
                 annotation = Annotated[
                     Optional[list[field_name.type_hint]],  # type: ignore
-                    QueryParameter(name=camelize(field_name.name)),
+                    QueryParameter(name=alias_for(field_name.name)),
                 ]
                 provide_choices_filter.__name__ = f"provide_choices_filter_{field_name.name}"
                 provide_choices_filter.__signature__ = inspect.Signature(  # type: ignore[attr-defined]
@@ -631,180 +643,53 @@ def _create_statement_filters(  # noqa: C901, PLR0915
             choices_provider = create_choices_filter_provider(choice_field_def)
             filters[f"{choice_field_def.name}_choices_filter"] = Provide(choices_provider, sync_to_thread=False)
 
-    if filters:
-        filters[dep_defaults.FILTERS_DEPENDENCY_KEY] = Provide(
-            _create_filter_aggregate_function(config), sync_to_thread=False
+    if filters and include_aggregate:
+        aggregate = _create_filter_aggregate_function(config, dep_defaults, filters)
+        dependency = Provide(aggregate, sync_to_thread=False)
+        dependency.parsed_fn_signature = ParsedSignature.from_signature(
+            inspect.signature(aggregate), aggregate.__annotations__
         )
+        filters[dep_defaults.FILTERS_DEPENDENCY_KEY] = dependency
 
     return filters
 
 
-def _create_filter_aggregate_function(config: FilterConfig) -> Callable[..., list[FilterTypes]]:  # noqa: C901, PLR0915
-    """Create a filter function based on the provided configuration.
-
-    Args:
-        config: The filter configuration.
-
-    Returns:
-        A function that returns a list of filters based on the configuration.
-    """
-
-    parameters: dict[str, inspect.Parameter] = {}
+def _create_filter_aggregate_function(
+    config: FilterConfig,
+    dep_defaults: DependencyDefaults = DEPENDENCY_DEFAULTS,
+    providers: Optional[dict[str, Provide]] = None,
+) -> Callable[..., list[FilterTypes]]:
+    """Build aggregate metadata from the registered dependencies themselves."""
+    if providers is None:
+        providers = _create_statement_filters(config, dep_defaults, include_aggregate=False)
+    keys = list(providers)
+    # Preserve the historical output order, including pagination before updated-at.
+    pagination = dep_defaults.LIMIT_OFFSET_FILTER_DEPENDENCY_KEY
+    updated = dep_defaults.UPDATED_FILTER_DEPENDENCY_KEY
+    if pagination in keys and updated in keys:
+        keys.remove(pagination)
+        keys.insert(keys.index(updated), pagination)
+    parameters: list[inspect.Parameter] = []
     annotations: dict[str, Any] = {}
+    for key in keys:
+        annotation = NamedDependency[SkipValidation[Any]]
+        parameters.append(inspect.Parameter(key, inspect.Parameter.KEYWORD_ONLY, annotation=annotation))
+        annotations[key] = annotation
+    aggregate = partial(_aggregate_filters, tuple(keys))
+    aggregate.__signature__ = inspect.Signature(parameters, return_annotation=list[FilterTypes])  # type: ignore[attr-defined]
+    aggregate.__annotations__ = {**annotations, "return": list[FilterTypes]}
+    return aggregate
 
-    # Build parameters based on config
-    if cls := config.get("id_filter"):
-        parameters["id_filter"] = inspect.Parameter(
-            name="id_filter",
-            kind=inspect.Parameter.POSITIONAL_OR_KEYWORD,
-            annotation=NamedDependency[SkipValidation[CollectionFilter[cls]]],  # type: ignore[valid-type]
-        )
-        annotations["id_filter"] = CollectionFilter[cls]  # type: ignore[valid-type]
 
-    if config.get("created_at"):
-        parameters["created_filter"] = inspect.Parameter(
-            name="created_filter",
-            kind=inspect.Parameter.POSITIONAL_OR_KEYWORD,
-            annotation=NamedDependency[SkipValidation[BeforeAfter]],
-        )
-        annotations["created_filter"] = BeforeAfter
-
-    if config.get("updated_at"):
-        parameters["updated_filter"] = inspect.Parameter(
-            name="updated_filter",
-            kind=inspect.Parameter.POSITIONAL_OR_KEYWORD,
-            annotation=NamedDependency[SkipValidation[BeforeAfter]],
-        )
-        annotations["updated_filter"] = BeforeAfter
-
-    if config.get("search"):
-        parameters["search_filter"] = inspect.Parameter(
-            name="search_filter",
-            kind=inspect.Parameter.POSITIONAL_OR_KEYWORD,
-            annotation=NamedDependency[SkipValidation[SearchFilter]],
-        )
-        annotations["search_filter"] = SearchFilter
-
-    if config.get("pagination_type") == "limit_offset":
-        parameters["limit_offset_filter"] = inspect.Parameter(
-            name="limit_offset_filter",
-            kind=inspect.Parameter.POSITIONAL_OR_KEYWORD,
-            annotation=NamedDependency[SkipValidation[LimitOffset]],
-        )
-        annotations["limit_offset_filter"] = LimitOffset
-
-    if config.get("sort_field"):
-        parameters["order_by_filter"] = inspect.Parameter(
-            name="order_by_filter",
-            kind=inspect.Parameter.POSITIONAL_OR_KEYWORD,
-            annotation=NamedDependency[SkipValidation[OrderBy,]],
-        )
-        annotations["order_by_filter"] = OrderBy
-
-    # Add parameters for not_in filters
-    if not_in_fields := config.get("not_in_fields"):
-        for field_def in normalize_field_name_types(not_in_fields):
-            annotation = NamedDependency[SkipValidation[NotInCollectionFilter[field_def.type_hint]]]  # type: ignore[name-defined]
-            parameters[f"{field_def.name}_not_in_filter"] = inspect.Parameter(
-                name=f"{field_def.name}_not_in_filter",
-                kind=inspect.Parameter.POSITIONAL_OR_KEYWORD,
-                annotation=annotation,
-            )
-            annotations[f"{field_def.name}_not_in_filter"] = annotation
-
-    # Add parameters for in filters
-    if in_fields := config.get("in_fields"):
-        for field_def in normalize_field_name_types(in_fields):
-            annotation = CollectionFilter[field_def.type_hint]  # type: ignore
-
-            parameters[f"{field_def.name}_in_filter"] = inspect.Parameter(
-                name=f"{field_def.name}_in_filter", kind=inspect.Parameter.POSITIONAL_OR_KEYWORD, annotation=annotation
-            )
-            annotations[f"{field_def.name}_in_filter"] = annotation
-
-    if boolean_fields := config.get("boolean_fields"):
-        for boolean_field_def in normalize_field_name_types(boolean_fields):
-            boolean_annotation = NamedDependency[SkipValidation[BooleanFilter]]
-            parameters[f"{boolean_field_def.name}_boolean_filter"] = inspect.Parameter(
-                name=f"{boolean_field_def.name}_boolean_filter",
-                kind=inspect.Parameter.POSITIONAL_OR_KEYWORD,
-                annotation=boolean_annotation,
-            )
-            annotations[f"{boolean_field_def.name}_boolean_filter"] = boolean_annotation
-
-    if choice_fields := config.get("choice_fields"):
-        for choice_field_def in normalize_choice_field_types(choice_fields):
-            choices_annotation = NamedDependency[SkipValidation[ChoicesFilter[choice_field_def.type_hint]]]  # type: ignore[name-defined]
-            parameters[f"{choice_field_def.name}_choices_filter"] = inspect.Parameter(
-                name=f"{choice_field_def.name}_choices_filter",
-                kind=inspect.Parameter.POSITIONAL_OR_KEYWORD,
-                annotation=choices_annotation,
-            )
-            annotations[f"{choice_field_def.name}_choices_filter"] = choices_annotation
-
-    def provide_filters(**kwargs: FilterTypes) -> list[FilterTypes]:  # noqa: C901
-        """Provide filter dependencies based on configuration.
-
-        Args:
-            **kwargs: Filter parameters dynamically provided based on configuration.
-
-        Returns:
-            list[FilterTypes]: List of configured filters.
-        """
-        filters: list[FilterTypes] = []
-        if id_filter := kwargs.get("id_filter"):
-            filters.append(id_filter)
-        if created_filter := kwargs.get("created_filter"):
-            filters.append(created_filter)
-        if limit_offset := kwargs.get("limit_offset_filter"):
-            filters.append(limit_offset)
-        if updated_filter := kwargs.get("updated_filter"):
-            filters.append(updated_filter)
-        if (
-            (search_filter := cast("Optional[SearchFilter]", kwargs.get("search_filter")))
-            and search_filter is not None  # pyright: ignore[reportUnnecessaryComparison]
-            and search_filter.field_name is not None  # pyright: ignore[reportUnnecessaryComparison]
-            and search_filter.value is not None  # pyright: ignore[reportUnnecessaryComparison]
-        ):
-            filters.append(search_filter)
-        if (
-            (order_by := cast("Optional[OrderBy]", kwargs.get("order_by_filter")))
-            and order_by is not None  # pyright: ignore[reportUnnecessaryComparison]
-            and order_by.field_name is not None  # pyright: ignore[reportUnnecessaryComparison]
-        ):
-            filters.append(order_by)
-
-        # Add not_in filters
-        if not_in_fields := config.get("not_in_fields"):
-            for field_def in normalize_field_name_types(not_in_fields):
-                filter_ = kwargs.get(f"{field_def.name}_not_in_filter")
-                if filter_ is not None:
-                    filters.append(filter_)
-
-        # Add in filters
-        if in_fields := config.get("in_fields"):
-            for field_def in normalize_field_name_types(in_fields):
-                filter_ = kwargs.get(f"{field_def.name}_in_filter")
-                if filter_ is not None:
-                    filters.append(filter_)
-        if boolean_fields := config.get("boolean_fields"):
-            for field_def in normalize_field_name_types(boolean_fields):
-                filter_ = kwargs.get(f"{field_def.name}_boolean_filter")
-                if filter_ is not None:
-                    filters.append(filter_)
-        if choice_fields := config.get("choice_fields"):
-            for field_def in normalize_choice_field_types(choice_fields):
-                filter_ = kwargs.get(f"{field_def.name}_choices_filter")
-                if filter_ is not None:
-                    filters.append(filter_)
-        return filters
-
-    # Set both signature and annotations
-    provide_filters.__signature__ = inspect.Signature(  # type: ignore
-        parameters=list(parameters.values()),
-        return_annotation=list[FilterTypes],
-    )
-    provide_filters.__annotations__ = annotations
-    provide_filters.__annotations__["return"] = list[FilterTypes]
-
-    return provide_filters
+def _aggregate_filters(keys: tuple[str, ...], **kwargs: Any) -> list[FilterTypes]:
+    filters: list[FilterTypes] = []
+    for key in keys:
+        value = kwargs.get(key)
+        if value is None:
+            continue
+        if isinstance(value, SearchFilter) and (value.field_name is None or value.value is None):  # pyright: ignore[reportUnnecessaryComparison]
+            continue  # type: ignore[unreachable]
+        if isinstance(value, OrderBy) and value.field_name is None:
+            continue  # type: ignore[unreachable]
+        filters.append(value)
+    return filters

--- a/advanced_alchemy/utils/dependencies.py
+++ b/advanced_alchemy/utils/dependencies.py
@@ -4,7 +4,7 @@ These primitives are framework-agnostic and reused by framework
 ``advanced_alchemy.extensions`` provider modules.
 """
 
-from collections.abc import Iterable, Mapping
+from collections.abc import Callable, Iterable, Mapping
 from dataclasses import dataclass
 from typing import Any, Literal, NamedTuple, Optional, Union, cast
 from uuid import UUID
@@ -99,6 +99,19 @@ class FilterConfig(TypedDict):
     """Fields that support boolean filters."""
     choice_fields: NotRequired[ChoiceFieldConfig]
     """Fields that support choices filters."""
+    alias_generator: NotRequired[Callable[[str], str]]
+    """Maps a parameter's snake_case name to its public query parameter.
+
+    Supported by both Litestar and FastAPI.
+
+    Receives ``created_before``, ``page_size``, ``sort_order``, or a model field name for the
+    per-field filters. Defaults to :func:`~advanced_alchemy.utils.text.camelize`, which produces the
+    names this has always generated (``createdBefore``, ``pageSize``, ``sortOrder``). Pass
+    ``lambda name: name`` to keep snake_case instead.
+
+    An explicit generator must give every parameter a distinct name; one shared between two filters is rejected when the
+    dependency is built, because the framework would bind the single value to both.
+    """
 
 
 class DependencyCache(metaclass=SingletonMeta):
@@ -266,3 +279,47 @@ def normalize_sort_field(sort_field: SortField) -> str:
     if isinstance(sort_field, list):
         return sort_field[0]
     return sorted(sort_field)[0]
+
+
+def resolve_filter_aliases(config: FilterConfig) -> dict[str, str]:
+    """Resolve public query names once, validating only opt-in custom naming."""
+    from advanced_alchemy.exceptions import ImproperConfigurationError
+    from advanced_alchemy.utils.text import camelize
+
+    names: list[str] = []
+    for key, parameters in (
+        ("id_filter", ("ids",)),
+        ("created_at", ("created_before", "created_after")),
+        ("updated_at", ("updated_before", "updated_after")),
+        ("pagination_type", ("current_page", "page_size")),
+        ("search", ("search_string", "search_ignore_case")),
+        ("sort_field", ("order_by", "sort_order")),
+    ):
+        if config.get(key):
+            names.extend(parameters)
+    for key, suffix in (("not_in_fields", "_not_in"), ("in_fields", "_in"), ("boolean_fields", "")):
+        if fields := config.get(key):
+            names.extend(field.name + suffix for field in normalize_field_name_types(cast("FieldNameConfig", fields)))
+    if choices := config.get("choice_fields"):
+        names.extend(field.name for field in normalize_choice_field_types(choices))
+    generator = config.get("alias_generator")
+    resolved: dict[str, str] = {}
+    claimed: set[str] = set()
+    for name in names:
+        alias: Any = camelize(name) if generator is None else generator(name)
+        if generator is not None and (not isinstance(alias, str) or not alias or alias in claimed):
+            msg = f"Filter parameter {name!r} has an invalid or duplicate query parameter {alias!r}"
+            raise ImproperConfigurationError(msg)
+        claimed.add(alias)
+        resolved[name] = alias
+    return resolved
+
+
+def filter_cache_key(namespace: str, config: FilterConfig, defaults: Any, aliases: dict[str, str]) -> tuple[Any, ...]:
+    """Cache effective configuration and names, retaining complete values for equality."""
+    values = {key: value for key, value in config.items() if key != "alias_generator"}
+    default_values = tuple(
+        (name, getattr(defaults, name))
+        for name in sorted({name for cls in type(defaults).__mro__ for name in getattr(cls, "__annotations__", {})})
+    )
+    return namespace, make_hashable(values), make_hashable(default_values), make_hashable(aliases)

--- a/advanced_alchemy/utils/dependencies.py
+++ b/advanced_alchemy/utils/dependencies.py
@@ -99,7 +99,7 @@ class FilterConfig(TypedDict):
     """Fields that support boolean filters."""
     choice_fields: NotRequired[ChoiceFieldConfig]
     """Fields that support choices filters."""
-    alias_generator: NotRequired[Callable[[str], str]]
+    alias_generator: NotRequired[Union[Literal["snake_case", "camel_case"], Callable[[str], str]]]
     """Maps a parameter's snake_case name to its public query parameter.
 
     Supported by both Litestar and FastAPI.
@@ -107,7 +107,8 @@ class FilterConfig(TypedDict):
     Receives ``created_before``, ``page_size``, ``sort_order``, or a model field name for the
     per-field filters. Defaults to :func:`~advanced_alchemy.utils.text.camelize`, which produces the
     names this has always generated (``createdBefore``, ``pageSize``, ``sortOrder``). Pass
-    ``lambda name: name`` to keep snake_case instead.
+    ``"snake_case"`` to keep snake_case instead, or ``"camel_case"`` for explicit camelCase.
+    A callable supports application-specific naming conventions.
 
     An explicit generator must give every parameter a distinct name; one shared between two filters is rejected when the
     dependency is built, because the framework would bind the single value to both.
@@ -303,10 +304,17 @@ def resolve_filter_aliases(config: FilterConfig) -> dict[str, str]:
     if choices := config.get("choice_fields"):
         names.extend(field.name for field in normalize_choice_field_types(choices))
     generator = config.get("alias_generator")
+    if isinstance(generator, str) and generator not in {"snake_case", "camel_case"}:
+        msg = f"Unknown filter alias preset {generator!r}; expected snake_case or camel_case"
+        raise ImproperConfigurationError(msg)
     resolved: dict[str, str] = {}
     claimed: set[str] = set()
     for name in names:
-        alias: Any = camelize(name) if generator is None else generator(name)
+        alias: Any
+        if isinstance(generator, str):
+            alias = name if generator == "snake_case" else camelize(name)
+        else:
+            alias = camelize(name) if generator is None else generator(name)
         if generator is not None and (not isinstance(alias, str) or not alias or alias in claimed):
             msg = f"Filter parameter {name!r} has an invalid or duplicate query parameter {alias!r}"
             raise ImproperConfigurationError(msg)

--- a/docs/usage/repositories/filtering.rst
+++ b/docs/usage/repositories/filtering.rst
@@ -117,3 +117,34 @@ All read and count operations support an optional ``bind_group`` parameter for e
     async def get_posts_from_analytics_replica(db_session: AsyncSession) -> list[FilteringPost]:
         repository = FilteringPostRepository(session=db_session)
         return await repository.get_many(bind_group="analytics")
+
+Generated query parameter names
+-------------------------------
+
+The Litestar ``create_filter_dependencies()`` and FastAPI ``provide_filters()`` helpers
+accept the same optional ``alias_generator`` configuration. Existing names such as
+``pageSize``, ``searchString``, and ``orderBy`` remain the default. To expose snake_case
+query parameters in either integration:
+
+.. code-block:: python
+
+    from advanced_alchemy.utils.dependencies import FilterConfig
+
+    config: FilterConfig = {
+        "pagination_type": "limit_offset",
+        "search": "name",
+        "sort_field": "created_at",
+        "alias_generator": lambda name: name,
+    }
+
+This configuration accepts ``?page_size=10&search_string=alice&order_by=created_at``.
+The generator receives canonical snake_case parameter names, including field-specific
+names such as ``account_id_in``. Custom generators must return nonempty, distinct
+strings. Names are resolved when dependencies are constructed and used consistently
+for requests and OpenAPI; the generator does not run during requests.
+
+This option controls query parameter names. It does not translate sort-field values
+or change the internal dependency names configured through ``DependencyDefaults``.
+Dependencies with equivalent configuration, defaults, and resolved query names reuse
+the same cached provider. Different pagination defaults or dependency names remain
+isolated.

--- a/docs/usage/repositories/filtering.rst
+++ b/docs/usage/repositories/filtering.rst
@@ -134,10 +134,12 @@ query parameters in either integration:
         "pagination_type": "limit_offset",
         "search": "name",
         "sort_field": "created_at",
-        "alias_generator": lambda name: name,
+        "alias_generator": "snake_case",
     }
 
 This configuration accepts ``?page_size=10&search_string=alice&order_by=created_at``.
+Use ``"camel_case"`` to explicitly select camelCase, or supply a callable for custom
+conventions. An explicit preset follows the same collision validation as a callable.
 The generator receives canonical snake_case parameter names, including field-specific
 names such as ``account_id_in``. Custom generators must return nonempty, distinct
 strings. Names are resolved when dependencies are constructed and used consistently

--- a/tests/unit/test_extensions/test_fastapi/test_providers.py
+++ b/tests/unit/test_extensions/test_fastapi/test_providers.py
@@ -6,7 +6,7 @@ import typing
 from collections.abc import AsyncGenerator
 from datetime import datetime
 from enum import Enum, IntEnum
-from typing import Annotated, Union, cast
+from typing import Annotated, Any, Union, cast
 from unittest.mock import patch
 from uuid import UUID
 
@@ -17,11 +17,12 @@ from sqlalchemy import String
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import Mapped, mapped_column
 
-# Assuming necessary classes are importable from the new provider module
 from advanced_alchemy.base import UUIDBase
+
+# Assuming necessary classes are importable from the new provider module
+from advanced_alchemy.exceptions import ImproperConfigurationError
 from advanced_alchemy.extensions.fastapi import SQLAlchemyAsyncConfig
 from advanced_alchemy.extensions.fastapi.providers import (
-    _CACHE_NAMESPACE,  # pyright: ignore[reportPrivateUsage]
     DEPENDENCY_DEFAULTS,
     ChoiceField,
     DependencyCache,
@@ -44,7 +45,6 @@ from advanced_alchemy.filters import (
 )
 from advanced_alchemy.repository import SQLAlchemyAsyncRepository
 from advanced_alchemy.service import SQLAlchemyAsyncRepositoryService
-from advanced_alchemy.utils.dependencies import make_hashable
 from advanced_alchemy.utils.singleton import SingletonMeta
 
 if sys.version_info >= (3, 11):
@@ -116,7 +116,11 @@ def test_create_filter_dependencies_cache_hit() -> None:
 def test_create_filter_dependencies_cache_miss() -> None:
     """Test create_filter_dependencies with cache miss."""
     config = cast(FilterConfig, {"created_at": True})
-    cache_key = hash((_CACHE_NAMESPACE, make_hashable(config)))
+    from advanced_alchemy.utils.dependencies import filter_cache_key, resolve_filter_aliases
+
+    cache_key = filter_cache_key(
+        "advanced_alchemy.extensions.fastapi.providers", config, DEPENDENCY_DEFAULTS, resolve_filter_aliases(config)
+    )
     mock_agg_func = lambda: [  # noqa: E731
         BeforeAfter(field_name="created_at", before=None, after=None)
     ]  # Dummy aggregate function
@@ -134,7 +138,7 @@ def test_create_filter_dependencies_cache_miss() -> None:
                 mock_get.assert_called_once_with(cache_key)
 
                 # Verify _create_filter_aggregate_function_fastapi was called
-                mock_create.assert_called_once_with(config, DEPENDENCY_DEFAULTS)
+                mock_create.assert_called_once()
 
                 # Verify cache was updated with the created dependencies
                 # We need to compare the structure, not object identity of Depends(mock_agg_func)
@@ -170,9 +174,7 @@ def test_create_filter_aggregate_function_fastapi() -> None:
     assert DEPENDENCY_DEFAULTS.ORDER_BY_FILTER_DEPENDENCY_KEY in sig.parameters
 
     # Check return annotation origin type (list) and its argument (FilterTypes)
-    assert hasattr(sig.return_annotation, "__origin__")
-    assert typing.get_origin(sig.return_annotation) is Annotated
-    assert sig.return_annotation.__args__[0] == list[FilterTypes]
+    assert sig.return_annotation == list[FilterTypes]
 
     for param_name, param in sig.parameters.items():
         # Check annotation (Optional[...] for filters that can return None)
@@ -889,3 +891,224 @@ async def test_provide_filters_with_dishka_integration(monkeypatch: pytest.Monke
     assert len(filter_types) == 1  # type: ignore
 
     await container.close()
+
+
+CONFIG: dict[str, Any] = {
+    "pagination_type": "limit_offset",
+    "search": "name",
+    "sort_field": "created_at",
+    "created_at": True,
+    "boolean_fields": ["is_active"],
+    "in_fields": ["status"],
+}
+
+
+def _parameter_names(config: dict[str, Any]) -> list[str]:
+    app = FastAPI()
+    dependency = provide_filters(cast(FilterConfig, config))
+
+    @app.get("/things")
+    async def list_things(filters: Annotated[list[Any], Depends(dependency)]) -> list[Any]:
+        return filters
+
+    return [parameter["name"] for parameter in app.openapi()["paths"]["/things"]["get"]["parameters"]]
+
+
+def test_default_names_are_unchanged() -> None:
+    """The default generator is `camelize`, which reproduces the previously hardcoded names."""
+    assert _parameter_names(dict(CONFIG)) == [
+        "createdBefore",
+        "createdAfter",
+        "currentPage",
+        "pageSize",
+        "searchString",
+        "searchIgnoreCase",
+        "orderBy",
+        "sortOrder",
+        "statusIn",
+        "isActive",
+    ]
+
+
+def test_alias_generator_renames_every_parameter() -> None:
+    """Including the per-field filters, which were camelized from the model's own field names."""
+    assert _parameter_names({**CONFIG, "alias_generator": lambda name: name}) == [
+        "created_before",
+        "created_after",
+        "current_page",
+        "page_size",
+        "search_string",
+        "search_ignore_case",
+        "order_by",
+        "sort_order",
+        "status_in",
+        "is_active",
+    ]
+
+
+def test_distinct_generators_get_distinct_dependencies() -> None:
+    """Two generators must not collide in the dependency cache.
+
+    A function hashes by identity, and CPython reuses the address of a collected object — so a key
+    that does not keep the generator alive can hand the second config the first one's providers.
+    """
+    snake = _parameter_names({**CONFIG, "alias_generator": lambda name: name})
+    upper = _parameter_names({**CONFIG, "alias_generator": lambda name: name.upper()})
+
+    assert snake[0] == "created_before"
+    assert upper[0] == "CREATED_BEFORE"
+    assert _parameter_names(dict(CONFIG))[0] == "createdBefore", "the default config must be unaffected"
+
+
+def test_a_generator_that_collides_is_rejected() -> None:
+    """Sharing a query parameter is silent and destructive, so it has to fail at build time.
+
+    FastAPI binds the one value to both parameters, so a `created_before`/`created_after` pair
+    collapsed onto a single name asks for `< x AND > x` and quietly matches nothing.
+    """
+    with pytest.raises(ImproperConfigurationError, match="duplicate query parameter 'created'"):
+        _parameter_names({"created_at": True, "alias_generator": lambda name: name.split("_")[0]})
+
+
+def test_default_alias_collisions_preserve_existing_configuration() -> None:
+    assert _parameter_names({"boolean_fields": ["status_in"], "in_fields": ["status"]}) == ["statusIn"]
+
+
+@pytest.mark.parametrize("field", ["created", "updated"])
+@pytest.mark.parametrize("bound", ["before", "after"])
+def test_custom_date_alias_validation_location(field: str, bound: str) -> None:
+    app = FastAPI()
+    dependency = provide_filters(cast(FilterConfig, {f"{field}_at": True, "alias_generator": str.upper}))
+
+    @app.get("/things")
+    async def list_things(filters: Annotated[list[Any], Depends(dependency)]) -> list[Any]:
+        return filters
+
+    alias = f"{field}_{bound}".upper()
+    with TestClient(app) as client:
+        response = client.get("/things", params={alias: "invalid"})
+    assert response.status_code == 422
+    assert response.json()["detail"][0]["loc"] == ["query", alias]
+
+
+def test_unhashable_falsy_generators_keep_distinct_cached_aliases() -> None:
+    from dataclasses import dataclass
+
+    @dataclass
+    class Generator:
+        prefix: str
+
+        def __bool__(self) -> bool:
+            return False
+
+        def __str__(self) -> str:
+            return "same"
+
+        def __call__(self, name: str) -> str:
+            return self.prefix + name
+
+    first = Generator("first_")
+    second = Generator("second_")
+    assert _parameter_names({"pagination_type": "limit_offset", "alias_generator": first}) == [
+        "first_current_page",
+        "first_page_size",
+    ]
+    assert _parameter_names({"pagination_type": "limit_offset", "alias_generator": second}) == [
+        "second_current_page",
+        "second_page_size",
+    ]
+    config: FilterConfig = {"pagination_type": "limit_offset", "alias_generator": first}
+    assert provide_filters(config) is provide_filters(config.copy())
+
+
+def _query_parameter_names(app: FastAPI, path: str) -> list[str]:
+    return [parameter["name"] for parameter in app.openapi()["paths"][path]["get"].get("parameters", [])]
+
+
+def test_two_configs_do_not_share_one_signature() -> None:
+    """Building a second dependency must not rewrite the first one's parameters.
+
+    The aggregate function used to be a single module-level object whose `__signature__` was
+    reassigned per config, so the last config built won and every earlier router silently served
+    the wrong query parameters.
+    """
+    app = FastAPI()
+    authors = provide_filters({"search": "name"})
+    books = provide_filters({"created_at": True})
+
+    @app.get("/authors")
+    async def list_authors(filters: Annotated[list[Any], Depends(authors)]) -> list[Any]:
+        return filters
+
+    @app.get("/books")
+    async def list_books(filters: Annotated[list[Any], Depends(books)]) -> list[Any]:
+        return filters
+
+    with TestClient(app) as client:
+        response = client.get("/authors", params={"searchString": "needle"})
+        assert response.status_code == 200
+        assert response.json()[0]["value"] == "needle"
+        response = client.get("/books", params={"createdAfter": "2025-01-01T00:00:00Z"})
+        assert response.status_code == 200
+        assert response.json()[0]["field_name"] == "created_at"
+        assert response.json()[0]["after"].startswith("2025-01-01")
+
+    assert authors is not books
+    assert _query_parameter_names(app, "/authors") == ["searchString", "searchIgnoreCase"]
+    assert _query_parameter_names(app, "/books") == ["createdBefore", "createdAfter"]
+
+
+def _cached_config() -> FilterConfig:
+    """A fresh, equal config each call, so the cache is exercised by value rather than by identity."""
+    return {"search": "name", "pagination_type": "limit_offset"}
+
+
+def test_the_same_config_is_still_cached() -> None:
+    """The per-config cache is what keeps repeated identical configs cheap; it should still hit."""
+    assert provide_filters(_cached_config()) is provide_filters(_cached_config())
+
+
+class _BigPages(DependencyDefaults):
+    DEFAULT_PAGINATION_SIZE = 100
+
+
+def _page_size(dependency: Any, path: str) -> Any:
+    app = FastAPI()
+
+    @app.get(path)
+    async def endpoint(filters: Annotated[list[Any], Depends(dependency)]) -> list[Any]:
+        return filters
+
+    with TestClient(app) as client:
+        response = client.get(path, params={"currentPage": 2})
+        assert response.status_code == 200
+        result = response.json()[0]
+        assert result["offset"] == result["limit"]
+
+    parameters = app.openapi()["paths"][path]["get"]["parameters"]
+    page_size = next(p["schema"]["default"] for p in parameters if p["name"] == "pageSize")
+    assert result["limit"] == page_size
+    return page_size
+
+
+def test_one_config_with_two_dependency_defaults_does_not_share_a_dependency() -> None:
+    """`dep_defaults` shapes the signature too, so it has to take part in the cache key.
+
+    Keyed on the config alone, whichever defaults were built first won for the whole process, and
+    the other caller silently served a page size it never asked for.
+    """
+    config: FilterConfig = {"pagination_type": "limit_offset"}
+
+    default = provide_filters(dict(config))  # type: ignore[arg-type]
+    big = provide_filters(dict(config), _BigPages())  # type: ignore[arg-type]
+
+    assert default is not big
+    assert _page_size(default, "/default") == DEPENDENCY_DEFAULTS.DEFAULT_PAGINATION_SIZE
+    assert _page_size(big, "/big") == _BigPages.DEFAULT_PAGINATION_SIZE
+
+
+def test_equal_dependency_defaults_still_share_a_dependency() -> None:
+    """Keying on the values rather than the instance is what keeps the cache useful here."""
+    assert provide_filters(_cached_config(), DependencyDefaults()) is provide_filters(
+        _cached_config(), DependencyDefaults()
+    )

--- a/tests/unit/test_extensions/test_litestar/test_providers.py
+++ b/tests/unit/test_extensions/test_litestar/test_providers.py
@@ -1208,7 +1208,7 @@ def test_custom_query_aliases_match_requests_and_openapi() -> None:
         "sort_field": "created_at",
         "in_fields": ["account_id"],
         "boolean_fields": ["is_active"],
-        "alias_generator": lambda name: name,
+        "alias_generator": "snake_case",
     }
 
     @get("/aliased")

--- a/tests/unit/test_extensions/test_litestar/test_providers.py
+++ b/tests/unit/test_extensions/test_litestar/test_providers.py
@@ -6,6 +6,7 @@ import inspect
 import sys
 import unittest.mock
 import uuid
+from dataclasses import asdict
 from datetime import datetime, timedelta
 from enum import Enum, IntEnum
 from typing import TYPE_CHECKING, Any, cast
@@ -351,7 +352,7 @@ def test_create_filter_dependencies_cache_miss() -> None:
                 mock_get.assert_called_once()
 
                 # Verify _create_statement_filters was called
-                mock_create.assert_called_once_with(config, DEPENDENCY_DEFAULTS)
+                mock_create.assert_called_once()
 
                 # Verify cache was updated
                 mock_add.assert_called_once()
@@ -708,6 +709,82 @@ def test_litestar_not_in_filter_values_are_isolated() -> None:
     payload = response.json()
     assert payload["first_name"] == ["Sezer"]
     assert payload["last_name"] == ["Tasan"]
+
+
+def test_filter_cache_separates_page_size_defaults() -> None:
+    class BigPages(DependencyDefaults):
+        DEFAULT_PAGINATION_SIZE = 100
+
+    config: FilterConfig = {"pagination_type": "limit_offset"}
+    default = create_filter_dependencies(config)
+    big = create_filter_dependencies(config, BigPages())
+    assert default is not big
+    key = DEPENDENCY_DEFAULTS.LIMIT_OFFSET_FILTER_DEPENDENCY_KEY
+    assert default[key].dependency().limit == 20
+    assert big[key].dependency().limit == 100
+
+
+def test_filter_cache_shares_equal_defaults() -> None:
+    config: FilterConfig = {"pagination_type": "limit_offset"}
+    assert create_filter_dependencies(config, DependencyDefaults()) is create_filter_dependencies(
+        config, DependencyDefaults()
+    )
+
+
+def test_custom_dependency_defaults_are_resolved_in_requests() -> None:
+    class CustomDefaults(DependencyDefaults):
+        FILTERS_DEPENDENCY_KEY = "custom_filters"
+        ID_FILTER_DEPENDENCY_KEY = "custom_ids"
+        CREATED_FILTER_DEPENDENCY_KEY = "custom_created"
+        UPDATED_FILTER_DEPENDENCY_KEY = "custom_updated"
+        LIMIT_OFFSET_FILTER_DEPENDENCY_KEY = "custom_page"
+        SEARCH_FILTER_DEPENDENCY_KEY = "custom_search"
+        ORDER_BY_FILTER_DEPENDENCY_KEY = "custom_order"
+        DEFAULT_PAGINATION_SIZE = 100
+
+    config: FilterConfig = {
+        "id_filter": str,
+        "created_at": True,
+        "updated_at": True,
+        "pagination_type": "limit_offset",
+        "search": "name",
+        "sort_field": "name",
+    }
+    default_dependencies = create_filter_dependencies(config)
+    custom_dependencies = create_filter_dependencies(config, CustomDefaults())
+    assert default_dependencies is not custom_dependencies
+
+    @get("/default", dependencies=default_dependencies, sync_to_thread=False)
+    def default_handler(filters: NamedDependency[SkipValidation[list[FilterTypes]]]) -> list[int]:
+        return [filter_.limit for filter_ in filters if isinstance(filter_, LimitOffset)]
+
+    @get("/custom", dependencies=custom_dependencies, sync_to_thread=False)
+    def custom_handler(custom_filters: NamedDependency[SkipValidation[list[FilterTypes]]]) -> dict[str, Any]:
+        return {
+            "types": [type(filter_).__name__ for filter_ in custom_filters],
+            "fields": [str(filter_.field_name) for filter_ in custom_filters if isinstance(filter_, BeforeAfter)],
+            "pages": [
+                [filter_.limit, filter_.offset] for filter_ in custom_filters if isinstance(filter_, LimitOffset)
+            ],
+            "ids": [list(filter_.values or []) for filter_ in custom_filters if isinstance(filter_, CollectionFilter)],
+            "search": [filter_.value for filter_ in custom_filters if isinstance(filter_, SearchFilter)],
+            "sort": [filter_.field_name for filter_ in custom_filters if isinstance(filter_, OrderBy)],
+        }
+
+    with TestClient(Litestar([default_handler, custom_handler])) as client:
+        response = client.get("/default")
+        assert response.status_code == 200
+        assert response.json() == [20]
+        response = client.get("/custom", params={"ids": "42", "searchString": "needle", "currentPage": 2})
+        assert response.status_code == 200
+        assert response.json() == {
+            "types": ["CollectionFilter", "BeforeAfter", "LimitOffset", "BeforeAfter", "SearchFilter", "OrderBy"],
+            "fields": ["created_at", "updated_at"],
+            "pages": [[100, 100]],
+            "ids": [["42"]],
+            "search": ["needle"],
+            "sort": ["name"],
+        }
 
 
 def test_custom_dependency_defaults() -> None:
@@ -1122,3 +1199,51 @@ def test_litestar_openapi_schema(mock_create_filters: unittest.mock.MagicMock) -
         if schema.get("type") == "array"
     )
     assert state_array_schema["items"]["type"] == "string"
+
+
+def test_custom_query_aliases_match_requests_and_openapi() -> None:
+    config: FilterConfig = {
+        "pagination_type": "limit_offset",
+        "search": "name",
+        "sort_field": "created_at",
+        "in_fields": ["account_id"],
+        "boolean_fields": ["is_active"],
+        "alias_generator": lambda name: name,
+    }
+
+    @get("/aliased")
+    def handler(filters: NamedDependency[SkipValidation[list[FilterTypes]]]) -> dict[str, Any]:
+        return {type(item).__name__: asdict(item) for item in filters}
+
+    app = Litestar(route_handlers=[handler], dependencies=create_filter_dependencies(config))
+    with TestClient(app) as client:
+        response = client.get(
+            "/aliased",
+            params={
+                "page_size": 7,
+                "current_page": 3,
+                "search_string": "needle",
+                "order_by": "other_field",
+                "account_id_in": "abc",
+                "is_active": "false",
+            },
+        )
+        assert response.status_code == 200, response.text
+        data = response.json()
+        assert data["LimitOffset"] == {"limit": 7, "offset": 14}
+        assert data["SearchFilter"]["value"] == "needle"
+        assert data["OrderBy"]["field_name"] == "other_field"
+        assert data["CollectionFilter"]["values"] == ["abc"]
+        assert data["BooleanFilter"]["value"] is False
+        schema = client.get("/schema/openapi.json").json()
+    names = {item["name"] for item in schema["paths"]["/aliased"]["get"]["parameters"]}
+    assert names == {
+        "page_size",
+        "current_page",
+        "search_string",
+        "search_ignore_case",
+        "order_by",
+        "sort_order",
+        "account_id_in",
+        "is_active",
+    }

--- a/tests/unit/test_utils/test_dependencies.py
+++ b/tests/unit/test_utils/test_dependencies.py
@@ -139,3 +139,39 @@ def test_dependency_cache_get_set_by_config() -> None:
         cache.set(config, dependencies)
 
         assert cache.get(config) == dependencies
+
+
+def test_filter_cache_uses_resolved_names_across_frameworks() -> None:
+    from advanced_alchemy.extensions.fastapi.providers import provide_filters
+    from advanced_alchemy.extensions.litestar.providers import create_filter_dependencies
+
+    class Generator:
+        def __init__(self, prefix: str) -> None:
+            self.prefix = prefix
+
+        def __call__(self, name: str) -> str:
+            return self.prefix + name
+
+        def __bool__(self) -> bool:
+            return False
+
+    for factory in (provide_filters, create_filter_dependencies):
+        generator = Generator("first_")
+        config: FilterConfig = {"search": "name", "alias_generator": generator}
+        first = factory(config)
+        assert first is factory({"search": "name", "alias_generator": Generator("first_")})
+        generator.prefix = "second_"
+        assert first is not factory(config)
+
+
+def test_custom_alias_validation_is_opt_in_for_both_frameworks() -> None:
+    import pytest
+
+    from advanced_alchemy.exceptions import ImproperConfigurationError
+    from advanced_alchemy.extensions.fastapi.providers import provide_filters
+    from advanced_alchemy.extensions.litestar.providers import create_filter_dependencies
+
+    for factory in (provide_filters, create_filter_dependencies):
+        factory({"boolean_fields": ["status_in"], "in_fields": ["status"]})
+        with pytest.raises(ImproperConfigurationError, match="duplicate query parameter"):
+            factory({"created_at": True, "alias_generator": lambda name: "same"})

--- a/tests/unit/test_utils/test_dependencies.py
+++ b/tests/unit/test_utils/test_dependencies.py
@@ -175,3 +175,19 @@ def test_custom_alias_validation_is_opt_in_for_both_frameworks() -> None:
         factory({"boolean_fields": ["status_in"], "in_fields": ["status"]})
         with pytest.raises(ImproperConfigurationError, match="duplicate query parameter"):
             factory({"created_at": True, "alias_generator": lambda name: "same"})
+
+
+def test_alias_presets_share_effective_names_across_frameworks() -> None:
+    import pytest
+
+    from advanced_alchemy.exceptions import ImproperConfigurationError
+    from advanced_alchemy.extensions.fastapi.providers import provide_filters
+    from advanced_alchemy.extensions.litestar.providers import create_filter_dependencies
+
+    for factory in (provide_filters, create_filter_dependencies):
+        assert factory({"search": "name", "alias_generator": "snake_case"}) is factory(
+            {"search": "name", "alias_generator": lambda name: name}
+        )
+        assert factory({"search": "name", "alias_generator": "camel_case"}) is factory({"search": "name"})
+        with pytest.raises(ImproperConfigurationError, match="Unknown filter alias preset"):
+            factory(cast(FilterConfig, {"search": "name", "alias_generator": "typo"}))


### PR DESCRIPTION
Generated filter dependencies could inherit another route's query parameters or pagination defaults because FastAPI reused one signature and both integrations omitted dependency defaults from their cache keys.

Give each configuration its own aggregate, derive Litestar aggregate inputs from registered providers, and share cache keys based on configuration, defaults, and resolved query names. This follows SQLSpec's aggregate provider pattern.

Both Litestar and FastAPI now accept naming presets or a custom callable:

```python
{"alias_generator": "snake_case"}  # page_size, search_string, order_by
{"alias_generator": "camel_case"}  # pageSize, searchString, orderBy
{"alias_generator": lambda name: f"filter_{name}"}
```

Omitting the option preserves existing query names and default collision behavior. Explicit presets and callables must produce nonempty, distinct names. Names are resolved during dependency construction and used for requests and OpenAPI; generators do not run during requests. Sort-field values and pagination defaults remain unchanged. The filtering guide and API docstrings document these options.

Replaces #784, #785, and #786, with Rui Leite credited as a co-author. Regression tests remain in the existing provider and utility modules. SQLSpec itself is unchanged.

Validation: the combined change passed 883 tests with 12 existing skips; the preset follow-up passed all 96 provider and dependency utility tests. Full mypy, Pyright, and commit hooks passed on the final commit.


<!-- docs-preview -->

<hr>
📚 Documentation preview: <a href="https://litestar-org.github.io/advanced-alchemy-docs-preview/798">https://litestar-org.github.io/advanced-alchemy-docs-preview/798</a> 
