### PR TITLE
fix(service): stop spurious SAWarning when to_model_on_update resolves m2m ids

### DIFF
--- a/advanced_alchemy/repository/_util.py
+++ b/advanced_alchemy/repository/_util.py
@@ -937,7 +937,7 @@ def snapshot_and_detach_relationships(instance: Any, mapper: Any) -> dict[str, A
         raw_value: Any = instance.__dict__.get(relationship.key)
         related_items: list[Any]
         if isinstance(raw_value, Mapping):
-            mapping = cast("Mapping[Any, Any]", raw_value)
+            mapping = cast("dict[Any, Any]", raw_value)
             values[relationship.key] = dict(mapping)
             related_items = list(mapping.values())
         elif isinstance(raw_value, (list, set)):

--- a/advanced_alchemy/repository/_util.py
+++ b/advanced_alchemy/repository/_util.py
@@ -23,6 +23,7 @@ from sqlalchemy.orm import (
     class_mapper,
     joinedload,
     lazyload,
+    object_session,
     selectinload,
 )
 from sqlalchemy.orm.strategy_options import (
@@ -897,3 +898,74 @@ def compare_values(existing_value: Any, new_value: Any) -> bool:
         # If comparison fails for any reason, consider them different
         # This is a safe fallback that will trigger updates when unsure
         return False
+
+
+def snapshot_and_detach_relationships(instance: Any, mapper: Any) -> dict[str, Any]:
+    """Capture explicitly-set relationship values on ``instance`` and undo any
+    backref pollution those assignments caused on already-persistent related objects.
+
+    A common ``to_model_on_update`` pattern builds a transient instance and assigns
+    already-persistent related objects (or a collection of them) to one of its
+    relationships, purely so the caller can copy that value onto the real,
+    session-attached instance afterwards. Because ``back_populates``/``backref``
+    synchronization is a Python-side event that fires regardless of session state,
+    the transient instance still gets appended into the related object's own
+    collection - even though it is never added to the session. The next autoflush
+    then tries to write that pairing, fails because the transient side has no
+    identity, and emits ``SAWarning: ... not in session ...`` for it.
+
+    This snapshots each explicitly-set relationship value before removing
+    ``instance`` from the corresponding back-populated collection/attribute on
+    every already-persistent related object, so the stale pairing never reaches a
+    flush. Only relationships declared with ``back_populates`` on a transient
+    ``instance`` are touched; persistent instances and one-directional
+    relationships are left untouched.
+
+    Args:
+        instance: The (possibly transient) instance to inspect.
+        mapper: The SQLAlchemy instance-state/mapper for ``instance``.
+
+    Returns:
+        A mapping of relationship name to the value that was explicitly set on
+        ``instance``, captured before any backref cleanup.
+    """
+    values: dict[str, Any] = {}
+    is_transient = object_session(instance) is None
+    for relationship in mapper.mapper.relationships:
+        if not was_attribute_set(instance, mapper, relationship.key):
+            continue
+        raw_value = instance.__dict__.get(relationship.key)
+        if isinstance(raw_value, Mapping):
+            values[relationship.key] = dict(raw_value)
+            related_items = list(raw_value.values())
+        elif isinstance(raw_value, (list, set)):
+            values[relationship.key] = list(raw_value)
+            related_items = list(raw_value)
+        else:
+            values[relationship.key] = raw_value
+            related_items = [raw_value]
+
+        back_attr = relationship.back_populates
+        if not is_transient or not back_attr or raw_value is None:
+            continue
+        for related in related_items:
+            if related is None or inspect(related, raiseerr=False) is None or object_session(related) is None:
+                continue
+            # Read the raw, already-loaded value to avoid triggering a lazy load
+            # (or raising, for relationships configured with ``lazy="raise"``):
+            # the backref sync that caused the pollution can only have populated
+            # an attribute that was already loaded in memory.
+            back_value = related.__dict__.get(back_attr)
+            if isinstance(back_value, (list, set)) and instance in back_value:
+                back_value.remove(instance)
+            elif back_value is instance:
+                setattr(related, back_attr, None)
+            else:
+                # The back-populated collection was never loaded (e.g. lazy="raise"),
+                # so the backref sync recorded the append as a pending mutation
+                # rather than materializing the collection. Cancel it there instead.
+                pending = getattr(inspect(related), "_pending_mutations", None)
+                added_items = getattr(pending.get(back_attr), "added_items", None) if pending else None
+                if added_items is not None and instance in added_items:
+                    added_items.discard(instance)
+    return values

--- a/advanced_alchemy/repository/_util.py
+++ b/advanced_alchemy/repository/_util.py
@@ -934,13 +934,16 @@ def snapshot_and_detach_relationships(instance: Any, mapper: Any) -> dict[str, A
     for relationship in mapper.mapper.relationships:
         if not was_attribute_set(instance, mapper, relationship.key):
             continue
-        raw_value = instance.__dict__.get(relationship.key)
+        raw_value: Any = instance.__dict__.get(relationship.key)
+        related_items: list[Any]
         if isinstance(raw_value, Mapping):
-            values[relationship.key] = dict(raw_value)
-            related_items = list(raw_value.values())
+            mapping = cast("Mapping[Any, Any]", raw_value)
+            values[relationship.key] = dict(mapping)
+            related_items = list(mapping.values())
         elif isinstance(raw_value, (list, set)):
-            values[relationship.key] = list(raw_value)
-            related_items = list(raw_value)
+            items = cast("Iterable[Any]", raw_value)
+            values[relationship.key] = list(items)
+            related_items = list(items)
         else:
             values[relationship.key] = raw_value
             related_items = [raw_value]
@@ -955,17 +958,18 @@ def snapshot_and_detach_relationships(instance: Any, mapper: Any) -> dict[str, A
             # (or raising, for relationships configured with ``lazy="raise"``):
             # the backref sync that caused the pollution can only have populated
             # an attribute that was already loaded in memory.
-            back_value = related.__dict__.get(back_attr)
+            back_value: Any = related.__dict__.get(back_attr)
             if isinstance(back_value, (list, set)) and instance in back_value:
-                back_value.remove(instance)
+                cast("Any", back_value).remove(instance)
             elif back_value is instance:
                 setattr(related, back_attr, None)
             else:
                 # The back-populated collection was never loaded (e.g. lazy="raise"),
                 # so the backref sync recorded the append as a pending mutation
                 # rather than materializing the collection. Cancel it there instead.
-                pending = getattr(inspect(related), "_pending_mutations", None)
-                added_items = getattr(pending.get(back_attr), "added_items", None) if pending else None
+                related_state: Any = inspect(related)
+                pending: Any = getattr(related_state, "_pending_mutations", None)
+                added_items: Any = getattr(pending.get(back_attr), "added_items", None) if pending else None
                 if added_items is not None and instance in added_items:
                     added_items.discard(instance)
     return values

--- a/advanced_alchemy/service/_async.py
+++ b/advanced_alchemy/service/_async.py
@@ -25,7 +25,7 @@ from advanced_alchemy.filters import StatementFilter
 from advanced_alchemy.repository import (
     SQLAlchemyAsyncQueryRepository,
 )
-from advanced_alchemy.repository._util import LoadSpec, model_from_dict
+from advanced_alchemy.repository._util import LoadSpec, model_from_dict, snapshot_and_detach_relationships
 from advanced_alchemy.repository.typing import MISSING, ModelT, OrderingPair, PrimaryKeyType, SQLAlchemyAsyncRepositoryT
 from advanced_alchemy.service._util import ResultConverter, resolve_item_ids
 from advanced_alchemy.utils.dataclass import Empty, EmptyType
@@ -884,6 +884,18 @@ class SQLAlchemyAsyncRepositoryService(
         if item_id is not None:
             # When item_id is provided, update existing instance rather than replacing it
             # This preserves relationships and database-managed fields
+            instance_state = sa_inspect(data)  # pyright: ignore[reportOptionalMemberAccess]
+
+            # A `to_model_on_update` hook may have built ``data`` as a transient
+            # instance and assigned already-persistent related objects onto one
+            # of its relationships (e.g. resolving m2m ids into model instances).
+            # That assignment's back_populates sync pollutes the related objects'
+            # own collections with a reference to the (soon to be discarded)
+            # transient ``data``, which the very next query below would try to
+            # autoflush and warn about. Snapshot the explicitly-set relationship
+            # values and undo that pollution before it can reach a flush.
+            relationship_values = snapshot_and_detach_relationships(data, instance_state)
+
             existing_instance: ModelT = await self.repository.get(
                 item_id,
                 id_attribute=id_attribute,
@@ -895,11 +907,14 @@ class SQLAlchemyAsyncRepositoryService(
 
             # Extract attributes from converted model to update existing instance
             # Only copy attributes that were explicitly set (present in instance state)
-            instance_state = sa_inspect(data)  # pyright: ignore[reportOptionalMemberAccess]
             for attr in instance_state.mapper.attrs:  # type: ignore[union-attr]  # pyright: ignore[reportOptionalMemberAccess]
                 # Check if attribute was explicitly set in the instance
                 if attr.key in instance_state.dict:  # type: ignore[union-attr]  # pyright: ignore[reportOptionalMemberAccess]
-                    value = getattr(data, attr.key, MISSING)
+                    value = (
+                        relationship_values[attr.key]
+                        if attr.key in relationship_values
+                        else getattr(data, attr.key, MISSING)
+                    )
                     if value is not MISSING and hasattr(existing_instance, attr.key):
                         setattr(existing_instance, attr.key, value)
 

--- a/advanced_alchemy/service/_sync.py
+++ b/advanced_alchemy/service/_sync.py
@@ -24,7 +24,7 @@ from advanced_alchemy.config.sync import SQLAlchemySyncConfig
 from advanced_alchemy.exceptions import AdvancedAlchemyError, ErrorMessages, ImproperConfigurationError, RepositoryError
 from advanced_alchemy.filters import StatementFilter
 from advanced_alchemy.repository import SQLAlchemySyncQueryRepository
-from advanced_alchemy.repository._util import LoadSpec, model_from_dict
+from advanced_alchemy.repository._util import LoadSpec, model_from_dict, snapshot_and_detach_relationships
 from advanced_alchemy.repository.typing import MISSING, ModelT, OrderingPair, PrimaryKeyType, SQLAlchemySyncRepositoryT
 from advanced_alchemy.service._util import ResultConverter, resolve_item_ids
 from advanced_alchemy.utils.dataclass import Empty, EmptyType
@@ -883,6 +883,18 @@ class SQLAlchemySyncRepositoryService(
         if item_id is not None:
             # When item_id is provided, update existing instance rather than replacing it
             # This preserves relationships and database-managed fields
+            instance_state = sa_inspect(data)  # pyright: ignore[reportOptionalMemberAccess]
+
+            # A `to_model_on_update` hook may have built ``data`` as a transient
+            # instance and assigned already-persistent related objects onto one
+            # of its relationships (e.g. resolving m2m ids into model instances).
+            # That assignment's back_populates sync pollutes the related objects'
+            # own collections with a reference to the (soon to be discarded)
+            # transient ``data``, which the very next query below would try to
+            # autoflush and warn about. Snapshot the explicitly-set relationship
+            # values and undo that pollution before it can reach a flush.
+            relationship_values = snapshot_and_detach_relationships(data, instance_state)
+
             existing_instance: ModelT = self.repository.get(
                 item_id,
                 id_attribute=id_attribute,
@@ -894,11 +906,14 @@ class SQLAlchemySyncRepositoryService(
 
             # Extract attributes from converted model to update existing instance
             # Only copy attributes that were explicitly set (present in instance state)
-            instance_state = sa_inspect(data)  # pyright: ignore[reportOptionalMemberAccess]
             for attr in instance_state.mapper.attrs:  # type: ignore[union-attr]  # pyright: ignore[reportOptionalMemberAccess]
                 # Check if attribute was explicitly set in the instance
                 if attr.key in instance_state.dict:  # type: ignore[union-attr]  # pyright: ignore[reportOptionalMemberAccess]
-                    value = getattr(data, attr.key, MISSING)
+                    value = (
+                        relationship_values[attr.key]
+                        if attr.key in relationship_values
+                        else getattr(data, attr.key, MISSING)
+                    )
                     if value is not MISSING and hasattr(existing_instance, attr.key):
                         setattr(existing_instance, attr.key, value)
 

--- a/tests/integration/test_service_update_m2m_no_sawarning.py
+++ b/tests/integration/test_service_update_m2m_no_sawarning.py
@@ -42,9 +42,9 @@ from typing import Any
 from uuid import UUID
 
 import pytest
-from sqlalchemy import Column, ForeignKey, Table
+from sqlalchemy import Column, ForeignKey, String, Table
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
-from sqlalchemy.orm import Mapped, attribute_keyed_dict, relationship, selectinload
+from sqlalchemy.orm import Mapped, attribute_keyed_dict, mapped_column, relationship, selectinload
 
 from advanced_alchemy.base import UUIDBase
 from advanced_alchemy.filters import CollectionFilter
@@ -66,14 +66,14 @@ user_role_790 = Table(
 class User790(UUIDBase):
     __tablename__ = "user_790"
 
-    alias: Mapped[str]
+    alias: Mapped[str] = mapped_column(String(50))
     roles: Mapped[list[Role790]] = relationship(secondary=user_role_790, back_populates="users", lazy="raise")
 
 
 class Role790(UUIDBase):
     __tablename__ = "role_790"
 
-    name: Mapped[str]
+    name: Mapped[str] = mapped_column(String(50))
     users: Mapped[list[User790]] = relationship(secondary=user_role_790, back_populates="roles", lazy="raise")
 
 
@@ -199,7 +199,7 @@ team_member_790 = Table(
 class Team790(UUIDBase):
     __tablename__ = "team_790"
 
-    label: Mapped[str]
+    label: Mapped[str] = mapped_column(String(50))
     members: Mapped[dict[str, Member790]] = relationship(
         secondary=team_member_790,
         collection_class=attribute_keyed_dict("name"),
@@ -211,7 +211,7 @@ class Team790(UUIDBase):
 class Member790(UUIDBase):
     __tablename__ = "member_790"
 
-    name: Mapped[str]
+    name: Mapped[str] = mapped_column(String(50))
     teams: Mapped[list[Team790]] = relationship(secondary=team_member_790, back_populates="members", lazy="raise")
 
 

--- a/tests/integration/test_service_update_m2m_no_sawarning.py
+++ b/tests/integration/test_service_update_m2m_no_sawarning.py
@@ -1,0 +1,270 @@
+"""Regression test for GitHub issue #790.
+
+``service.update()`` with an existing ``item_id`` copies the attributes
+produced by ``to_model_on_update()`` onto the fetched, session-attached
+instance. A common pattern for handling many-to-many relationships in that
+hook is to build a transient model and assign already-persistent related
+rows onto one of its relationships, e.g.::
+
+    async def to_model_on_update(self, data):
+        data = schema_dump(data)
+        role_ids = data.pop("roles", None)
+        model = await self.to_model(data)
+        if role_ids is not None:
+            model.roles = await RoleRepository(
+                session=self.repository.session
+            ).get_many(
+                CollectionFilter(
+                    field_name="id", values=role_ids
+                )
+            )
+        return model
+
+Because ``back_populates`` synchronization is a Python-side event that fires
+regardless of session state, that assignment also appends the transient
+``model`` into each related ``Role.users`` collection - even though ``model``
+is discarded immediately after and never added to the session. The next
+autoflush then tries to write that pairing, fails because the transient side
+has no identity, and emits::
+
+    SAWarning: Object of type <User> not in session, add operation along
+    'Role.users' won't proceed
+
+The secondary-table rows still end up correct (the real, session-attached
+instance is what ultimately gets assigned), so the warning is spurious - but
+it makes callers suspect the update silently failed.
+"""
+
+from __future__ import annotations
+
+import warnings
+from typing import Any
+from uuid import UUID
+
+import pytest
+from sqlalchemy import Column, ForeignKey, Table
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import Mapped, attribute_keyed_dict, relationship, selectinload
+
+from advanced_alchemy.base import UUIDBase
+from advanced_alchemy.filters import CollectionFilter
+from advanced_alchemy.repository import SQLAlchemyAsyncRepository
+from advanced_alchemy.service import SQLAlchemyAsyncRepositoryService
+from advanced_alchemy.utils.serialization import schema_dump
+
+pytestmark = [pytest.mark.integration, pytest.mark.aiosqlite]
+
+
+user_role_790 = Table(
+    "user_role_790",
+    UUIDBase.metadata,
+    Column("user_id", ForeignKey("user_790.id"), primary_key=True),
+    Column("role_id", ForeignKey("role_790.id"), primary_key=True),
+)
+
+
+class User790(UUIDBase):
+    __tablename__ = "user_790"
+
+    alias: Mapped[str]
+    roles: Mapped[list[Role790]] = relationship(secondary=user_role_790, back_populates="users", lazy="raise")
+
+
+class Role790(UUIDBase):
+    __tablename__ = "role_790"
+
+    name: Mapped[str]
+    users: Mapped[list[User790]] = relationship(secondary=user_role_790, back_populates="roles", lazy="raise")
+
+
+class RoleRepository790(SQLAlchemyAsyncRepository[Role790]):
+    model_type = Role790
+
+
+class UserRepository790(SQLAlchemyAsyncRepository[User790]):
+    model_type = User790
+
+
+class UserService790(SQLAlchemyAsyncRepositoryService[User790]):
+    repository_type = UserRepository790
+
+    async def to_model_on_update(self, data: Any) -> Any:
+        data = schema_dump(data)
+        role_ids = data.pop("roles", None)
+        model = await self.to_model(data)
+        if role_ids is not None:
+            model.roles = await RoleRepository790(session=self.repository.session).get_many(
+                CollectionFilter(field_name="id", values=role_ids)
+            )
+        return model
+
+
+@pytest.fixture
+async def user_790_session() -> Any:
+    engine = create_async_engine("sqlite+aiosqlite://")
+    async with engine.begin() as conn:
+        await conn.run_sync(UUIDBase.metadata.create_all)
+    async with AsyncSession(engine, expire_on_commit=False) as session:
+        yield session
+    await engine.dispose()
+
+
+def _sa_warnings(caught: list[warnings.WarningMessage]) -> list[warnings.WarningMessage]:
+    return [w for w in caught if "not in session" in str(w.message)]
+
+
+async def test_service_update_m2m_relationship_no_sawarning_github_790(user_790_session: AsyncSession) -> None:
+    """``service.update()`` must not emit a spurious SAWarning when
+    ``to_model_on_update`` resolves many-to-many ids into related objects,
+    and the association rows must be persisted correctly (GitHub #790)."""
+    session = user_790_session
+    role1 = Role790(name="admin")
+    role2 = Role790(name="editor")
+    user = User790(alias="orig")
+    session.add_all([role1, role2, user])
+    await session.commit()
+    user_id: UUID = user.id
+    role_ids = [role1.id, role2.id]
+
+    service = UserService790(session=session)
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        updated = await service.update(
+            {"roles": role_ids, "alias": "x"},
+            user_id,
+            load=[selectinload(User790.roles)],
+            auto_commit=True,
+        )
+
+    assert not _sa_warnings(caught), [str(w.message) for w in _sa_warnings(caught)]
+    assert updated.alias == "x"
+
+    # Re-fetch independently to confirm the association rows were actually written.
+    # ``auto_refresh`` expires the lazy="raise" collection on ``updated``, so verify
+    # through a fresh session rather than accessing ``updated.roles`` directly.
+    async with AsyncSession(session.bind, expire_on_commit=False) as check_session:
+        check = await check_session.get(User790, user_id)
+        assert check is not None
+        await check_session.refresh(check, attribute_names=["roles"])
+        assert sorted(r.name for r in check.roles) == ["admin", "editor"]
+
+
+async def test_service_update_m2m_relationship_clear_no_sawarning_github_790(
+    user_790_session: AsyncSession,
+) -> None:
+    """Boundary case: clearing a many-to-many relationship to an empty list
+    through the same hook must also be warning-free and persist correctly."""
+    session = user_790_session
+    role1 = Role790(name="admin")
+    user = User790(alias="orig")
+    session.add_all([role1, user])
+    await session.commit()
+    # Associate role1 with user directly through the secondary table, avoiding
+    # any relationship access before commit (roles is ``lazy="raise"``).
+    await session.execute(user_role_790.insert().values(user_id=user.id, role_id=role1.id))
+    await session.commit()
+    user_id: UUID = user.id
+
+    service = UserService790(session=session)
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        updated = await service.update(
+            {"roles": [], "alias": "cleared"},
+            user_id,
+            load=[selectinload(User790.roles)],
+            auto_commit=True,
+        )
+
+    assert not _sa_warnings(caught), [str(w.message) for w in _sa_warnings(caught)]
+    assert updated.alias == "cleared"
+
+    # Re-fetch independently: ``auto_refresh`` expires the lazy="raise" collection
+    # on ``updated``, so check persistence through a fresh session instead of
+    # accessing ``updated.roles`` directly.
+    async with AsyncSession(session.bind, expire_on_commit=False) as check_session:
+        check = await check_session.get(User790, user_id)
+        assert check is not None
+        await check_session.refresh(check, attribute_names=["roles"])
+        assert list(check.roles) == []
+
+
+team_member_790 = Table(
+    "team_member_790",
+    UUIDBase.metadata,
+    Column("team_id", ForeignKey("team_790.id"), primary_key=True),
+    Column("member_id", ForeignKey("member_790.id"), primary_key=True),
+)
+
+
+class Team790(UUIDBase):
+    __tablename__ = "team_790"
+
+    label: Mapped[str]
+    members: Mapped[dict[str, Member790]] = relationship(
+        secondary=team_member_790,
+        collection_class=attribute_keyed_dict("name"),
+        back_populates="teams",
+        lazy="raise",
+    )
+
+
+class Member790(UUIDBase):
+    __tablename__ = "member_790"
+
+    name: Mapped[str]
+    teams: Mapped[list[Team790]] = relationship(secondary=team_member_790, back_populates="members", lazy="raise")
+
+
+class MemberRepository790(SQLAlchemyAsyncRepository[Member790]):
+    model_type = Member790
+
+
+class TeamRepository790(SQLAlchemyAsyncRepository[Team790]):
+    model_type = Team790
+
+
+class TeamService790(SQLAlchemyAsyncRepositoryService[Team790]):
+    repository_type = TeamRepository790
+
+    async def to_model_on_update(self, data: Any) -> Any:
+        data = schema_dump(data)
+        member_ids = data.pop("members", None)
+        model = await self.to_model(data)
+        if member_ids is not None:
+            members = await MemberRepository790(session=self.repository.session).get_many(
+                CollectionFilter(field_name="id", values=member_ids)
+            )
+            model.members = {member.name: member for member in members}
+        return model
+
+
+async def test_service_update_m2m_dict_collection_no_sawarning_github_790(user_790_session: AsyncSession) -> None:
+    """A dict-keyed collection (``attribute_keyed_dict``) assigned by the hook is a
+    mapping of related objects, not one related object; it must be detached per
+    value and must not raise."""
+    session = user_790_session
+    alice = Member790(name="alice")
+    bob = Member790(name="bob")
+    team = Team790(label="orig")
+    session.add_all([alice, bob, team])
+    await session.commit()
+    team_id: UUID = team.id
+
+    service = TeamService790(session=session)
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        updated = await service.update(
+            {"members": [alice.id, bob.id], "label": "renamed"},
+            team_id,
+            load=[selectinload(Team790.members)],
+            auto_commit=True,
+        )
+
+    assert not _sa_warnings(caught), [str(w.message) for w in _sa_warnings(caught)]
+    assert updated.label == "renamed"
+
+    async with AsyncSession(session.bind, expire_on_commit=False) as check_session:
+        check = await check_session.get(Team790, team_id)
+        assert check is not None
+        await check_session.refresh(check, attribute_names=["members"])
+        assert sorted(check.members) == ["alice", "bob"]


### PR DESCRIPTION
## Description

`service.update()` with an existing `item_id` emits `SAWarning: Object of type <User> not in session, add operation along 'Role.users' won't proceed` when a `to_model_on_update` hook resolves a many-to-many id list into related objects and assigns them onto the transient model it returns. The association rows are still written, so the warning makes a correct update look like a failed one (#790).

**Cause.** `back_populates` synchronisation is a Python-side event and fires regardless of session state. Assigning already-persistent `Role` rows onto the transient model also appends that transient model into each `Role.users` collection. For a `lazy="raise"` collection the append lives in `InstanceState._pending_mutations` rather than `__dict__`, so the copy loop in `update()` cannot see it. The `self.repository.get(item_id, ...)` call that follows autoflushes, the unit of work tries to write the pairing for an instance with no identity, and warns. `repository.update()` already guards its own relationship handling with `no_autoflush` and `merge()`, but it runs after `service.update()` has touched the relationships.

**Change.** `snapshot_and_detach_relationships()` in `advanced_alchemy/repository/_util.py` snapshots each explicitly set relationship on the transient instance and removes that instance from the back-populated collection or attribute of every persistent related object, covering the materialised collection, the scalar backref, the pending-mutation case, and dict-keyed collections (`attribute_keyed_dict`), which are iterated by value. Values that are not mapped instances are skipped, and the pending-mutation access is a guarded `getattr`, so a SQLAlchemy release without that attribute degrades to today's warning rather than an error (the project supports 2.0.41 and up; the attribute exists there). `service/_async.py` `update()` calls it right after `to_model()` and copies from the snapshot; `_sync.py` is the `unasyncd` output. No public API changes. `no_autoflush` around the copy loop alone does not fix it: the pairing still flushes at commit.

**Proof.** `tests/integration/test_service_update_m2m_no_sawarning.py` (sqlite): the reported case fails on `main` with two warnings and passes here; a clear-to-empty boundary case; and a dict-keyed collection case that raised `UnmappedInstanceError` on the first version of this helper and passes now. Suites: `tests/unit/test_service_to_model_flow.py`, `tests/unit/test_repository.py`, `tests/integration/test_repository.py` and the new file, all green on aiosqlite. `ruff check`, `ruff format --check` and `mypy` (python 3.11, as CI) clean on the touched files. `unasyncd --check` reports no drift.

Disclosure per the Litestar AI policy: the change was prepared with AI assistance under my direction, and I am the human in the loop responsible for it.

Fixes #790


<!-- docs-preview -->

<hr>
📚 Documentation preview: <a href="https://litestar-org.github.io/advanced-alchemy-docs-preview/800">https://litestar-org.github.io/advanced-alchemy-docs-preview/800</a> 
